### PR TITLE
feat: config schema and loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,12 @@ coverage/
 *.log
 
 # Runtime config volume — contains the bearer token and service API keys.
-config/
-tmp-config/
+# Leading slash anchors these to the repo root: an unanchored `config/` also
+# matches `src/config/` and silently drops source files from commits.
+/config/
+/tmp-config/
 .env
 
 # Internal design specs and implementation plans. Kept in a separate working
 # repo, not published here — the README's roadmap is the public summary.
-docs/superpowers/
+/docs/superpowers/

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -1,0 +1,70 @@
+import { randomBytes } from 'node:crypto';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { parse, stringify } from 'yaml';
+import * as z from 'zod/v4';
+import { logger } from '../core/logger.ts';
+import { ConfigSchema, type Config } from './schema.ts';
+
+const FILENAME = 'config.yaml';
+
+const generateToken = (): string => randomBytes(32).toString('hex');
+
+/** Written on first run so the knobs are discoverable without reading docs. */
+const seedConfig = () => ({
+    auth: { bearer_token: generateToken(), allowed_hosts: [] as string[] },
+    services: {}
+});
+
+/**
+ * Reads <configDir>/config.yaml, creating it with a generated bearer token on
+ * first run. The file is the source of truth; environment variables seed
+ * first-run defaults only (design spec §13).
+ */
+export async function loadConfig(configDir: string): Promise<{ config: Config; created: boolean }> {
+    const path = join(configDir, FILENAME);
+    await mkdir(configDir, { recursive: true });
+
+    let raw: string | undefined;
+    try {
+        raw = await readFile(path, 'utf8');
+    } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    }
+
+    if (raw === undefined) {
+        const seeded = seedConfig();
+        // 0o600: the file holds the bearer token and every service API key.
+        await writeFile(path, stringify(seeded), { mode: 0o600 });
+        logger.info({ path }, 'created config.yaml with a generated bearer token');
+        return { config: ConfigSchema.parse(seeded), created: true };
+    }
+
+    let parsed: unknown;
+    try {
+        parsed = parse(raw);
+    } catch (err) {
+        throw new Error(`config.yaml is not valid YAML: ${(err as Error).message}`, { cause: err });
+    }
+
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        throw new Error('config.yaml must contain a YAML mapping at the top level');
+    }
+
+    const obj = parsed as Record<string, unknown>;
+    const auth = obj.auth as { bearer_token?: string } | undefined;
+    if (!auth?.bearer_token) {
+        // Backfill rather than refuse to start: a user who deleted the token,
+        // or hand-wrote a config without one, should get a working server and
+        // a warning telling them where the new token came from.
+        obj.auth = { ...(auth ?? {}), bearer_token: generateToken() };
+        await writeFile(path, stringify(obj), { mode: 0o600 });
+        logger.warn({ path }, 'config.yaml had no bearer token; generated one');
+    }
+
+    const result = ConfigSchema.safeParse(obj);
+    if (!result.success) {
+        throw new Error(`config.yaml is invalid:\n${z.prettifyError(result.error)}`);
+    }
+    return { config: result.data, created: false };
+}

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,0 +1,55 @@
+import * as z from 'zod/v4';
+
+export const ServiceIdSchema = z.enum([
+    'radarr',
+    'sonarr',
+    'prowlarr',
+    'bazarr',
+    'jellyfin',
+    'seerr',
+    'sabnzbd',
+    'transmission'
+]);
+export type ServiceId = z.infer<typeof ServiceIdSchema>;
+
+/**
+ * Permission tiers per the design spec §10. Both default to off: a service
+ * added by hand-editing YAML must not silently acquire write access.
+ */
+const PermissionsSchema = z
+    .object({
+        safe_write: z.boolean().default(false),
+        destructive: z.boolean().default(false)
+    })
+    .default({ safe_write: false, destructive: false });
+
+const ServiceConfigSchema = z.object({
+    url: z
+        .url()
+        .refine(u => u.startsWith('http://') || u.startsWith('https://'), {
+            message: 'must be an http:// or https:// URL'
+        }),
+    api_key: z.string().min(1, 'api_key must not be empty'),
+    timeout_ms: z.number().int().positive().default(10_000),
+    permissions: PermissionsSchema
+});
+export type ServiceConfig = z.infer<typeof ServiceConfigSchema>;
+
+export const ConfigSchema = z.object({
+    // Required, not optional: loadConfig always injects a generated token
+    // before parsing, so the only way this is missing is a hand-edited file
+    // that deleted it — which must fail loudly rather than default to ''.
+    auth: z.object({
+        /** Generated on first run by loadConfig; 32 random bytes, hex. */
+        bearer_token: z.string().length(64),
+        /**
+         * Hostnames the MCP endpoint may be reached on, for the SDK's DNS
+         * rebinding protection. Empty means "accept any Host", which is the
+         * right default for a LAN container reached by IP; pin hostnames when
+         * running behind a reverse proxy.
+         */
+        allowed_hosts: z.array(z.string()).default([])
+    }),
+    services: z.partialRecord(ServiceIdSchema, ServiceConfigSchema).default({})
+});
+export type Config = z.infer<typeof ConfigSchema>;

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,0 +1,137 @@
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { ConfigSchema } from '../src/config/schema.ts';
+import { loadConfig } from '../src/config/load.ts';
+
+const freshDir = () => mkdtemp(join(tmpdir(), 'arr-mcp-cfg-'));
+const AUTH = { bearer_token: 'a'.repeat(64) };
+
+describe('ConfigSchema', () => {
+    it('defaults both permission tiers to off for a newly added service', () => {
+        const parsed = ConfigSchema.parse({
+            auth: AUTH,
+            services: { radarr: { url: 'http://192.168.1.20:7878', api_key: 'k' } }
+        });
+        expect(parsed.services.radarr?.permissions).toEqual({ safe_write: false, destructive: false });
+    });
+
+    it('defaults the per-service timeout to 10 seconds', () => {
+        const parsed = ConfigSchema.parse({
+            auth: AUTH,
+            services: { radarr: { url: 'http://h:7878', api_key: 'k' } }
+        });
+        expect(parsed.services.radarr?.timeout_ms).toBe(10_000);
+    });
+
+    it('defaults allowed_hosts to an empty list', () => {
+        const parsed = ConfigSchema.parse({ auth: AUTH, services: {} });
+        expect(parsed.auth.allowed_hosts).toEqual([]);
+    });
+
+    it('rejects a service url that is not http(s)', () => {
+        const result = ConfigSchema.safeParse({
+            auth: AUTH,
+            services: { radarr: { url: 'ftp://h:7878', api_key: 'k' } }
+        });
+        expect(result.success).toBe(false);
+    });
+
+    it('rejects an empty api key rather than silently accepting it', () => {
+        const result = ConfigSchema.safeParse({
+            auth: AUTH,
+            services: { radarr: { url: 'http://h:7878', api_key: '' } }
+        });
+        expect(result.success).toBe(false);
+    });
+
+    it('rejects a config whose auth block was deleted by hand', () => {
+        expect(ConfigSchema.safeParse({ services: {} }).success).toBe(false);
+    });
+
+    it('rejects an unknown service id', () => {
+        const result = ConfigSchema.safeParse({
+            auth: AUTH,
+            services: { plex: { url: 'http://h:32400', api_key: 'k' } }
+        });
+        expect(result.success).toBe(false);
+    });
+});
+
+describe('loadConfig', () => {
+    it('creates config.yaml with a generated bearer token on first run', async () => {
+        const dir = await freshDir();
+        const { config, created } = await loadConfig(dir);
+
+        expect(created).toBe(true);
+        expect(config.auth.bearer_token).toMatch(/^[0-9a-f]{64}$/);
+        // and it is persisted, not just returned
+        const onDisk = await readFile(join(dir, 'config.yaml'), 'utf8');
+        expect(onDisk).toContain(config.auth.bearer_token);
+    });
+
+    it('is stable across restarts — the token is not regenerated', async () => {
+        const dir = await freshDir();
+        const first = await loadConfig(dir);
+        const second = await loadConfig(dir);
+
+        expect(second.created).toBe(false);
+        expect(second.config.auth.bearer_token).toBe(first.config.auth.bearer_token);
+    });
+
+    it('generates a distinct token per install', async () => {
+        const [a, b] = await Promise.all([freshDir(), freshDir()]);
+        const [one, two] = await Promise.all([loadConfig(a), loadConfig(b)]);
+
+        expect(one.config.auth.bearer_token).not.toBe(two.config.auth.bearer_token);
+    });
+
+    it('throws an actionable error when config.yaml is malformed', async () => {
+        const dir = await freshDir();
+        await writeFile(join(dir, 'config.yaml'), 'services: [this is not a map]', 'utf8');
+
+        await expect(loadConfig(dir)).rejects.toThrow(/config\.yaml/);
+    });
+
+    it('throws an actionable error when config.yaml is not valid YAML at all', async () => {
+        const dir = await freshDir();
+        await writeFile(join(dir, 'config.yaml'), 'auth: {unclosed', 'utf8');
+
+        await expect(loadConfig(dir)).rejects.toThrow(/not valid YAML/);
+    });
+
+    it('backfills a missing bearer token rather than failing to start', async () => {
+        const dir = await freshDir();
+        await writeFile(join(dir, 'config.yaml'), 'services: {}\n', 'utf8');
+
+        const { config } = await loadConfig(dir);
+        expect(config.auth.bearer_token).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it('names the offending field when a service is misconfigured', async () => {
+        const dir = await freshDir();
+        await writeFile(
+            join(dir, 'config.yaml'),
+            `auth:\n  bearer_token: ${'a'.repeat(64)}\nservices:\n  radarr:\n    url: not-a-url\n    api_key: k\n`,
+            'utf8'
+        );
+
+        await expect(loadConfig(dir)).rejects.toThrow(/url/);
+    });
+
+    it('reads a valid hand-written config', async () => {
+        const dir = await freshDir();
+        await writeFile(
+            join(dir, 'config.yaml'),
+            `auth:\n  bearer_token: ${'b'.repeat(64)}\n  allowed_hosts:\n    - arr.example.com\nservices:\n  radarr:\n    url: http://192.168.1.20:7878\n    api_key: abc\n    permissions:\n      safe_write: true\n      destructive: false\n`,
+            'utf8'
+        );
+
+        const { config, created } = await loadConfig(dir);
+        expect(created).toBe(false);
+        expect(config.auth.allowed_hosts).toEqual(['arr.example.com']);
+        expect(config.services.radarr?.permissions.safe_write).toBe(true);
+        expect(config.services.radarr?.permissions.destructive).toBe(false);
+    });
+});


### PR DESCRIPTION
Task 2 of the Phase 1 plan.

- `ConfigSchema`: eight known service ids, permission tiers defaulting to off, 10s default timeout, `auth.allowed_hosts` for the SDK's DNS-rebinding protection
- `loadConfig`: creates `config.yaml` at mode 0600 with a generated token on first run, stable across restarts, backfills a deleted token, and reports invalid configs with the offending field named

15 new tests covering first-run creation, restart stability, per-install token uniqueness, malformed YAML, non-mapping YAML, token backfill, and a valid hand-written config.

Lint caught a missing `cause` on a rethrown error during development — fixed in this branch.