### PR TITLE
feat: error taxonomy and response shaping

### DIFF
--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -1,0 +1,130 @@
+import type { ServiceId } from '../config/schema.ts';
+
+export type ServiceErrorKind =
+    | 'Unreachable'
+    | 'AuthFailed'
+    | 'NotFound'
+    | 'RateLimited'
+    | 'Timeout'
+    | 'VersionUnsupported'
+    | 'UpstreamError';
+
+const PROSE: Record<ServiceErrorKind, string> = {
+    Unreachable: 'unreachable',
+    AuthFailed: 'auth failed',
+    NotFound: 'not found',
+    RateLimited: 'rate limited',
+    Timeout: 'timed out',
+    VersionUnsupported: 'version unsupported',
+    UpstreamError: 'upstream error'
+};
+
+/**
+ * A model told *why* something failed reports it; a model handed an opaque
+ * error invents an explanation (design spec §15). `toModelText` is the only
+ * string that ever reaches the model — it never includes a stack trace, and
+ * never the underlying cause, which stays available for logs via `.cause`.
+ */
+export class ServiceError extends Error {
+    readonly kind: ServiceErrorKind;
+    readonly service: ServiceId;
+    readonly detail: string;
+    readonly remedy: string | undefined;
+
+    constructor(
+        kind: ServiceErrorKind,
+        service: ServiceId,
+        detail: string,
+        opts?: { remedy?: string; cause?: unknown }
+    ) {
+        super(`${service} ${PROSE[kind]}: ${detail}`, opts?.cause !== undefined ? { cause: opts.cause } : undefined);
+        this.name = 'ServiceError';
+        this.kind = kind;
+        this.service = service;
+        this.detail = detail;
+        this.remedy = opts?.remedy;
+    }
+
+    toModelText(): string {
+        const base = `${this.service} ${PROSE[this.kind]}: ${this.detail}`;
+        return this.remedy ? `${base} — ${this.remedy}` : base;
+    }
+}
+
+/** Extracts the path alone, so an api key in a query string cannot leak. */
+function safePath(url: string): string {
+    try {
+        return new URL(url).pathname;
+    } catch {
+        return url;
+    }
+}
+
+function safeHost(url: string): string {
+    try {
+        return new URL(url).host;
+    } catch {
+        return url;
+    }
+}
+
+export function classifyHttpStatus(status: number, service: ServiceId, url: string): ServiceError | undefined {
+    if (status < 400) return undefined;
+    const at = `HTTP ${status} at ${safePath(url)}`;
+
+    if (status === 401 || status === 403) {
+        return new ServiceError('AuthFailed', service, at, {
+            remedy: 'The API key is wrong. Check the service’s Settings → General page.'
+        });
+    }
+    if (status === 404) {
+        return new ServiceError('NotFound', service, at, {
+            remedy: 'Wrong base path — check the URL does not include a trailing path or reverse-proxy prefix.'
+        });
+    }
+    if (status === 429) {
+        return new ServiceError('RateLimited', service, at);
+    }
+    return new ServiceError('UpstreamError', service, at);
+}
+
+const TLS_CODES = new Set([
+    'DEPTH_ZERO_SELF_SIGNED_CERT',
+    'SELF_SIGNED_CERT_IN_CHAIN',
+    'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+    'CERT_HAS_EXPIRED',
+    'ERR_TLS_CERT_ALTNAME_INVALID'
+]);
+
+export function classifyFetchError(err: unknown, service: ServiceId, url: string): ServiceError {
+    const e = (err ?? {}) as { name?: string; code?: string; message?: string; cause?: { code?: string } };
+    // undici wraps the OS-level failure one level down as `cause`.
+    const code = e.code ?? e.cause?.code;
+    const host = safeHost(url);
+
+    if (e.name === 'AbortError' || e.name === 'TimeoutError') {
+        return new ServiceError('Timeout', service, `no response from ${host} within the configured timeout`, {
+            cause: err
+        });
+    }
+    if (code !== undefined && TLS_CODES.has(code)) {
+        return new ServiceError('Unreachable', service, `TLS error (${code}) at ${host}`, {
+            remedy:
+                'The TLS certificate could not be verified. Use http:// on the LAN, or install a trusted certificate.',
+            cause: err
+        });
+    }
+    if (code === 'ENOTFOUND' || code === 'EAI_AGAIN') {
+        return new ServiceError('Unreachable', service, `DNS lookup failed for ${host}`, {
+            remedy: 'The hostname does not resolve. Use an IP address, or check your DNS.',
+            cause: err
+        });
+    }
+    if (code === 'ECONNREFUSED') {
+        return new ServiceError('Unreachable', service, `connection refused at ${host}`, {
+            remedy: 'Nothing is listening on that port. Check the service is running and the port is right.',
+            cause: err
+        });
+    }
+    return new ServiceError('Unreachable', service, `${e.message ?? 'unknown error'} at ${host}`, { cause: err });
+}

--- a/src/core/shape.ts
+++ b/src/core/shape.ts
@@ -1,0 +1,44 @@
+import * as z from 'zod/v4';
+
+export const DETAIL_LEVELS = ['minimal', 'standard', 'full'] as const;
+export type DetailLevel = (typeof DETAIL_LEVELS)[number];
+
+export const DEFAULT_LIMIT = 50;
+export const MAX_LIMIT = 500;
+
+export const DetailSchema = z
+    .enum(DETAIL_LEVELS)
+    .default('standard')
+    .describe('How much per-item detail to return. Defaults to standard.');
+
+export const LimitSchema = z
+    .number()
+    .int()
+    .positive()
+    .max(MAX_LIMIT)
+    .default(DEFAULT_LIMIT)
+    .describe(`Maximum items to return. Defaults to ${DEFAULT_LIMIT}, hard maximum ${MAX_LIMIT}.`);
+
+/**
+ * The truncation contract from design spec §12. Silent truncation is how a
+ * model confidently reports that a 900-film library contains 50 films, so
+ * every read tool routes its list through here and serialises all four fields.
+ *
+ * `limit` is clamped defensively even though LimitSchema also caps it — a
+ * future internal caller that bypasses the schema must not be able to request
+ * 5000 items, and must not be able to request zero and get a silently empty
+ * list back.
+ */
+export function applyLimit<T>(
+    items: readonly T[],
+    limit: number
+): { items: T[]; total: number; returned: number; truncated: boolean } {
+    const effective = Math.min(Math.max(Math.trunc(limit), 1), MAX_LIMIT);
+    const sliced = items.slice(0, effective);
+    return {
+        items: sliced,
+        total: items.length,
+        returned: sliced.length,
+        truncated: sliced.length < items.length
+    };
+}

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import { ServiceError, classifyFetchError, classifyHttpStatus } from '../src/core/errors.ts';
+
+describe('ServiceError.toModelText', () => {
+    it('produces actionable text naming the service, cause, and target', () => {
+        const err = new ServiceError('Unreachable', 'bazarr', 'connection refused at 192.168.1.20:6767');
+        expect(err.toModelText()).toBe('bazarr unreachable: connection refused at 192.168.1.20:6767');
+    });
+
+    it('appends the remedy when one is known', () => {
+        const err = new ServiceError('AuthFailed', 'radarr', 'HTTP 401 at /api/v3/system/status', {
+            remedy: 'The API key is wrong. Radarr → Settings → General.'
+        });
+        expect(err.toModelText()).toBe(
+            'radarr auth failed: HTTP 401 at /api/v3/system/status — The API key is wrong. Radarr → Settings → General.'
+        );
+    });
+
+    it('never leaks a stack trace into model-facing text', () => {
+        const err = new ServiceError('UpstreamError', 'radarr', 'boom');
+        expect(err.toModelText()).not.toContain('at ');
+        expect(err.toModelText()).not.toContain(import.meta.url);
+    });
+
+    it('preserves the original error as cause for logs without exposing it to the model', () => {
+        const original = new Error('socket hang up');
+        const err = new ServiceError('Timeout', 'sonarr', 'no response', { cause: original });
+        expect(err.cause).toBe(original);
+        expect(err.toModelText()).not.toContain('socket hang up');
+    });
+});
+
+describe('classifyHttpStatus', () => {
+    it.each([
+        [401, 'AuthFailed'],
+        [403, 'AuthFailed'],
+        [404, 'NotFound'],
+        [429, 'RateLimited'],
+        [500, 'UpstreamError'],
+        [502, 'UpstreamError']
+    ])('maps HTTP %i to %s', (status, kind) => {
+        expect(classifyHttpStatus(status, 'radarr', 'http://h/api')?.kind).toBe(kind);
+    });
+
+    it('returns undefined for a success status', () => {
+        expect(classifyHttpStatus(200, 'radarr', 'http://h/api')).toBeUndefined();
+    });
+
+    it('returns undefined for a 3xx redirect', () => {
+        expect(classifyHttpStatus(302, 'radarr', 'http://h/api')).toBeUndefined();
+    });
+
+    it('gives a 404 the wrong-base-path remedy, not a generic message', () => {
+        expect(classifyHttpStatus(404, 'radarr', 'http://h/api/v3/system/status')?.remedy).toMatch(/base path/i);
+    });
+
+    it('names the path but not the host in the detail, so keys in query strings cannot leak', () => {
+        const err = classifyHttpStatus(401, 'radarr', 'http://h:7878/api/v3/system/status?apikey=secret');
+        expect(err?.detail).toContain('/api/v3/system/status');
+        expect(err?.detail).not.toContain('secret');
+    });
+});
+
+describe('classifyFetchError', () => {
+    it('maps DNS failure to Unreachable with a DNS remedy', () => {
+        const e = Object.assign(new Error('getaddrinfo ENOTFOUND nope'), { code: 'ENOTFOUND' });
+        const out = classifyFetchError(e, 'radarr', 'http://nope:7878');
+        expect(out.kind).toBe('Unreachable');
+        expect(out.remedy).toMatch(/hostname/i);
+    });
+
+    it('maps connection refused to Unreachable', () => {
+        const e = Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' });
+        expect(classifyFetchError(e, 'radarr', 'http://h:7878').kind).toBe('Unreachable');
+    });
+
+    it('maps an AbortError to Timeout', () => {
+        const e = Object.assign(new Error('aborted'), { name: 'AbortError' });
+        expect(classifyFetchError(e, 'radarr', 'http://h:7878').kind).toBe('Timeout');
+    });
+
+    it('maps a TimeoutError to Timeout', () => {
+        const e = Object.assign(new Error('timed out'), { name: 'TimeoutError' });
+        expect(classifyFetchError(e, 'radarr', 'http://h:7878').kind).toBe('Timeout');
+    });
+
+    it('maps a TLS certificate failure to Unreachable with a TLS remedy', () => {
+        const e = Object.assign(new Error('self-signed'), { code: 'DEPTH_ZERO_SELF_SIGNED_CERT' });
+        expect(classifyFetchError(e, 'radarr', 'https://h:7878').remedy).toMatch(/certificate/i);
+    });
+
+    it('reads the error code from a nested cause, as undici reports it', () => {
+        const e = Object.assign(new Error('fetch failed'), { cause: { code: 'ECONNREFUSED' } });
+        expect(classifyFetchError(e, 'radarr', 'http://h:7878').remedy).toMatch(/listening/i);
+    });
+
+    it('falls back to Unreachable for an unrecognised failure without throwing', () => {
+        const out = classifyFetchError({ weird: true }, 'radarr', 'http://h:7878');
+        expect(out.kind).toBe('Unreachable');
+        expect(out.toModelText()).toContain('radarr');
+    });
+
+    it('does not throw when the url is unparseable', () => {
+        const e = Object.assign(new Error('nope'), { code: 'ECONNREFUSED' });
+        expect(() => classifyFetchError(e, 'radarr', 'not a url')).not.toThrow();
+    });
+});

--- a/test/shape.test.ts
+++ b/test/shape.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_LIMIT, DetailSchema, LimitSchema, MAX_LIMIT, applyLimit } from '../src/core/shape.ts';
+
+describe('applyLimit', () => {
+    it('reports truncation honestly when the list is longer than the limit', () => {
+        const out = applyLimit(
+            Array.from({ length: 900 }, (_, i) => i),
+            50
+        );
+        expect(out.returned).toBe(50);
+        expect(out.total).toBe(900);
+        expect(out.truncated).toBe(true);
+    });
+
+    it('reports truncated: false when everything fits', () => {
+        const out = applyLimit([1, 2, 3], 50);
+        expect(out).toEqual({ items: [1, 2, 3], total: 3, returned: 3, truncated: false });
+    });
+
+    it('caps at MAX_LIMIT regardless of what was requested', () => {
+        const out = applyLimit(
+            Array.from({ length: 2000 }, (_, i) => i),
+            9999
+        );
+        expect(out.returned).toBe(MAX_LIMIT);
+        expect(out.truncated).toBe(true);
+    });
+
+    it('handles an empty list without claiming truncation', () => {
+        expect(applyLimit([], 50)).toEqual({ items: [], total: 0, returned: 0, truncated: false });
+    });
+
+    it('clamps a nonsensical limit to at least one item rather than returning nothing', () => {
+        const out = applyLimit([1, 2, 3], 0);
+        expect(out.returned).toBe(1);
+        expect(out.total).toBe(3);
+        expect(out.truncated).toBe(true);
+    });
+
+    it('returns exactly the boundary case without claiming truncation', () => {
+        const out = applyLimit([1, 2, 3], 3);
+        expect(out.truncated).toBe(false);
+        expect(out.returned).toBe(3);
+    });
+
+    it('does not mutate the input array', () => {
+        const input = [1, 2, 3, 4];
+        applyLimit(input, 2);
+        expect(input).toEqual([1, 2, 3, 4]);
+    });
+});
+
+describe('schemas', () => {
+    it('defaults detail to standard', () => {
+        expect(DetailSchema.parse(undefined)).toBe('standard');
+    });
+
+    it('accepts all three detail levels', () => {
+        expect(DetailSchema.parse('minimal')).toBe('minimal');
+        expect(DetailSchema.parse('standard')).toBe('standard');
+        expect(DetailSchema.parse('full')).toBe('full');
+    });
+
+    it('rejects an unknown detail level', () => {
+        expect(DetailSchema.safeParse('verbose').success).toBe(false);
+    });
+
+    it('defaults limit to 50', () => {
+        expect(LimitSchema.parse(undefined)).toBe(DEFAULT_LIMIT);
+    });
+
+    it('rejects a limit above the hard maximum at the schema boundary', () => {
+        expect(LimitSchema.safeParse(501).success).toBe(false);
+    });
+
+    it('accepts the hard maximum itself', () => {
+        expect(LimitSchema.parse(MAX_LIMIT)).toBe(MAX_LIMIT);
+    });
+
+    it('rejects a non-positive limit', () => {
+        expect(LimitSchema.safeParse(0).success).toBe(false);
+    });
+
+    it('rejects a fractional limit', () => {
+        expect(LimitSchema.safeParse(1.5).success).toBe(false);
+    });
+});


### PR DESCRIPTION
Tasks 3 and 4 of the Phase 1 plan. Both are small, dependency-free core modules that every later task builds on, so they share a PR.

**Error taxonomy** (`src/core/errors.ts`)
- `ServiceError` with the seven kinds from spec §15 and `toModelText()`
- `classifyHttpStatus` — 401/403 → AuthFailed with a key remedy, 404 → NotFound with the wrong-base-path remedy, 429 → RateLimited, 5xx → UpstreamError
- `classifyFetchError` — DNS, connection refused, TLS, abort/timeout, reading undici's nested `cause.code`
- only the URL *path* appears in messages, so an api key in a query string cannot leak into model context
- the original error stays on `.cause` for logs but never reaches the model

**Response shaping** (`src/core/shape.ts`)
- `DetailSchema` (minimal/standard/full, default standard) and `LimitSchema` (default 50, hard max 500)
- `applyLimit` returns `{items, total, returned, truncated}`, clamped defensively against internal callers that bypass the schema

37 new tests; 53 total.