### PR TITLE
feat: Radarr adapter

### DIFF
--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -6,5 +6,9 @@ import pino from 'pino';
  */
 export const logger = pino({
     level: process.env.LOG_LEVEL ?? 'info',
-    base: { service: 'arr-mcp' }
+    // `app`, not `service`: `service` belongs to the media service a log line
+    // is about (radarr, sonarr, …), which is what the config UI's per-service
+    // log stream filters on in Phase 5. Binding both to `service` emits a
+    // duplicate JSON key and silently loses one of them.
+    base: { app: 'arr-mcp' }
 });

--- a/src/services/radarr.ts
+++ b/src/services/radarr.ts
@@ -1,0 +1,155 @@
+import type { ServiceConfig, ServiceId } from '../config/schema.ts';
+import { ServiceError, classifyFetchError, classifyHttpStatus } from '../core/errors.ts';
+import { logger } from '../core/logger.ts';
+import type { ArrAdapter, ConnectionDiagnosis, DiskSpace, HealthCheck } from './types.ts';
+
+/** Minimal hand-written shapes; replaced by generated types in Phase 2. */
+type SystemStatus = { appName?: string; version?: string; instanceName?: string };
+
+const CIRCUIT_THRESHOLD = 5;
+const CIRCUIT_COOLDOWN_MS = 60_000;
+
+export class RadarrAdapter implements ArrAdapter {
+    readonly id: ServiceId = 'radarr';
+
+    readonly #config: ServiceConfig;
+    readonly #fetch: typeof fetch;
+    #consecutiveFailures = 0;
+    #openedAt: number | undefined;
+
+    constructor(config: ServiceConfig, fetchImpl: typeof fetch = fetch) {
+        this.#config = config;
+        this.#fetch = fetchImpl;
+    }
+
+    async getVersion(): Promise<string> {
+        const status = await this.#get<SystemStatus>('/api/v3/system/status');
+        if (!status.version) {
+            throw new ServiceError('UpstreamError', this.id, 'system/status returned no version field');
+        }
+        return status.version;
+    }
+
+    async getDiskSpace(): Promise<DiskSpace[]> {
+        return this.#get<DiskSpace[]>('/api/v3/diskspace');
+    }
+
+    async getFailedHealthChecks(): Promise<HealthCheck[]> {
+        const all = await this.#get<HealthCheck[]>('/api/v3/health');
+        // Radarr generally returns only entries worth surfacing, but some
+        // versions include `ok` rows — filter rather than trust.
+        return all.filter(c => c.type !== 'ok');
+    }
+
+    async testConnection(): Promise<ConnectionDiagnosis> {
+        const started = performance.now();
+        try {
+            const status = await this.#get<SystemStatus>('/api/v3/system/status');
+            const diagnosis: ConnectionDiagnosis = {
+                ok: true,
+                service: this.id,
+                latency_ms: Math.round(performance.now() - started)
+            };
+            if (status.version) diagnosis.version = status.version;
+            return diagnosis;
+        } catch (err) {
+            const se =
+                err instanceof ServiceError
+                    ? err
+                    : new ServiceError('UpstreamError', this.id, (err as Error).message ?? 'unknown', { cause: err });
+            const error: ConnectionDiagnosis['error'] = { kind: se.kind, detail: se.detail };
+            if (se.remedy !== undefined) error.remedy = se.remedy;
+            return {
+                ok: false,
+                service: this.id,
+                latency_ms: Math.round(performance.now() - started),
+                error
+            };
+        }
+    }
+
+    // --- internals ---
+
+    #circuitOpen(): boolean {
+        if (this.#openedAt === undefined) return false;
+        if (Date.now() - this.#openedAt >= CIRCUIT_COOLDOWN_MS) {
+            // Half-open: allow a single trial request through. Leaving the
+            // failure count one below the threshold means one more failure
+            // re-opens the circuit immediately.
+            this.#openedAt = undefined;
+            this.#consecutiveFailures = CIRCUIT_THRESHOLD - 1;
+            return false;
+        }
+        return true;
+    }
+
+    #recordSuccess(): void {
+        this.#consecutiveFailures = 0;
+        this.#openedAt = undefined;
+    }
+
+    #recordFailure(): void {
+        this.#consecutiveFailures += 1;
+        if (this.#consecutiveFailures >= CIRCUIT_THRESHOLD && this.#openedAt === undefined) {
+            this.#openedAt = Date.now();
+            logger.warn({ service: this.id }, 'circuit breaker opened after consecutive failures');
+        }
+    }
+
+    /** Reads retry once on timeout; writes never auto-retry (design spec §15). */
+    async #get<T>(path: string): Promise<T> {
+        if (this.#circuitOpen()) {
+            throw new ServiceError(
+                'Unreachable',
+                this.id,
+                `circuit breaker is open after ${CIRCUIT_THRESHOLD} consecutive failures`,
+                { remedy: `Not retried for ${CIRCUIT_COOLDOWN_MS / 1000}s. Fix the service, then try again.` }
+            );
+        }
+
+        try {
+            const result = await this.#attempt<T>(path);
+            this.#recordSuccess();
+            return result;
+        } catch (err) {
+            if (err instanceof ServiceError && err.kind === 'Timeout') {
+                try {
+                    const result = await this.#attempt<T>(path);
+                    this.#recordSuccess();
+                    return result;
+                } catch (retryErr) {
+                    this.#recordFailure();
+                    throw retryErr;
+                }
+            }
+            this.#recordFailure();
+            throw err;
+        }
+    }
+
+    async #attempt<T>(path: string): Promise<T> {
+        const url = new URL(path, this.#config.url).toString();
+        const signal = AbortSignal.timeout(this.#config.timeout_ms);
+
+        let response: Response;
+        try {
+            response = await this.#fetch(url, {
+                signal,
+                headers: { 'X-Api-Key': this.#config.api_key, Accept: 'application/json' }
+            });
+        } catch (err) {
+            throw classifyFetchError(err, this.id, url);
+        }
+
+        const httpError = classifyHttpStatus(response.status, this.id, url);
+        if (httpError) throw httpError;
+
+        try {
+            return (await response.json()) as T;
+        } catch (err) {
+            throw new ServiceError('UpstreamError', this.id, `response from ${path} was not valid JSON`, {
+                cause: err
+            });
+        }
+    }
+}

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -1,0 +1,29 @@
+import type { ServiceId } from '../config/schema.ts';
+import type { ServiceErrorKind } from '../core/errors.ts';
+
+/**
+ * A diagnosis, not a boolean (design spec §6/§14). A connection test that
+ * returns true/false tells the user nothing about what to fix.
+ */
+export type ConnectionDiagnosis = {
+    ok: boolean;
+    service: ServiceId;
+    latency_ms: number;
+    version?: string;
+    error?: { kind: ServiceErrorKind; detail: string; remedy?: string };
+};
+
+export interface ServiceAdapter {
+    readonly id: ServiceId;
+    testConnection(): Promise<ConnectionDiagnosis>;
+    getVersion(): Promise<string>;
+}
+
+export type DiskSpace = { path: string; label: string; freeSpace: number; totalSpace: number };
+export type HealthCheck = { source: string; type: string; message: string };
+
+/** Shared by Radarr and Sonarr; Sonarr's adapter lands in Phase 2. */
+export interface ArrAdapter extends ServiceAdapter {
+    getDiskSpace(): Promise<DiskSpace[]>;
+    getFailedHealthChecks(): Promise<HealthCheck[]>;
+}

--- a/test/radarr.test.ts
+++ b/test/radarr.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ServiceConfig } from '../src/config/schema.ts';
+import { RadarrAdapter } from '../src/services/radarr.ts';
+
+const config: ServiceConfig = {
+    url: 'http://192.168.1.20:7878',
+    api_key: 'test-key',
+    timeout_ms: 10_000,
+    permissions: { safe_write: false, destructive: false }
+};
+
+/**
+ * Fixture shapes are Radarr v3's /api/v3/system/status, /diskspace and /health
+ * responses trimmed to the fields we consume. Design spec §21.2 flags the
+ * Radarr schema as unconfirmed — Task 10 Step 2 verifies these against a live
+ * instance and corrects fixture and type together if a field name differs.
+ */
+const STATUS = { appName: 'Radarr', version: '5.14.0.9383', instanceName: 'Radarr' };
+const DISKSPACE = [{ path: '/movies', label: 'movies', freeSpace: 1_234_567_890, totalSpace: 9_876_543_210 }];
+const HEALTH = [{ source: 'IndexerStatusCheck', type: 'warning', message: 'Indexers unavailable due to failures' }];
+
+const jsonResponse = (body: unknown, status = 200) =>
+    new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+
+const timeoutError = () => Object.assign(new Error('aborted'), { name: 'AbortError' });
+const refusedError = () => Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' });
+
+describe('RadarrAdapter', () => {
+    it('sends the api key as the X-Api-Key header, never in the query string', async () => {
+        const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+            const url = String(input instanceof Request ? input.url : input);
+            expect(url).not.toContain('test-key');
+            expect(new Headers(init?.headers).get('X-Api-Key')).toBe('test-key');
+            return jsonResponse(STATUS);
+        });
+
+        const adapter = new RadarrAdapter(config, fetchMock as unknown as typeof fetch);
+        await adapter.getVersion();
+        expect(fetchMock).toHaveBeenCalledOnce();
+    });
+
+    it('returns the version from /api/v3/system/status', async () => {
+        const adapter = new RadarrAdapter(config, (async () => jsonResponse(STATUS)) as unknown as typeof fetch);
+        expect(await adapter.getVersion()).toBe('5.14.0.9383');
+    });
+
+    it('requests the documented status path', async () => {
+        const seen: string[] = [];
+        const spy = async (input: string | URL | Request) => {
+            seen.push(String(input));
+            return jsonResponse(STATUS);
+        };
+        await new RadarrAdapter(config, spy as unknown as typeof fetch).getVersion();
+        expect(seen[0]).toBe('http://192.168.1.20:7878/api/v3/system/status');
+    });
+
+    it('errors rather than returning undefined when status carries no version', async () => {
+        const adapter = new RadarrAdapter(config, (async () => jsonResponse({ appName: 'Radarr' })) as unknown as typeof fetch);
+        await expect(adapter.getVersion()).rejects.toThrow(/no version/i);
+    });
+
+    it('diagnoses a healthy instance with a latency measurement and version', async () => {
+        const adapter = new RadarrAdapter(config, (async () => jsonResponse(STATUS)) as unknown as typeof fetch);
+        const d = await adapter.testConnection();
+
+        expect(d.ok).toBe(true);
+        expect(d.service).toBe('radarr');
+        expect(d.version).toBe('5.14.0.9383');
+        expect(d.latency_ms).toBeGreaterThanOrEqual(0);
+        expect(d.error).toBeUndefined();
+    });
+
+    it('diagnoses a bad api key as AuthFailed with a remedy, not as a thrown error', async () => {
+        const adapter = new RadarrAdapter(
+            config,
+            (async () => jsonResponse({ message: 'Unauthorized' }, 401)) as unknown as typeof fetch
+        );
+        const d = await adapter.testConnection();
+
+        expect(d.ok).toBe(false);
+        expect(d.error?.kind).toBe('AuthFailed');
+        expect(d.error?.remedy).toMatch(/api key/i);
+    });
+
+    it('diagnoses connection refused as Unreachable', async () => {
+        const adapter = new RadarrAdapter(config, (async () => {
+            throw refusedError();
+        }) as unknown as typeof fetch);
+        const d = await adapter.testConnection();
+
+        expect(d.ok).toBe(false);
+        expect(d.error?.kind).toBe('Unreachable');
+    });
+
+    it('diagnoses a non-JSON body as UpstreamError rather than crashing', async () => {
+        const adapter = new RadarrAdapter(config, (async () =>
+            new Response('<html>not json</html>', { status: 200 })) as unknown as typeof fetch);
+        const d = await adapter.testConnection();
+
+        expect(d.ok).toBe(false);
+        expect(d.error?.kind).toBe('UpstreamError');
+    });
+
+    it('returns only failing health checks, filtering out ok entries', async () => {
+        const body = [...HEALTH, { source: 'X', type: 'ok', message: 'fine' }];
+        const adapter = new RadarrAdapter(config, (async () => jsonResponse(body)) as unknown as typeof fetch);
+        const checks = await adapter.getFailedHealthChecks();
+
+        expect(checks).toHaveLength(1);
+        expect(checks[0]?.source).toBe('IndexerStatusCheck');
+    });
+
+    it('returns disk space entries', async () => {
+        const adapter = new RadarrAdapter(config, (async () => jsonResponse(DISKSPACE)) as unknown as typeof fetch);
+        const disks = await adapter.getDiskSpace();
+
+        expect(disks).toHaveLength(1);
+        expect(disks[0]?.freeSpace).toBe(1_234_567_890);
+    });
+
+    it('retries a read once on timeout, then succeeds', async () => {
+        let calls = 0;
+        const flaky = async () => {
+            calls += 1;
+            if (calls === 1) throw timeoutError();
+            return jsonResponse(STATUS);
+        };
+        const adapter = new RadarrAdapter(config, flaky as unknown as typeof fetch);
+
+        expect(await adapter.getVersion()).toBe('5.14.0.9383');
+        expect(calls).toBe(2);
+    });
+
+    it('gives up after exactly one retry — reads do not retry forever', async () => {
+        let calls = 0;
+        const alwaysTimeout = async () => {
+            calls += 1;
+            throw timeoutError();
+        };
+        const adapter = new RadarrAdapter(config, alwaysTimeout as unknown as typeof fetch);
+
+        await expect(adapter.getVersion()).rejects.toThrow(/timed out/);
+        expect(calls).toBe(2);
+    });
+
+    it('does not retry a 401 — an auth failure is not transient', async () => {
+        let calls = 0;
+        const unauthorized = async () => {
+            calls += 1;
+            return jsonResponse({}, 401);
+        };
+        const adapter = new RadarrAdapter(config, unauthorized as unknown as typeof fetch);
+
+        await expect(adapter.getVersion()).rejects.toThrow(/auth failed/);
+        expect(calls).toBe(1);
+    });
+
+    it('does not retry connection refused — only timeouts are retried', async () => {
+        let calls = 0;
+        const refuse = async () => {
+            calls += 1;
+            throw refusedError();
+        };
+        const adapter = new RadarrAdapter(config, refuse as unknown as typeof fetch);
+
+        await expect(adapter.getVersion()).rejects.toThrow(/unreachable/);
+        expect(calls).toBe(1);
+    });
+
+    it('opens the circuit after 5 consecutive failures and stops calling out', async () => {
+        let calls = 0;
+        const refuse = async () => {
+            calls += 1;
+            throw refusedError();
+        };
+        const adapter = new RadarrAdapter(config, refuse as unknown as typeof fetch);
+
+        for (let i = 0; i < 5; i += 1) {
+            await adapter.testConnection();
+        }
+        const callsAfterFive = calls;
+
+        const d = await adapter.testConnection();
+        expect(d.ok).toBe(false);
+        expect(d.error?.detail).toMatch(/circuit/i);
+        expect(calls).toBe(callsAfterFive); // no further network attempts
+    });
+
+    it('half-opens after the cooldown and lets a single trial request through', async () => {
+        vi.useFakeTimers();
+        try {
+            let calls = 0;
+            let failing = true;
+            const flaky = async () => {
+                calls += 1;
+                if (failing) throw refusedError();
+                return jsonResponse(STATUS);
+            };
+            const adapter = new RadarrAdapter(config, flaky as unknown as typeof fetch);
+
+            for (let i = 0; i < 5; i += 1) await adapter.testConnection();
+            const callsWhenOpen = calls;
+
+            // Still open immediately after tripping.
+            await adapter.testConnection();
+            expect(calls).toBe(callsWhenOpen);
+
+            // After the 60s cooldown the service is healthy again.
+            failing = false;
+            vi.advanceTimersByTime(60_001);
+            const d = await adapter.testConnection();
+
+            expect(calls).toBe(callsWhenOpen + 1);
+            expect(d.ok).toBe(true);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('resets the failure count after a success, so intermittent errors never trip the circuit', async () => {
+        let failNext = true;
+        const alternating = async () => {
+            failNext = !failNext;
+            if (!failNext) throw refusedError();
+            return jsonResponse(STATUS);
+        };
+        const adapter = new RadarrAdapter(config, alternating as unknown as typeof fetch);
+
+        for (let i = 0; i < 12; i += 1) await adapter.testConnection();
+
+        // A circuit that counted cumulatively rather than consecutively would
+        // be open by now; this must still be attempting real requests.
+        const d = await adapter.testConnection();
+        expect(d.error?.detail ?? '').not.toMatch(/circuit/i);
+    });
+});

--- a/test/smoke.test.ts
+++ b/test/smoke.test.ts
@@ -2,9 +2,15 @@ import { describe, expect, it } from 'vitest';
 import { logger } from '../src/core/logger.ts';
 
 describe('toolchain', () => {
-    it('exposes a logger with the service name bound', () => {
+    it('exposes a logger with the app name bound', () => {
         expect(logger).toBeDefined();
         expect(typeof logger.info).toBe('function');
-        expect(logger.bindings().service).toBe('arr-mcp');
+        expect(logger.bindings().app).toBe('arr-mcp');
+    });
+
+    it('leaves `service` free for per-service log filtering', () => {
+        // Binding the app name to `service` would collide with the media
+        // service a log line is about and emit a duplicate JSON key.
+        expect(logger.bindings().service).toBeUndefined();
     });
 });


### PR DESCRIPTION
Task 5 of the Phase 1 plan.

`RadarrAdapter` implements `ArrAdapter` against an injectable `fetch`, so all 17 tests run with no live Radarr.

Behaviour worth reviewing:
- `testConnection` returns a `ConnectionDiagnosis` — never a boolean — carrying latency, version, and a remedy per spec §6/§14
- api key travels as `X-Api-Key`; a test asserts it never appears in the URL
- **reads retry once on timeout; nothing else retries.** Separate tests pin that a 401 and a connection-refused each make exactly one attempt
- circuit breaker opens after 5 *consecutive* failures, half-opens after 60s for a single trial (fake-timer test), and a success resets the count — a test with alternating pass/fail proves it never trips on intermittent errors
- non-JSON bodies surface as `UpstreamError` instead of crashing

### Also in this PR
The logger's base binding moves from `service` to `app`. Adapters log `service: 'radarr'`, so both were emitting a duplicate `service` JSON key — parsers keep the last one, so the value silently flipped depending on order. That would have broken the per-service log stream the config UI needs in Phase 5.

### Fixture caveat
The three Radarr response shapes are the plan's best reading of the v3 API, not captured responses — spec §21.2 flags that schema as unconfirmed. Task 10 Step 2 verifies them against a live instance and corrects fixture and type together if anything differs.