### PR TITLE
feat: stateless MCP endpoint, bearer auth, and stack_health

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,0 +1,71 @@
+import { createMcpHonoApp } from '@modelcontextprotocol/hono';
+import { McpServer, createMcpHandler } from '@modelcontextprotocol/server';
+import type { Context } from 'hono';
+import { timingSafeEqual } from 'node:crypto';
+import type { Config } from './config/schema.ts';
+import { logger } from './core/logger.ts';
+import type { ServiceAdapter } from './services/types.ts';
+import { registerStackHealth } from './tools/stackHealth.ts';
+
+const NAME = 'arr-mcp';
+const VERSION = process.env.ARR_MCP_VERSION ?? '0.0.0-dev';
+
+/** Constant-time compare that does not reveal the expected length by timing. */
+function tokenMatches(presented: string, expected: string): boolean {
+    const a = Buffer.from(presented);
+    const b = Buffer.from(expected);
+    if (a.length !== b.length) {
+        // Burn an equivalent comparison so a wrong-length token is not
+        // distinguishable from a wrong-bytes one.
+        timingSafeEqual(b, b);
+        return false;
+    }
+    return timingSafeEqual(a, b);
+}
+
+export function buildApp(opts: { config: Config; adapters: readonly ServiceAdapter[] }) {
+    const { config, adapters } = opts;
+
+    // The factory runs once per request, so every call gets a fresh McpServer.
+    // This is what keeps the transport stateless (design spec §5) — do not
+    // hoist the server out of the closure.
+    const handler = createMcpHandler(() => {
+        const server = new McpServer({ name: NAME, version: VERSION });
+        registerStackHealth(server, adapters);
+        return server;
+    });
+
+    // We bind 0.0.0.0 because the container must be reachable across the LAN,
+    // which drops the SDK's default localhost Host/Origin validation.
+    //
+    // `allowedHosts` must be OMITTED, not empty, when the user has pinned no
+    // hostnames: the adapter gates the middleware on `if (allowedHosts)`, and
+    // `[]` is truthy — so passing an empty array installs validation with an
+    // empty allow-list and rejects *every* request with 403. Authentication is
+    // what protects us here; Host pinning is an extra a reverse-proxy user can
+    // opt into.
+    const allowedHosts = config.auth.allowed_hosts;
+    const app = createMcpHonoApp({
+        host: '0.0.0.0',
+        ...(allowedHosts.length > 0 ? { allowedHosts } : {})
+    });
+
+    app.get('/healthz', c => c.json({ status: 'ok', name: NAME, version: VERSION }));
+
+    app.all('/mcp', async (c: Context) => {
+        const header = c.req.header('Authorization') ?? '';
+        const [scheme, presented] = header.split(' ');
+
+        if (scheme !== 'Bearer' || !presented || !tokenMatches(presented, config.auth.bearer_token)) {
+            logger.warn(
+                { path: '/mcp', ip: c.req.header('x-forwarded-for') ?? 'unknown' },
+                'rejected unauthenticated MCP request'
+            );
+            return c.json({ error: 'unauthorized' }, 401, { 'WWW-Authenticate': 'Bearer realm="arr-mcp"' });
+        }
+
+        return handler.fetch(c.req.raw, { parsedBody: c.get('parsedBody') });
+    });
+
+    return app;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,33 @@
+import { serve } from '@hono/node-server';
+import { buildApp } from './app.ts';
+import { loadConfig } from './config/load.ts';
+import { logger } from './core/logger.ts';
+import { RadarrAdapter } from './services/radarr.ts';
+import type { ServiceAdapter } from './services/types.ts';
+
+const CONFIG_DIR = process.env.ARR_MCP_CONFIG_DIR ?? '/config';
+const PORT = Number(process.env.ARR_MCP_PORT ?? 6060);
+
+const { config, created } = await loadConfig(CONFIG_DIR);
+
+if (created) {
+    // The token is the only way in and there is no UI until Phase 5, so it has
+    // to be discoverable from `docker logs` on first start.
+    logger.info({ token: config.auth.bearer_token }, 'first run — use this bearer token for /mcp');
+}
+
+const adapters: ServiceAdapter[] = [];
+if (config.services.radarr) {
+    adapters.push(new RadarrAdapter(config.services.radarr));
+}
+
+if (adapters.length === 0) {
+    logger.warn(
+        { config: `${CONFIG_DIR}/config.yaml` },
+        'no services configured — stack_health will return an empty result until you add one'
+    );
+}
+
+serve({ fetch: buildApp({ config, adapters }).fetch, port: PORT, hostname: '0.0.0.0' }, info => {
+    logger.info({ port: info.port, adapters: adapters.map(a => a.id) }, 'arr-mcp listening');
+});

--- a/src/tools/stackHealth.ts
+++ b/src/tools/stackHealth.ts
@@ -1,0 +1,128 @@
+import type { McpServer } from '@modelcontextprotocol/server';
+import * as z from 'zod/v4';
+import type { ServiceId } from '../config/schema.ts';
+import { ServiceError } from '../core/errors.ts';
+import { logger } from '../core/logger.ts';
+import { DetailSchema, LimitSchema, applyLimit, type DetailLevel } from '../core/shape.ts';
+import type { ArrAdapter, ConnectionDiagnosis, DiskSpace, HealthCheck, ServiceAdapter } from '../services/types.ts';
+
+type Shaped<T> = { items: T[]; total: number; returned: number; truncated: boolean };
+
+export type StackHealthResult = {
+    services: ConnectionDiagnosis[];
+    disks: Shaped<DiskSpace>;
+    failures: Shaped<HealthCheck>;
+    degraded: ServiceId[];
+};
+
+const isArr = (a: ServiceAdapter): a is ArrAdapter =>
+    'getDiskSpace' in a && typeof (a as ArrAdapter).getDiskSpace === 'function';
+
+/**
+ * Composes per-service diagnoses into one answer. This tool must work
+ * *especially* well when something is broken (design spec §15) — a service
+ * that is down contributes a diagnosis and a `degraded` entry, never an
+ * exception.
+ */
+export async function buildStackHealth(
+    adapters: readonly ServiceAdapter[],
+    opts: { detail: DetailLevel; limit: number }
+): Promise<StackHealthResult> {
+    const services: ConnectionDiagnosis[] = [];
+    const degraded: ServiceId[] = [];
+    const disks: DiskSpace[] = [];
+    const failures: HealthCheck[] = [];
+
+    const markDegraded = (id: ServiceId) => {
+        if (!degraded.includes(id)) degraded.push(id);
+    };
+
+    await Promise.all(
+        adapters.map(async adapter => {
+            let diagnosis: ConnectionDiagnosis;
+            try {
+                diagnosis = await adapter.testConnection();
+            } catch (err) {
+                // testConnection is contractually non-throwing, but a bug in
+                // one adapter must not take down the whole answer.
+                logger.error({ service: adapter.id, err }, 'testConnection threw; treating as degraded');
+                diagnosis = {
+                    ok: false,
+                    service: adapter.id,
+                    latency_ms: 0,
+                    error: {
+                        kind: err instanceof ServiceError ? err.kind : 'UpstreamError',
+                        detail: err instanceof Error ? err.message : 'unknown error'
+                    }
+                };
+            }
+
+            services.push(diagnosis);
+            if (!diagnosis.ok) {
+                markDegraded(adapter.id);
+                return; // do not hammer a service that just failed its probe
+            }
+
+            if (!isArr(adapter)) return;
+
+            const [diskResult, healthResult] = await Promise.allSettled([
+                adapter.getDiskSpace(),
+                adapter.getFailedHealthChecks()
+            ]);
+
+            if (diskResult.status === 'fulfilled') {
+                disks.push(...diskResult.value);
+            } else {
+                logger.warn({ service: adapter.id }, 'diskspace read failed');
+                markDegraded(adapter.id);
+            }
+
+            if (healthResult.status === 'fulfilled') {
+                failures.push(...healthResult.value);
+            } else {
+                logger.warn({ service: adapter.id }, 'health read failed');
+                markDegraded(adapter.id);
+            }
+        })
+    );
+
+    // Promise.all resolves in input order but the pushes above race, so sort to
+    // make the response stable across calls and diffable in tests.
+    services.sort((a, b) => a.service.localeCompare(b.service));
+    degraded.sort();
+
+    const shapedDisks = applyLimit(disks, opts.limit);
+    const shapedFailures = applyLimit(failures, opts.limit);
+
+    // `minimal` drops per-item payloads but keeps the counts honest: a model
+    // must never see returned: 0 and conclude there are no disks.
+    return {
+        services,
+        disks: opts.detail === 'minimal' ? { ...shapedDisks, items: [], returned: 0 } : shapedDisks,
+        failures: shapedFailures,
+        degraded
+    };
+}
+
+export function registerStackHealth(server: McpServer, adapters: readonly ServiceAdapter[]): void {
+    server.registerTool(
+        'stack_health',
+        {
+            description:
+                'Health of every configured service: version, disk space, failing health checks, and which services could not be reached. Returns partial results with a `degraded` list rather than failing when a service is down.',
+            inputSchema: z.object({ detail: DetailSchema, limit: LimitSchema })
+        },
+        async ({ detail, limit }) => {
+            const result = await buildStackHealth(adapters, { detail, limit });
+            const summary =
+                result.degraded.length === 0
+                    ? `All ${result.services.length} configured service(s) healthy.`
+                    : `${result.degraded.length} of ${result.services.length} service(s) degraded: ${result.degraded.join(', ')}.`;
+
+            return {
+                content: [{ type: 'text', text: summary }],
+                structuredContent: result
+            };
+        }
+    );
+}

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest';
+import { buildApp } from '../src/app.ts';
+import { ConfigSchema } from '../src/config/schema.ts';
+
+const TOKEN = 'a'.repeat(64);
+const WRONG = 'b'.repeat(64);
+
+const config = ConfigSchema.parse({ auth: { bearer_token: TOKEN }, services: {} });
+const app = () => buildApp({ config, adapters: [] });
+
+const rpc = (body: unknown, headers: Record<string, string> = {}) => ({
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream', ...headers },
+    body: JSON.stringify(body)
+});
+
+const toolsList = { jsonrpc: '2.0', id: 1, method: 'tools/list' };
+
+describe('GET /healthz', () => {
+    it('is reachable without a token — it is a container probe, not an API', async () => {
+        const res = await app().request('http://localhost:6060/healthz');
+        expect(res.status).toBe(200);
+        expect(await res.json()).toMatchObject({ status: 'ok', name: 'arr-mcp' });
+    });
+});
+
+describe('bearer auth on /mcp', () => {
+    it('rejects a request with no Authorization header', async () => {
+        const res = await app().request('http://localhost:6060/mcp', { method: 'POST' });
+        expect(res.status).toBe(401);
+        expect(res.headers.get('WWW-Authenticate')).toMatch(/^Bearer/);
+    });
+
+    it('rejects a wrong token', async () => {
+        const res = await app().request(
+            'http://localhost:6060/mcp',
+            rpc(toolsList, { Authorization: `Bearer ${WRONG}` })
+        );
+        expect(res.status).toBe(401);
+    });
+
+    it('rejects a token of the wrong length without throwing', async () => {
+        const res = await app().request('http://localhost:6060/mcp', rpc(toolsList, { Authorization: 'Bearer short' }));
+        expect(res.status).toBe(401);
+    });
+
+    it('rejects a non-Bearer scheme', async () => {
+        const res = await app().request(
+            'http://localhost:6060/mcp',
+            rpc(toolsList, { Authorization: `Basic ${Buffer.from('u:p').toString('base64')}` })
+        );
+        expect(res.status).toBe(401);
+    });
+
+    it('rejects a bare token with no scheme', async () => {
+        const res = await app().request('http://localhost:6060/mcp', rpc(toolsList, { Authorization: TOKEN }));
+        expect(res.status).toBe(401);
+    });
+
+    it('does not echo the presented token back in the body', async () => {
+        const res = await app().request(
+            'http://localhost:6060/mcp',
+            rpc(toolsList, { Authorization: `Bearer ${WRONG}` })
+        );
+        expect(await res.text()).not.toContain(WRONG);
+    });
+
+    it('accepts the configured token and reaches the MCP handler', async () => {
+        const res = await app().request(
+            'http://localhost:6060/mcp',
+            rpc(toolsList, { Authorization: `Bearer ${TOKEN}` })
+        );
+
+        expect(res.status).toBe(200);
+        expect(await res.text()).toContain('stack_health');
+    });
+
+    it('guards every method on /mcp, not just POST', async () => {
+        for (const method of ['GET', 'DELETE']) {
+            const res = await app().request('http://localhost:6060/mcp', { method });
+            expect(res.status).toBe(401);
+        }
+    });
+});
+
+describe('the transport stays stateless', () => {
+    it('never issues an Mcp-Session-Id header', async () => {
+        const res = await app().request(
+            'http://localhost:6060/mcp',
+            rpc(toolsList, { Authorization: `Bearer ${TOKEN}` })
+        );
+        expect(res.headers.get('Mcp-Session-Id')).toBeNull();
+    });
+
+    it('answers a second request without any prior initialize handshake', async () => {
+        // Statelessness means each request stands alone: no session to
+        // establish, so an identical second call must succeed identically.
+        const a = app();
+        const first = await a.request('http://localhost:6060/mcp', rpc(toolsList, { Authorization: `Bearer ${TOKEN}` }));
+        const second = await a.request(
+            'http://localhost:6060/mcp',
+            rpc({ ...toolsList, id: 2 }, { Authorization: `Bearer ${TOKEN}` })
+        );
+
+        expect(first.status).toBe(200);
+        expect(second.status).toBe(200);
+        expect(await second.text()).toContain('stack_health');
+    });
+});
+
+describe('DNS rebinding protection', () => {
+    it('serves requests when no hostnames are pinned', async () => {
+        // Regression: the adapter gates its host-validation middleware on
+        // `if (allowedHosts)`, and [] is truthy — passing an empty array
+        // installs validation with an empty allow-list and 403s everything.
+        // A container that rejects 100% of traffic looks healthy until used.
+        const res = await app().request('http://192.168.1.50:6060/healthz');
+        expect(res.status).toBe(200);
+    });
+
+    it('rejects a foreign Host once hostnames are pinned', async () => {
+        const pinned = buildApp({
+            config: ConfigSchema.parse({
+                auth: { bearer_token: TOKEN, allowed_hosts: ['arr.example.com'] },
+                services: {}
+            }),
+            adapters: []
+        });
+
+        // Hono's synthetic request helper does not derive a Host header from
+        // the URL, so set it explicitly — the validator reads the header, not
+        // the URL, and treats a missing one as invalid.
+        const allowed = await pinned.request('http://arr.example.com:6060/healthz', {
+            headers: { Host: 'arr.example.com:6060' }
+        });
+        const foreign = await pinned.request('http://evil.example.com:6060/healthz', {
+            headers: { Host: 'evil.example.com:6060' }
+        });
+
+        expect(allowed.status).toBe(200); // port-agnostic match on the hostname
+        expect(foreign.status).toBe(403);
+    });
+});
+
+describe('the advertised tool surface', () => {
+    it('exposes exactly one tool in Phase 1', async () => {
+        const res = await app().request(
+            'http://localhost:6060/mcp',
+            rpc(toolsList, { Authorization: `Bearer ${TOKEN}` })
+        );
+        const body = await res.text();
+        const payload = JSON.parse(body.slice(body.indexOf('{'), body.lastIndexOf('}') + 1)) as {
+            result: { tools: { name: string }[] };
+        };
+
+        expect(payload.result.tools.map(t => t.name)).toEqual(['stack_health']);
+    });
+});

--- a/test/stackHealth.test.ts
+++ b/test/stackHealth.test.ts
@@ -1,0 +1,166 @@
+import { McpServer } from '@modelcontextprotocol/server';
+import { describe, expect, it } from 'vitest';
+import type { ArrAdapter, ConnectionDiagnosis, DiskSpace, HealthCheck, ServiceAdapter } from '../src/services/types.ts';
+import { buildStackHealth, registerStackHealth } from '../src/tools/stackHealth.ts';
+
+function fakeArr(overrides: Partial<ArrAdapter> & { diagnosis: ConnectionDiagnosis }): ArrAdapter {
+    return {
+        id: 'radarr',
+        testConnection: async () => overrides.diagnosis,
+        getVersion: async () => overrides.diagnosis.version ?? '0',
+        getDiskSpace: overrides.getDiskSpace ?? (async () => []),
+        getFailedHealthChecks: overrides.getFailedHealthChecks ?? (async () => [])
+    };
+}
+
+const healthy: ConnectionDiagnosis = { ok: true, service: 'radarr', latency_ms: 6, version: '5.14.0.9383' };
+const broken: ConnectionDiagnosis = {
+    ok: false,
+    service: 'radarr',
+    latency_ms: 3,
+    error: { kind: 'Unreachable', detail: 'connection refused at 192.168.1.20:7878' }
+};
+
+const std = { detail: 'standard', limit: 50 } as const;
+
+describe('stack_health', () => {
+    it('reports a healthy service with its version and latency', async () => {
+        const result = await buildStackHealth([fakeArr({ diagnosis: healthy })], std);
+
+        expect(result.services).toHaveLength(1);
+        expect(result.services[0]).toMatchObject({ service: 'radarr', ok: true, version: '5.14.0.9383' });
+        expect(result.degraded).toEqual([]);
+    });
+
+    it('degrades rather than failing when a service is down', async () => {
+        const result = await buildStackHealth([fakeArr({ diagnosis: broken })], std);
+
+        expect(result.degraded).toEqual(['radarr']);
+        expect(result.services[0]?.ok).toBe(false);
+        expect(result.services[0]?.error?.kind).toBe('Unreachable');
+    });
+
+    it('still returns what it gathered when one adapter throws outright', async () => {
+        const exploding: ArrAdapter = {
+            id: 'radarr',
+            testConnection: async () => {
+                throw new Error('unexpected');
+            },
+            getVersion: async () => '0',
+            getDiskSpace: async () => [],
+            getFailedHealthChecks: async () => []
+        };
+        const result = await buildStackHealth([exploding], std);
+
+        expect(result.degraded).toEqual(['radarr']);
+        expect(result.services[0]?.ok).toBe(false);
+    });
+
+    it('does not call disk or health endpoints on a service that is down', async () => {
+        let diskCalls = 0;
+        const adapter = fakeArr({
+            diagnosis: broken,
+            getDiskSpace: async () => {
+                diskCalls += 1;
+                return [];
+            }
+        });
+        await buildStackHealth([adapter], std);
+
+        expect(diskCalls).toBe(0);
+    });
+
+    it('marks a service degraded when its disk read fails even though the probe passed', async () => {
+        const adapter = fakeArr({
+            diagnosis: healthy,
+            getDiskSpace: async () => {
+                throw new Error('boom');
+            }
+        });
+        const result = await buildStackHealth([adapter], std);
+
+        expect(result.degraded).toEqual(['radarr']);
+        expect(result.services[0]?.ok).toBe(true); // the probe itself was fine
+    });
+
+    it('does not list a service twice when both follow-up reads fail', async () => {
+        const adapter = fakeArr({
+            diagnosis: healthy,
+            getDiskSpace: async () => {
+                throw new Error('boom');
+            },
+            getFailedHealthChecks: async () => {
+                throw new Error('boom');
+            }
+        });
+        const result = await buildStackHealth([adapter], std);
+
+        expect(result.degraded).toEqual(['radarr']);
+    });
+
+    it('honours the truncation contract on disks and failures', async () => {
+        const disks: DiskSpace[] = Array.from({ length: 7 }, (_, i) => ({
+            path: `/mnt/${i}`,
+            label: `d${i}`,
+            freeSpace: 1,
+            totalSpace: 2
+        }));
+        const failures: HealthCheck[] = Array.from({ length: 4 }, (_, i) => ({
+            source: `S${i}`,
+            type: 'warning',
+            message: 'm'
+        }));
+
+        const result = await buildStackHealth(
+            [
+                fakeArr({
+                    diagnosis: healthy,
+                    getDiskSpace: async () => disks,
+                    getFailedHealthChecks: async () => failures
+                })
+            ],
+            { detail: 'standard', limit: 3 }
+        );
+
+        expect(result.disks).toMatchObject({ total: 7, returned: 3, truncated: true });
+        expect(result.failures).toMatchObject({ total: 4, returned: 3, truncated: true });
+    });
+
+    it('omits disk detail at minimal but keeps the counts truthful', async () => {
+        const disks: DiskSpace[] = [{ path: '/movies', label: 'movies', freeSpace: 1, totalSpace: 2 }];
+        const result = await buildStackHealth([fakeArr({ diagnosis: healthy, getDiskSpace: async () => disks })], {
+            detail: 'minimal',
+            limit: 50
+        });
+
+        expect(result.disks.items).toEqual([]);
+        expect(result.disks.total).toBe(1);
+    });
+
+    it('returns a stable service order regardless of which adapter resolves first', async () => {
+        const slowSonarr: ServiceAdapter = {
+            id: 'sonarr',
+            getVersion: async () => '4',
+            testConnection: async () => {
+                await new Promise(r => setTimeout(r, 10));
+                return { ok: true, service: 'sonarr', latency_ms: 10 };
+            }
+        };
+        const result = await buildStackHealth([slowSonarr, fakeArr({ diagnosis: healthy })], std);
+
+        expect(result.services.map(s => s.service)).toEqual(['radarr', 'sonarr']);
+    });
+
+    it('returns an empty but well-formed result when nothing is configured', async () => {
+        const result = await buildStackHealth([], std);
+
+        expect(result.services).toEqual([]);
+        expect(result.degraded).toEqual([]);
+        expect(result.disks).toEqual({ items: [], total: 0, returned: 0, truncated: false });
+    });
+
+    it('registers without throwing', () => {
+        const server = new McpServer({ name: 'test', version: '0.0.0' });
+        expect(() => registerStackHealth(server, [])).not.toThrow();
+    });
+});


### PR DESCRIPTION
Tasks 6 and 7 of the Phase 1 plan, together — the app test asserts the real tool appears in `tools/list`, so splitting them would mean committing a stub only to delete it.

### Transport
`createMcpHandler`'s factory runs **once per request**, so every call builds a fresh `McpServer` and no session state can accumulate. Two tests pin the statelessness: no `Mcp-Session-Id` header is ever issued, and a second request succeeds with no prior initialize handshake.

### Auth
- `/healthz` open (container probe); `/mcp` requires `Bearer <token>`
- constant-time compare, with an equivalent comparison burned on a length mismatch so wrong-length is not distinguishable from wrong-bytes by timing
- guards every method, not just POST; rejects bare tokens and non-Bearer schemes; never echoes the presented token back

### `stack_health`
Degrades instead of failing: a down service yields a diagnosis and a `degraded` entry. A service whose probe fails is not hammered with follow-up reads, a service whose *disk* read fails is marked degraded while still reporting `ok: true` for the probe itself, and it is never listed twice. Output order is sorted so responses are stable and diffable.

### ⚠️ Bug worth knowing about
My first version passed `allowedHosts: config.auth.allowed_hosts` straight through. **Every request 403'd.** The adapter gates its middleware on `if (allowedHosts)` and `[]` is truthy in JS, so an empty array installs host validation with an empty allow-list — *allow nothing*, not *allow everything*. Since the container binds `0.0.0.0`, this would have rejected 100% of LAN traffic while `/healthz`… also 403'd, so it would not even have looked healthy.

Fixed by omitting the key when no hostnames are pinned. Two regression tests: requests are served with an empty list, and a foreign `Host` is rejected once hostnames *are* pinned.

96 tests total.