### PR TITLE
feat: container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+node_modules
+dist
+.git
+.github
+test
+docs
+config
+tmp-config
+coverage
+*.log
+.env
+vitest.config.ts
+eslint.config.mjs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+# syntax=docker/dockerfile:1
+
+FROM node:24-bookworm-slim AS build
+WORKDIR /app
+# better-sqlite3 compiles a native addon; unused in Phase 1 but proven here so
+# Phase 4 does not discover a broken build stage.
+RUN apt-get update && apt-get install -y --no-install-recommends python3 make g++ \
+    && rm -rf /var/lib/apt/lists/*
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY tsconfig.json tsconfig.build.json ./
+COPY src ./src
+RUN npm run build && npm prune --omit=dev
+
+FROM node:24-bookworm-slim AS runtime
+WORKDIR /app
+
+ARG ARR_MCP_VERSION=0.0.0-dev
+
+# The node image already ships a non-root `node` user at 1000:1000, which is
+# also our default PUID/PGID — reuse it rather than creating a second account
+# at the same ids (groupadd -g 1000 fails outright).
+RUN apt-get update && apt-get install -y --no-install-recommends gosu wget \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/package.json ./package.json
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+ENV NODE_ENV=production \
+    ARR_MCP_CONFIG_DIR=/config \
+    ARR_MCP_PORT=6060 \
+    ARR_MCP_VERSION=$ARR_MCP_VERSION \
+    PUID=1000 \
+    PGID=1000
+
+VOLUME ["/config"]
+EXPOSE 6060
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD wget -qO- http://localhost:6060/healthz || exit 1
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+# tsc emits under dist/src because rootDir is the repo root.
+CMD ["node", "dist/src/index.js"]

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,0 +1,20 @@
+services:
+  arr-mcp:
+    image: ghcr.io/bardesss/arr-mcp:latest
+    container_name: arr-mcp
+    ports: ['6060:6060']
+    volumes: ['./config:/config']
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Europe/Amsterdam
+    restart: unless-stopped
+    healthcheck:
+      test: ['CMD', 'wget', '-qO-', 'http://localhost:6060/healthz']
+
+# On first start, read the generated bearer token out of the log:
+#
+#   docker compose logs arr-mcp | grep 'first run'
+#
+# then add your services to ./config/config.yaml and restart. Hot-reload
+# arrives with the config UI in 0.5; until then a restart is required.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -e
+
+# linuxserver-style PUID/PGID so the /config bind mount stays writable by the
+# host user who owns it.
+PUID=${PUID:-1000}
+PGID=${PGID:-1000}
+CONFIG_DIR=${ARR_MCP_CONFIG_DIR:-/config}
+
+if [ "$(id -u)" = "0" ]; then
+    # `node` is the base image's non-root account, already at 1000:1000.
+    groupmod -o -g "$PGID" node 2>/dev/null || true
+    usermod -o -u "$PUID" node 2>/dev/null || true
+    mkdir -p "$CONFIG_DIR"
+    chown -R "$PUID:$PGID" "$CONFIG_DIR"
+    exec gosu node "$@"
+fi
+
+# Already unprivileged (e.g. `docker run --user`): run as-is.
+exec "$@"


### PR DESCRIPTION
Task 8 of the Phase 1 plan. This also makes the `docker` CI job do real work for the first time — it has been skipping since there was no Dockerfile to build.

### Verified by actually running it, not just building
- `/healthz` → `{"status":"ok","version":"0.1.0-test"}` — the `ARR_MCP_VERSION` build arg reaches the runtime stage
- unauthenticated `POST /mcp` → `401`
- PID 1 runs as **uid 1000**, not root
- `config.yaml` written `0600`, owned by that user
- `PUID=1050 PGID=1050` → PID 1 runs as 1050
- `docker inspect` reports the container **healthy**

### Two fixes found while building
1. **`groupadd -g 1000 arrmcp` fails** — `node:24-bookworm-slim` already has `node` at 1000:1000. Reusing that account is simpler and happens to match our default PUID/PGID.
2. **`docker exec … id` does not tell you what the process runs as** — it reports the exec session's user (root, since no `USER` is set). The real check is `/proc/1/status`. My plan's verification step was wrong about this; noted for the plan.

### Note for Task 9
`CMD` is `node dist/src/index.js` — `tsc` emits under `dist/src` because `rootDir` is the repo root. `tsconfig.build.json` keeps the test suite out of the image.