### PR TITLE
fix: pin the first release to 0.1.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,7 +8,8 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": false,
       "draft": false,
-      "prerelease": false
+      "prerelease": false,
+      "initial-version": "0.1.0"
     }
   }
 }


### PR DESCRIPTION
release-please opened `chore(main): release arr-mcp 1.0.0` — wrong. Spec §18 reserves 1.0.0 for the end of phase 6, once the tool surface has stopped moving; this is the 0.1 walking skeleton.

release-please defaults a first release to 1.0.0 when there is no prior tag. `bump-minor-pre-major` doesn't help — it only governs how *breaking changes* behave below 1.0. `initial-version` is the knob that sets the starting point.

Once merged, release-please should retitle its release PR to 0.1.0.