### PR TITLE
fix: publish version image tags, not just latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,11 @@ jobs:
 
       # Stable releases get X.Y.Z / X.Y / X / latest; every other push to main
       # gets `main` for bleeding edge. Nothing else (design spec §18).
+      #
+      # Feed `outputs.version` (a bare `0.1.0`) to the semver patterns, not
+      # `outputs.tag`. metadata-action parses the value as semver and silently
+      # emits nothing when it cannot — so a tag like `arr-mcp-v0.1.0` produced
+      # an image with only `latest`, with the job still green.
       - name: Compute tags
         id: meta
         uses: docker/metadata-action@v5
@@ -51,10 +56,23 @@ jobs:
           images: ghcr.io/bardesss/arr-mcp
           tags: |
             type=raw,value=main,enable=${{ needs.release-please.outputs.released != 'true' }}
-            type=semver,pattern={{version}},value=${{ needs.release-please.outputs.tag }},enable=${{ needs.release-please.outputs.released == 'true' }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ needs.release-please.outputs.tag }},enable=${{ needs.release-please.outputs.released == 'true' }}
-            type=semver,pattern={{major}},value=${{ needs.release-please.outputs.tag }},enable=${{ needs.release-please.outputs.released == 'true' }}
+            type=semver,pattern={{version}},value=${{ needs.release-please.outputs.version }},enable=${{ needs.release-please.outputs.released == 'true' }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs.release-please.outputs.version }},enable=${{ needs.release-please.outputs.released == 'true' }}
+            type=semver,pattern={{major}},value=${{ needs.release-please.outputs.version }},enable=${{ needs.release-please.outputs.released == 'true' }}
             type=raw,value=latest,enable=${{ needs.release-please.outputs.released == 'true' }}
+
+      # A release that publishes only `latest` is a silent policy violation, so
+      # fail loudly rather than discovering it after the fact.
+      - name: Assert the release produced version tags
+        if: needs.release-please.outputs.released == 'true'
+        run: |
+          tags='${{ steps.meta.outputs.tags }}'
+          echo "$tags"
+          version='${{ needs.release-please.outputs.version }}'
+          if ! echo "$tags" | grep -q ":${version}$"; then
+            echo "::error::Release ${version} computed no ${version} image tag — got: ${tags}"
+            exit 1
+          fi
 
       - name: Build and push
         id: push

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,7 +9,8 @@
       "bump-patch-for-minor-pre-major": false,
       "draft": false,
       "prerelease": false,
-      "initial-version": "0.1.0"
+      "initial-version": "0.1.0",
+      "include-component-in-tag": false
     }
   }
 }


### PR DESCRIPTION
The 0.1.0 release pushed **only `:latest`**. `:0.1.0`, `:0.1` and `:0` are missing — spec §18's tag policy — and the job was green throughout.

Verified: `docker pull ghcr.io/bardesss/arr-mcp:latest` works anonymously and reports `{"version":"0.1.0"}`; `docker pull …:0.1.0` → `not found`.

### Two causes
1. **release-please emits component-prefixed tags** when `package-name` is set, so the git tag is `arr-mcp-v0.1.0`, not `v0.1.0`. → `include-component-in-tag: false`.
2. **`metadata-action` was fed `outputs.tag`.** Its `type=semver` patterns parse the value as semver and, when parsing fails, emit *nothing* rather than erroring. → feed `outputs.version` (a bare `0.1.0`) instead, so tagging no longer depends on tag format.

### And a guard
A release that publishes only `latest` is a silent policy violation, so the job now asserts a tag matching the release version was computed and fails loudly otherwise.

### Note on 0.1.0 itself
This fixes releases going forward; it cannot retroactively tag the published 0.1.0 image. Backfilling needs a GHCR push, e.g.

```sh
docker buildx imagetools create   -t ghcr.io/bardesss/arr-mcp:0.1.0   -t ghcr.io/bardesss/arr-mcp:0.1   -t ghcr.io/bardesss/arr-mcp:0   ghcr.io/bardesss/arr-mcp:latest
```

Alternatively leave 0.1.0 as `latest`-only and let 0.2.0 be the first correctly-tagged release.