### PR TITLE
fix: drop privileges by numeric id so PUID/PGID cannot silently fail

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,109 @@
+name: Bug report
+description: Something in arr-mcp behaves incorrectly
+labels: ['bug']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting. Two fields below matter more than the rest:
+        **which versions you are running**, and **logs**.
+
+        arr-mcp talks to eight services whose APIs change independently, so a
+        report without versions usually cannot be reproduced.
+
+  - type: input
+    id: arr-mcp-version
+    attributes:
+      label: arr-mcp version
+      description: The image tag you pulled, or `git rev-parse --short HEAD` if running from source.
+      placeholder: '0.2.0'
+    validations:
+      required: true
+
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: How are you running it?
+      options:
+        - Docker image (ghcr.io/bardesss/arr-mcp)
+        - Docker Compose
+        - From source (node)
+        - Other
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: services
+    attributes:
+      label: Which services are involved?
+      description: Tick every service the failing request touches. Tick nothing if the problem is in arr-mcp itself.
+      options:
+        - label: Radarr
+        - label: Sonarr
+        - label: Prowlarr
+        - label: Bazarr
+        - label: Jellyfin
+        - label: Seerr
+        - label: SABnzbd
+        - label: Transmission
+
+  - type: input
+    id: service-versions
+    attributes:
+      label: Service version(s)
+      description: >-
+        The version of each service you ticked above. Found in that service's
+        own Settings or System page.
+      placeholder: 'Radarr 6.3.0.10514, Jellyfin 10.11.2'
+    validations:
+      required: true
+
+  - type: input
+    id: mcp-client
+    attributes:
+      label: MCP client
+      description: Which client was calling arr-mcp, and its version, if the problem involves a tool call.
+      placeholder: 'Claude Code 2.1.0'
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Include the tool you called and the arguments, if applicable.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: |
+        Relevant output from `docker logs arr-mcp`, or the terminal if running from source.
+
+        **Redact before pasting.** arr-mcp logs are JSON and normally contain no
+        secrets, but two things do appear in them:
+
+        - On **first run only**, the generated bearer token is printed so you
+          can find it (`use this bearer token for /mcp`). Anyone with that token
+          can reach your `/mcp` endpoint. Remove that line.
+        - Service URLs may include internal hostnames you would rather not
+          publish.
+
+        Never paste the contents of `config/config.yaml` — it holds the bearer
+        token and every service API key.
+      render: shell
+
+  - type: checkboxes
+    id: redaction
+    attributes:
+      label: Before submitting
+      options:
+        - label: I removed the bearer token and any API keys from the logs above.
+          required: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,26 +26,15 @@ jobs:
       - run: npm run typecheck
       - run: npm test
 
-  # Catches Dockerfile rot on every PR. Skips cleanly until the Dockerfile
-  # exists (Task 8 of the Phase 1 plan) rather than reporting a red build for
-  # a file nobody has written yet.
+  # Catches Dockerfile rot on every PR. The probe that let this job skip before
+  # a Dockerfile existed is gone: `docker` is now a required status check, so a
+  # missing Dockerfile must fail rather than skip green.
   docker:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - name: Check for a Dockerfile
-        id: probe
-        run: |
-          if [ -f Dockerfile ]; then
-            echo "present=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "present=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::No Dockerfile yet — skipping the image build."
-          fi
       - uses: docker/setup-buildx-action@v3
-        if: steps.probe.outputs.present == 'true'
       - name: Build image (no push)
-        if: steps.probe.outputs.present == 'true'
         uses: docker/build-push-action@v6
         with:
           context: .

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,12 +8,19 @@ PGID=${PGID:-1000}
 CONFIG_DIR=${ARR_MCP_CONFIG_DIR:-/config}
 
 if [ "$(id -u)" = "0" ]; then
-    # `node` is the base image's non-root account, already at 1000:1000.
-    groupmod -o -g "$PGID" node 2>/dev/null || true
-    usermod -o -u "$PUID" node 2>/dev/null || true
     mkdir -p "$CONFIG_DIR"
     chown -R "$PUID:$PGID" "$CONFIG_DIR"
-    exec gosu node "$@"
+
+    # Drop straight to the numeric ids rather than rewriting the base image's
+    # `node` account with usermod/groupmod first.
+    #
+    # Those tools live in the `passwd` package and are not guaranteed present
+    # in a slim base image. The previous version hid that behind
+    # `2>/dev/null || true`, which turned a missing binary into a container
+    # that starts and *then* cannot write its own config: chown had already
+    # applied PUID, but the process still ran as uid 1000. gosu takes uid:gid
+    # directly, needs neither tool, and cannot half-succeed.
+    exec gosu "$PUID:$PGID" "$@"
 fi
 
 # Already unprivileged (e.g. `docker run --user`): run as-is.


### PR DESCRIPTION
Three findings from auditing the shipped Phase 1 implementation against the design spec. All three are independent of Phase 2 and none touches `src/`.

## The entrypoint could silently fail to apply PUID/PGID

`docker-entrypoint.sh` rewrote the base image's `node` account with `usermod`/`groupmod` before dropping privileges, and swallowed failures with `2>/dev/null || true`. Those tools ship in the `passwd` package and are not guaranteed present in a slim base image.

On an image without them the script carried on regardless: `chown -R $PUID:$PGID /config` had already succeeded, but `gosu node` still resolved to uid 1000. The container would start and then fail to write its own config — and the cause was deliberately hidden by the `|| true`.

`exec gosu "$PUID:$PGID"` takes the ids directly. It needs neither tool and cannot half-succeed.

Not confirmed as broken on `node:24-bookworm-slim` — I have no Docker here to check whether those binaries are present. The point is that the failure mode was unobservable either way, and the fix removes the question rather than answering it.

## No issue template

Spec §18 asks for one requesting service versions, arr-mcp version and redacted logs. `0.2.0` is published, so this window is already open.

Every behaviour arr-mcp exposes varies by upstream service version — §21 alone lists seven — so a report without versions usually cannot be reproduced. The template makes arr-mcp version, deployment method and service versions required.

It also warns about something specific to this project: **on first run the generated bearer token is printed to stdout** so it can be found with `docker logs`, which is exactly what a bug reporter is asked to paste. The template calls that out and gates submission on a redaction checkbox.

## The CI Dockerfile probe is now dead scaffolding

The `docker` job probed for a Dockerfile and skipped cleanly when absent, so CI stayed green before Task 8 of the Phase 1 plan wrote one. The Dockerfile exists and `docker` is now a required status check, so the probe's only remaining effect is that deleting the Dockerfile would produce a green skip on a required check instead of a failure.

---

**Verified locally:** `npm run lint`, `npm run typecheck`, `npm test` (96 passed), `bash -n docker-entrypoint.sh`, LF line endings preserved, and all three YAML files parse.

**Not verified:** the entrypoint itself, which needs a container to exercise. CI builds the image but does not run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
