### PR TITLE
docs: bring the README up to date with 0.2 and require it every release

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ Jellyfin. arr-mcp correlates them and gives you the causal chain.
 - **Safe by default.** Deletion is off until you deliberately enable it, and
   then still asks per call.
 
-> ### Status: 0.1 walking skeleton
+> ### Status: 0.2 — walking skeleton, published
 >
-> Radarr and a single `stack_health` tool. Not yet useful — this is the
-> foundation the rest lands on. See [the roadmap](#roadmap).
+> Radarr and a single `stack_health` tool. Runnable, but not yet useful for
+> much — this is the foundation the rest lands on. **0.3 adds the remaining
+> seven services and ten read tools.** See [the roadmap](#roadmap).
 
 ## Planned services
 
@@ -25,12 +26,10 @@ Radarr · Sonarr · Prowlarr · Bazarr · Jellyfin · Seerr · SABnzbd · Transm
 
 ## Quick start
 
-Not yet — there is no published image until 0.1.0 ships. Once it does:
-
 ```yaml
 services:
   arr-mcp:
-    image: ghcr.io/bardesss/arr-mcp:latest
+    image: ghcr.io/bardesss/arr-mcp:0.2
     ports: ['6060:6060']
     volumes: ['./config:/config']
     environment:
@@ -40,23 +39,42 @@ services:
     restart: unless-stopped
 ```
 
-The bearer token for the MCP endpoint is generated on first run and printed to
-the container log. Until the config UI lands in 0.5, edit
-`config/config.yaml` by hand and **restart the container** to pick up changes.
+Tags are `X.Y.Z`, `X.Y`, `X` and `latest` for releases, plus `main` for
+bleeding edge. Pin a minor while the tool surface is still moving.
+
+On first start, `config/config.yaml` is created and **the bearer token for the
+MCP endpoint is printed to the container log** — `docker logs arr-mcp`. Add
+your services to that file:
+
+```yaml
+services:
+  radarr:
+    url: http://192.168.1.20:7878
+    api_key: "…"
+```
+
+Radarr is the only service 0.2 speaks to; the other seven land in 0.3. Until
+the config UI arrives in 0.6, edit the file by hand and **restart the
+container** to pick up changes.
 
 ## Roadmap
 
 | Version | Delivers |
 | --- | --- |
-| 0.1 | Walking skeleton: stateless MCP transport, bearer auth, Radarr, `stack_health` |
-| 0.2 | The remaining seven service adapters and 11 read tools |
-| 0.3 | Cross-service correlation: identity resolver, three-way library join, `diagnose` |
-| 0.4 | Writes: permission tiers, `dry_run`, write audit, per-call confirmation |
-| 0.5 | Web config page: dashboard, diagnosing connection tests, log streams |
-| 0.6 → 1.0 | Metadata providers, MCP resources and prompts |
+| 0.1 / 0.2 | Walking skeleton: stateless MCP transport, bearer auth, Radarr, `stack_health` |
+| 0.3 | The remaining seven service adapters and ten read tools |
+| 0.4 | Cross-service correlation: identity resolver, three-way library join, `diagnose` |
+| 0.5 | Writes: permission tiers, `dry_run`, write audit, per-call confirmation |
+| 0.6 | Web config page: dashboard, diagnosing connection tests, log streams |
+| 0.7 → 1.0 | Metadata providers, MCP resources and prompts |
 
-Each version is a self-contained, shippable slice — the goal is that 0.3 already
-answers questions no individual service can, with 0.4–0.6 making it complete.
+Each version is a self-contained, shippable slice — the goal is that 0.4 already
+answers questions no individual service can, with 0.5–0.7 making it complete.
+
+0.1 and 0.2 are the same code under two tags. Dropping the component prefix
+from the release configuration made the release tooling treat the package as
+new and re-cut it; the changelog shows the same features twice. Not two
+releases.
 
 ## Requirements
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,45 @@
+# Releasing
+
+## Mechanics
+
+Conventional Commits drive release-please, which keeps a release PR open
+against `main`. Merging that PR tags the version, publishes the GitHub release,
+and pushes multi-arch images to GHCR with an SBOM and build provenance.
+
+```
+PR merged to main  →  release-please updates its release PR
+merge release PR   →  tag vX.Y.Z + GitHub Release
+tag                →  buildx multi-arch → ghcr.io/bardesss/arr-mcp
+                   →  SBOM + provenance attestation
+```
+
+Image tags are `X.Y.Z`, `X.Y`, `X` and `latest` for releases, plus `main` for
+bleeding edge. Nothing else. The release workflow fails the job when a release
+computes no version tag — a release that publishes only `latest` is a silent
+policy violation, and it has happened once.
+
+## Every release updates the README
+
+**This is not optional and it is not a follow-up.** The README is the only
+thing most people read, and a stale one is worse than none: it told users there
+was no published image for two releases after there was.
+
+Before merging the release PR, check every one of these and fix what has
+drifted:
+
+- [ ] **Status callout** — names the version being cut and describes what it
+      actually does, not what the previous one did
+- [ ] **Quick start** — the pinned image tag exists, and the instructions work
+      start to finish for someone who has never run it
+- [ ] **Roadmap table** — versions match reality, including any that shifted
+- [ ] **Tool list** — every tool the release exposes, and nothing it does not
+- [ ] **Forward references** — "lands in 0.x" claims still point at the right
+      version
+
+A phase that ships without its README change is not finished.
+
+## Verify before announcing
+
+- [ ] `docker run` the published tag against a real stack, not just the build
+- [ ] An MCP client lists the expected tool count and calls one successfully
+- [ ] `/healthz` responds, and an unauthenticated `/mcp` request is rejected


### PR DESCRIPTION
The README was not just stale — it was wrong in the place that costs most.

**Quick start said "there is no published image until 0.1.0 ships"** while `0.1.0`, `0.2.0`, `0.2`, `0`, `latest` and `main` were all sitting on GHCR. Anyone arriving from a listing would have concluded the project wasn't usable yet and left.

## Fixed

| Was | Now |
| --- | --- |
| Status callout: "0.1 walking skeleton" | Names 0.2 and describes what it actually does |
| "no published image until 0.1.0 ships" | A working Quick start with a pinned tag and the tag policy |
| "edit `config/config.yaml` by hand" with no schema | A `config.yaml` snippet, so the instruction is actionable |
| Roadmap 0.1→0.6, off by one | Remapped 0.1/0.2 → 0.7, with a note on why two releases share a changelog |
| "config UI lands in 0.5" | 0.6, after the remap |

The roadmap was off by one because `0.2.0` was cut from Phase 1's code — dropping the component prefix from `release-please-config.json` made release-please treat the package as new and re-emit the whole changelog. Rather than leave two releases looking like two features, the README now says plainly that they are the same code.

## Why `RELEASING.md`

This drift lasted two releases because nothing structural caught it. The new file makes the README check a required step of cutting a release, with the specific things that rot — status callout, quick start, roadmap, tool list, forward references — enumerated rather than left to memory.

It also records the release mechanics and the tag policy, including the assertion step that fails a release publishing only `latest`.

## Verified

`npm run lint`, `npm test` (96 passed), and every version reference in the README re-checked against the remapped roadmap.

No `src/` changes — `docs:` so release-please will not cut a release for this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
