### PR TITLE
fix: remove the byte order mark that broke release-please

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "name": "arr-mcp",
   "version": "0.2.1",
   "private": true,

--- a/test/encoding.test.ts
+++ b/test/encoding.test.ts
@@ -1,0 +1,61 @@
+import { readFile, readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = join(import.meta.dirname, '..');
+
+/**
+ * A UTF-8 byte order mark. Node strips it when `require`-ing JSON, and npm and
+ * tsc tolerate it — but `JSON.parse` does not, and release-please parses
+ * package.json that way. So a BOM here fails the *release*, days after it
+ * passes lint, tests and the Docker build.
+ *
+ * That is exactly what happened: PowerShell's `Set-Content -Encoding UTF8`
+ * writes a BOM on Windows, one edit to package.json broke releases, and every
+ * other gate stayed green. This test is the gate that would have caught it.
+ */
+const BOM = '﻿';
+
+/** Root-level JSON is what the toolchain reads: npm, tsc, release-please. */
+async function rootJsonFiles(): Promise<string[]> {
+    const entries = await readdir(ROOT, { withFileTypes: true });
+    return entries
+        .filter(e => e.isFile() && e.name.endsWith('.json'))
+        .map(e => e.name)
+        .sort();
+}
+
+/**
+ * `tsconfig*.json` is JSONC — it carries `//` comments on purpose, and tsc
+ * parses it that way. Only these are read by strict `JSON.parse` consumers,
+ * so only these have to survive it.
+ */
+const isStrictJson = (name: string) => !name.startsWith('tsconfig');
+
+describe('repository JSON encoding', () => {
+    it('finds the config files it is supposed to be guarding', async () => {
+        const files = await rootJsonFiles();
+        expect(files).toContain('package.json');
+        expect(files).toContain('release-please-config.json');
+        expect(files).toContain('.release-please-manifest.json');
+    });
+
+    it('has no byte order mark in any root JSON file', async () => {
+        const offenders: string[] = [];
+        for (const name of await rootJsonFiles()) {
+            const raw = await readFile(join(ROOT, name), 'utf8');
+            if (raw.startsWith(BOM)) offenders.push(name);
+        }
+        expect(offenders).toEqual([]);
+    });
+
+    it('parses strict-JSON config files the way release-please does', async () => {
+        const files = (await rootJsonFiles()).filter(isStrictJson);
+        expect(files.length).toBeGreaterThan(0);
+
+        for (const name of files) {
+            const raw = await readFile(join(ROOT, name), 'utf8');
+            expect(() => JSON.parse(raw) as unknown, `${name} is not valid JSON`).not.toThrow();
+        }
+    });
+});


### PR DESCRIPTION
The release job on `main` failed with:

```
release-please failed: Unexpected token '﻿', "﻿{ "name"... is not valid JSON
```

`package.json` had a **UTF-8 byte order mark**. I introduced it when adding the `capture` script — PowerShell's `Set-Content -Encoding UTF8` writes a BOM on Windows PowerShell.

## Why every other gate stayed green

Node strips a BOM when `require`-ing JSON, and npm and tsc tolerate it. Lint, typecheck, 176 tests and the Docker build all passed. release-please uses `JSON.parse`, which does not tolerate it — so the failure surfaced only at release time, on `main`, after the code had already merged.

That is the worst shape a defect can have: green everywhere the author looks, red in the one place nobody watches until it matters.

## The guard

`test/encoding.test.ts` checks every root JSON file for a BOM, and parses the strict-JSON ones the way release-please does. I verified it by reintroducing the BOM — two tests fail, and pass again once it's gone.

The parse check deliberately skips `tsconfig*.json`: that is JSONC and carries `//` comments on purpose. The first draft of this test flattened that distinction and failed against our own tsconfig, which is how I found it.

## Verified

`lint`, `typecheck`, `test` — **179 passed**, up from 176 — and `JSON.parse` against `package.json` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
