### PR TITLE
fix: classify the connect failures a wrong LAN address actually produces

### DIFF
--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -97,7 +97,12 @@ const TLS_CODES = new Set([
 ]);
 
 export function classifyFetchError(err: unknown, service: ServiceId, url: string): ServiceError {
-    const e = (err ?? {}) as { name?: string; code?: string; message?: string; cause?: { code?: string } };
+    const e = (err ?? {}) as {
+        name?: string;
+        code?: string;
+        message?: string;
+        cause?: { code?: string; message?: string };
+    };
     // undici wraps the OS-level failure one level down as `cause`.
     const code = e.code ?? e.cause?.code;
     const host = safeHost(url);
@@ -126,5 +131,32 @@ export function classifyFetchError(err: unknown, service: ServiceId, url: string
             cause: err
         });
     }
-    return new ServiceError('Unreachable', service, `${e.message ?? 'unknown error'} at ${host}`, { cause: err });
+    // Windows reports a firewall-blocked outbound connection as EACCES on
+    // connect, which reads nothing like a permission problem to the user.
+    if (code === 'EACCES' || code === 'EPERM') {
+        return new ServiceError('Unreachable', service, `connection blocked at ${host}`, {
+            remedy: 'Something refused to let the connection out — usually a local firewall. Check the host can reach that address and port.',
+            cause: err
+        });
+    }
+    if (code === 'EHOSTUNREACH' || code === 'ENETUNREACH') {
+        return new ServiceError('Unreachable', service, `no route to ${host}`, {
+            remedy: 'That address is not reachable from this machine. Check the IP is right and on a network this host can see.',
+            cause: err
+        });
+    }
+    if (code === 'ETIMEDOUT') {
+        // Deliberately Unreachable rather than Timeout: Timeout makes reads
+        // retry once, and a connect that timed out against a dead address will
+        // simply time out again, doubling the wait for no new information.
+        return new ServiceError('Unreachable', service, `connection to ${host} timed out`, {
+            remedy: 'Nothing answered at that address. Check the IP and port, and that a firewall is not dropping the packets.',
+            cause: err
+        });
+    }
+
+    // undici's own message is always the useless "fetch failed"; the cause
+    // carries the one that says what actually happened.
+    const detail = e.cause?.message ?? e.message ?? 'unknown error';
+    return new ServiceError('Unreachable', service, `${detail} at ${host}`, { cause: err });
 }

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -84,6 +84,41 @@ describe('classifyFetchError', () => {
         expect(classifyFetchError(e, 'radarr', 'http://h:7878').kind).toBe('Timeout');
     });
 
+    it('maps a firewall-blocked connection to a remedy that names the firewall', () => {
+        // Windows reports this as EACCES on connect, which reads like a
+        // permission problem and sends people looking in the wrong place.
+        const e = Object.assign(new TypeError('fetch failed'), {
+            cause: { code: 'EACCES', message: 'connect EACCES 192.168.1.20:7878' }
+        });
+        const out = classifyFetchError(e, 'radarr', 'http://192.168.1.20:7878');
+
+        expect(out.kind).toBe('Unreachable');
+        expect(out.remedy).toMatch(/firewall/i);
+    });
+
+    it('maps an unroutable address to Unreachable with a routing remedy', () => {
+        const e = Object.assign(new TypeError('fetch failed'), { cause: { code: 'EHOSTUNREACH' } });
+        const out = classifyFetchError(e, 'radarr', 'http://10.9.9.9:7878');
+
+        expect(out.kind).toBe('Unreachable');
+        expect(out.remedy).toMatch(/not reachable|network/i);
+    });
+
+    it('maps a connect timeout to Unreachable, not Timeout, so reads do not retry a dead address', () => {
+        const e = Object.assign(new TypeError('fetch failed'), { cause: { code: 'ETIMEDOUT' } });
+        expect(classifyFetchError(e, 'radarr', 'http://10.9.9.9:7878').kind).toBe('Unreachable');
+    });
+
+    it('surfaces the underlying cause rather than undici’s opaque "fetch failed"', () => {
+        const e = Object.assign(new TypeError('fetch failed'), {
+            cause: { code: 'ESOMETHINGNEW', message: 'connect ESOMETHINGNEW 192.168.1.20:7878' }
+        });
+        const out = classifyFetchError(e, 'radarr', 'http://192.168.1.20:7878');
+
+        expect(out.detail).toContain('ESOMETHINGNEW');
+        expect(out.detail).not.toBe('fetch failed at 192.168.1.20:7878');
+    });
+
     it('maps a TLS certificate failure to Unreachable with a TLS remedy', () => {
         const e = Object.assign(new Error('self-signed'), { code: 'DEPTH_ZERO_SELF_SIGNED_CERT' });
         expect(classifyFetchError(e, 'radarr', 'https://h:7878').remedy).toMatch(/certificate/i);


### PR DESCRIPTION
Found by running the real capture against a stale LAN address. Twenty-two endpoints failed with the same useless line:

```
radarr unreachable: fetch failed at 192.168.1.20:7878
```

"fetch failed" is undici's top-level message. It is the same string for every connect failure there is, and it tells the user nothing about which one they have. Design spec §15 requires errors to reach the model as structured, actionable text — this was neither.

## What was actually wrong

The cause carried `code: 'EACCES'`, `message: 'connect EACCES 192.168.1.20:7878'`. That is how **Windows reports a firewall-blocked outbound connection**, and unclassified it reads like a permissions problem — which sends whoever is debugging it to entirely the wrong place.

## Changes

Five connect-level codes now classify, each with a remedy naming what to check:

| Code | Detail | Remedy points at |
| --- | --- | --- |
| `EACCES` / `EPERM` | connection blocked | a local firewall |
| `EHOSTUNREACH` / `ENETUNREACH` | no route | wrong IP, or a network this host cannot see |
| `ETIMEDOUT` | connection timed out | address, port, packets being dropped |

`ETIMEDOUT` maps to **`Unreachable`, not `Timeout`**, deliberately. `Timeout` makes reads retry once, and a connect that timed out against a dead address will time out again — doubling the wait for no new information.

And the fallback now prefers `cause.message` over the top-level message, so even an unrecognised code says what actually happened rather than "fetch failed".

The same misconfiguration now reads:

```
radarr unreachable: connection blocked at 192.168.1.20:7878 — Something refused to
let the connection out — usually a local firewall. Check the host can reach that
address and port.
```

## Incidental

The failure also exercised the circuit breaker against a genuinely dead service for the first time: Prowlarr's opened after five consecutive failures, exactly as §15 specifies, and the remaining endpoint was skipped without a network call.

## Verified

`lint`, `typecheck`, `test` — **183 passed**, up from 179. Four new cases, including one asserting the fallback never returns bare `fetch failed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
