### PR TITLE
feat: complete Phase 2a — seven adapters, registry, stack_health across eight services

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,20 +52,43 @@ before it adds one.
 
 ## Adding a service adapter
 
-The highest-value contribution, and deliberately self-contained. The contract
-lives in [`src/services/types.ts`](src/services/types.ts) and
-[`src/services/radarr.ts`](src/services/radarr.ts) is the reference
-implementation — read those two files and you have everything you need.
+The highest-value contribution, and deliberately self-contained. Six steps,
+each with a worked example already in the tree.
+
+1. **Add the service id** to `ServiceIdSchema` in `src/config/schema.ts`, and a
+   schema for it in `ServicesSchema`. Reuse `KeyedServiceSchema` unless the
+   service authenticates differently.
+2. **Pick or write an auth strategy** in `src/core/auth.ts`. The five existing
+   shapes cover most services; write a new one only if the service does
+   something genuinely different, as Transmission's session handshake does.
+3. **Add its endpoints** to `ENDPOINTS` in `scripts/capture-fixtures.ts` and run
+   `npm run capture` against a live instance. Review the diff.
+4. **Write the adapter** in `src/services/<id>.ts`, implementing `ServiceAdapter`
+   plus whichever capability interfaces the service actually supports.
+   `src/services/sonarr.ts` is the simplest example; `src/services/transmission.ts`
+   is the most unusual.
+5. **Declare its contract** in `test/contract.test.ts` — the response fields your
+   adapter reads. Omit the `spec` when the service publishes no OpenAPI document.
+6. **Register it** in `src/services/registry.ts`.
 
 An adapter must:
 
-- implement `ServiceAdapter` (`id`, `testConnection`, `getVersion`)
-- return a `ConnectionDiagnosis` from `testConnection`, **never a boolean** — it
-  distinguishes DNS failure, connection refused, TLS error, 401, 404 and
-  version-too-old, and states the remedy
-- map every failure onto the error taxonomy in `src/core/errors.ts`
+- return a `ConnectionDiagnosis` from `testConnection`, **never a boolean** and
+  **never a thrown error** — use `diagnoseConnection`, which every adapter shares
 - accept an injectable `fetch` so it is testable without the service
-- ship recorded fixtures covering success and each error mode
+- **not implement a capability it has no fixture for.** Prowlarr is not
+  `DiskSpaceCapable` because its diskspace endpoint 404s. A method nothing has
+  tested is a method `stack_health` will call in production
+
+Transport concerns — timeouts, retries, the circuit breaker, error
+classification — belong to `ServiceHttp` and must not be reimplemented in an
+adapter. If a service needs behaviour `ServiceHttp` does not have, that is a
+change to `ServiceHttp`, so every service gets it.
+
+**Match on stable identifiers, not on display strings.** Both scan-state
+implementations learned this the hard way: Radarr runs three tasks whose names
+contain "Refresh", only one of which is the library scan, and Jellyfin's task
+names are localised — a Dutch server returns "Mediabibliotheek scannen".
 
 Three of the eight services publish no usable OpenAPI spec, so the adapter
 interface is defined by us and must stay hand-writable. Code generation is an

--- a/README.md
+++ b/README.md
@@ -14,22 +14,25 @@ Jellyfin. arr-mcp correlates them and gives you the causal chain.
 - **Safe by default.** Deletion is off until you deliberately enable it, and
   then still asks per call.
 
-> ### Status: 0.2 — walking skeleton, published
+> ### Status: 0.3 — all eight services
 >
-> Radarr and a single `stack_health` tool. Runnable, but not yet useful for
-> much — this is the foundation the rest lands on. **0.3 adds the remaining
-> seven services and ten read tools.** See [the roadmap](#roadmap).
+> Every service reachable, with `stack_health` reporting versions, disk space,
+> failing checks and library scan staleness across the whole stack. The read
+> tools that answer questions about your library land in the same release; the
+> cross-service `diagnose` arrives in 0.4. See [the roadmap](#roadmap).
 
-## Planned services
+## Services
 
 Radarr · Sonarr · Prowlarr · Bazarr · Jellyfin · Seerr · SABnzbd · Transmission
+
+All eight are supported as of 0.3.
 
 ## Quick start
 
 ```yaml
 services:
   arr-mcp:
-    image: ghcr.io/bardesss/arr-mcp:0.2
+    image: ghcr.io/bardesss/arr-mcp:0.3
     ports: ['6060:6060']
     volumes: ['./config:/config']
     environment:
@@ -51,10 +54,24 @@ services:
   radarr:
     url: http://192.168.1.20:7878
     api_key: "…"
+  jellyfin:
+    url: http://192.168.1.20:8096
+    api_key: "…"
+    default_user: "you"      # whose watched state `watched` means
+  transmission:
+    url: http://192.168.1.20:9091
+    username: "…"            # Transmission has no API key
+    password: "…"
 ```
 
-Radarr is the only service 0.2 speaks to; the other seven land in 0.3. Until
-the config UI arrives in 0.6, edit the file by hand and **restart the
+All eight are supported: `radarr`, `sonarr`, `prowlarr`, `bazarr`, `jellyfin`,
+`seerr`, `sabnzbd`, `transmission`. Configure only what you run — anything you
+leave out is simply absent, not broken.
+
+A misspelled key, an unknown service, or an `api_key` on Transmission fails at
+startup with the offending field named, rather than being silently ignored.
+
+Until the config UI arrives in 0.6, edit the file by hand and **restart the
 container** to pick up changes.
 
 ## Roadmap

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -43,3 +43,22 @@ A phase that ships without its README change is not finished.
 - [ ] `docker run` the published tag against a real stack, not just the build
 - [ ] An MCP client lists the expected tool count and calls one successfully
 - [ ] `/healthz` responds, and an unauthenticated `/mcp` request is rejected
+
+## Distribution
+
+Do this at **0.3 and later**, not for 0.1 or 0.2 — those are foundations, and
+an announcement lands once.
+
+- [ ] [MCP registry](https://github.com/modelcontextprotocol/registry) listing
+- [ ] Unraid Community Applications template
+- [ ] Umbrel app store submission
+- [ ] CasaOS app store submission
+- [ ] r/selfhosted post — lead with the differentiator, not the feature list:
+      one server for the whole stack, a config page that diagnoses instead of
+      printing pass/fail, and tool output treated as untrusted data
+- [ ] Link the release in the README's status callout
+
+Lead every listing with what no comparable project does. Fourteen of them
+exist; none ships a config UI and none addresses untrusted tool content.
+Discovery, not capability, is the binding constraint here — the unmaintained
+project this one succeeds still leads the field on stars.

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,7 @@ import { serve } from '@hono/node-server';
 import { buildApp } from './app.ts';
 import { loadConfig } from './config/load.ts';
 import { logger } from './core/logger.ts';
-import { RadarrAdapter } from './services/radarr.ts';
-import type { ServiceAdapter } from './services/types.ts';
+import { buildAdapters } from './services/registry.ts';
 
 const CONFIG_DIR = process.env.ARR_MCP_CONFIG_DIR ?? '/config';
 const PORT = Number(process.env.ARR_MCP_PORT ?? 6060);
@@ -16,10 +15,7 @@ if (created) {
     logger.info({ token: config.auth.bearer_token }, 'first run — use this bearer token for /mcp');
 }
 
-const adapters: ServiceAdapter[] = [];
-if (config.services.radarr) {
-    adapters.push(new RadarrAdapter(config.services.radarr));
-}
+const adapters = buildAdapters(config);
 
 if (adapters.length === 0) {
     logger.warn(

--- a/src/services/bazarr.ts
+++ b/src/services/bazarr.ts
@@ -1,0 +1,63 @@
+import type { KeyedServiceConfig, ServiceId } from '../config/schema.ts';
+import { apiKeyHeader } from '../core/auth.ts';
+import { ServiceError } from '../core/errors.ts';
+import { ServiceHttp } from '../core/http.ts';
+import {
+    diagnoseConnection,
+    type ConnectionDiagnosis,
+    type HealthCheck,
+    type HealthCheckCapable,
+    type ServiceAdapter
+} from './types.ts';
+
+/**
+ * Hand-written: Bazarr publishes no OpenAPI document (design spec §21.1), so
+ * these shapes come from recorded fixtures and the contract test checks them
+ * against those fixtures rather than against a spec.
+ *
+ * Confirmed against a live Bazarr 1.6.0: every payload is wrapped in
+ * `{ data: … }`, and the version field is `bazarr_version`.
+ */
+type Envelope<T> = { data?: T };
+type RawStatus = { bazarr_version?: string };
+type RawHealth = { object?: string; issue?: string };
+
+export class BazarrAdapter implements ServiceAdapter, HealthCheckCapable {
+    readonly id: ServiceId = 'bazarr';
+    readonly #http: ServiceHttp;
+
+    constructor(config: KeyedServiceConfig, fetchImpl: typeof fetch = fetch) {
+        // Bazarr spells the header X-API-KEY, not X-Api-Key. Header names are
+        // case-insensitive per RFC 9110, so this is cosmetic — but it matches
+        // Bazarr's own documentation, which is what a reader will compare to.
+        this.#http = new ServiceHttp('bazarr', config, apiKeyHeader('X-API-KEY', config.api_key), fetchImpl);
+    }
+
+    async getVersion(): Promise<string> {
+        const body = await this.#http.get<Envelope<RawStatus>>('/api/system/status');
+        const version = body.data?.bazarr_version;
+        if (!version) {
+            throw new ServiceError('UpstreamError', this.id, 'system/status returned no version field');
+        }
+        return version;
+    }
+
+    /**
+     * Bazarr reports problems rather than a pass/fail per check, so every row
+     * returned is a failure. There is no `ok` type to filter out, and the
+     * shared HealthCheck shape wants one — `warning` is the honest mapping.
+     */
+    async getFailedHealthChecks(): Promise<HealthCheck[]> {
+        const body = await this.#http.get<Envelope<RawHealth[]>>('/api/system/health');
+        return (body.data ?? []).map(row => ({
+            service: this.id,
+            source: row.object ?? 'bazarr',
+            type: 'warning',
+            message: row.issue ?? ''
+        }));
+    }
+
+    async testConnection(): Promise<ConnectionDiagnosis> {
+        return diagnoseConnection(this.id, () => this.getVersion());
+    }
+}

--- a/src/services/jellyfin.ts
+++ b/src/services/jellyfin.ts
@@ -1,0 +1,84 @@
+import type { MultiUserServiceConfig, ServiceId } from '../config/schema.ts';
+import { embyToken } from '../core/auth.ts';
+import { ServiceError } from '../core/errors.ts';
+import { ServiceHttp } from '../core/http.ts';
+import {
+    diagnoseConnection,
+    type ConnectionDiagnosis,
+    type ScanState,
+    type ScanStateCapable,
+    type ServiceAdapter,
+    type ServiceUser,
+    type UserDirectoryCapable
+} from './types.ts';
+
+/**
+ * Jellyfin's generated types are a megabyte of declarations and its PascalCase
+ * field names are stable across releases, so these three narrow shapes are
+ * declared locally. The contract test checks them against the vendored spec,
+ * which is where that checking belongs.
+ */
+type RawSystemInfo = { Version?: string; ServerName?: string; Id?: string };
+type RawUser = { Id?: string; Name?: string };
+type RawTask = {
+    Key?: string;
+    Name?: string;
+    State?: string;
+    LastExecutionResult?: { EndTimeUtc?: string; Status?: string };
+};
+
+/**
+ * The task Jellyfin runs to scan libraries, confirmed against a live 10.11.11.
+ *
+ * Keyed on `Key`, never on `Name`, for two independent reasons. A live server
+ * exposes eight library-ish keys including `LanguageTagsSetsRefreshLibraryTask`
+ * and `TraktSyncLibraryTask`, so a pattern would match the wrong one — and
+ * `Name` is **localised to the server language**. The instance this was
+ * captured from returns "Mediabibliotheek scannen".
+ */
+const LIBRARY_SCAN_KEY = 'RefreshLibrary';
+
+export class JellyfinAdapter implements ServiceAdapter, ScanStateCapable, UserDirectoryCapable {
+    readonly id: ServiceId = 'jellyfin';
+    readonly #http: ServiceHttp;
+
+    constructor(config: MultiUserServiceConfig, fetchImpl: typeof fetch = fetch) {
+        this.#http = new ServiceHttp('jellyfin', config, embyToken(config.api_key), fetchImpl);
+    }
+
+    async getVersion(): Promise<string> {
+        const info = await this.#http.get<RawSystemInfo>('/System/Info');
+        if (!info.Version) {
+            throw new ServiceError('UpstreamError', this.id, 'System/Info returned no version field');
+        }
+        return info.Version;
+    }
+
+    /**
+     * Jellyfin identifies users by GUID while config names them by username, so
+     * every per-user call resolves through this list. Typing a username by hand
+     * is a guaranteed source of silent mismatches (design spec §14), which is
+     * why the resolver reports the available names on a miss.
+     */
+    async listUsers(): Promise<ServiceUser[]> {
+        const users = await this.#http.get<RawUser[]>('/Users');
+        return users
+            .filter((u): u is { Id: string; Name: string } => typeof u.Id === 'string' && typeof u.Name === 'string')
+            .map(u => ({ id: u.Id, name: u.Name }));
+    }
+
+    async getScanState(): Promise<ScanState> {
+        const tasks = await this.#http.get<RawTask[]>('/ScheduledTasks');
+        const scan = tasks.find(t => t.Key === LIBRARY_SCAN_KEY);
+        const lastCompleted = scan?.LastExecutionResult?.EndTimeUtc;
+        return {
+            service: this.id,
+            running: scan?.State === 'Running',
+            ...(typeof lastCompleted === 'string' ? { lastCompleted } : {})
+        };
+    }
+
+    async testConnection(): Promise<ConnectionDiagnosis> {
+        return diagnoseConnection(this.id, () => this.getVersion());
+    }
+}

--- a/src/services/prowlarr.ts
+++ b/src/services/prowlarr.ts
@@ -1,0 +1,57 @@
+import type { KeyedServiceConfig, ServiceId } from '../config/schema.ts';
+import { apiKeyHeader } from '../core/auth.ts';
+import { ServiceError } from '../core/errors.ts';
+import { ServiceHttp } from '../core/http.ts';
+import type { components } from './generated/prowlarr.ts';
+import {
+    diagnoseConnection,
+    type ConnectionDiagnosis,
+    type HealthCheck,
+    type HealthCheckCapable,
+    type ServiceAdapter
+} from './types.ts';
+
+type RawStatus = components['schemas']['SystemResource'];
+type RawHealthCheck = components['schemas']['HealthResource'];
+
+/**
+ * Prowlarr manages indexers, not files, and exposes no diskspace endpoint —
+ * `/api/v1/diskspace` returns 404, confirmed against a live instance during the
+ * Phase 2a capture run. It is therefore deliberately not `DiskSpaceCapable`:
+ * a method with no fixture is a method stack_health would call and nothing
+ * would have tested.
+ *
+ * It is also API v1, not v3 — Prowlarr never had a v3 like its siblings.
+ */
+export class ProwlarrAdapter implements ServiceAdapter, HealthCheckCapable {
+    readonly id: ServiceId = 'prowlarr';
+    readonly #http: ServiceHttp;
+
+    constructor(config: KeyedServiceConfig, fetchImpl: typeof fetch = fetch) {
+        this.#http = new ServiceHttp('prowlarr', config, apiKeyHeader('X-Api-Key', config.api_key), fetchImpl);
+    }
+
+    async getVersion(): Promise<string> {
+        const status = await this.#http.get<RawStatus>('/api/v1/system/status');
+        if (!status.version) {
+            throw new ServiceError('UpstreamError', this.id, 'system/status returned no version field');
+        }
+        return status.version;
+    }
+
+    async getFailedHealthChecks(): Promise<HealthCheck[]> {
+        const all = await this.#http.get<RawHealthCheck[]>('/api/v1/health');
+        return all
+            .filter(c => c.type !== 'ok')
+            .map(c => ({
+                service: this.id,
+                source: c.source ?? 'unknown',
+                type: String(c.type ?? 'warning'),
+                message: c.message ?? ''
+            }));
+    }
+
+    async testConnection(): Promise<ConnectionDiagnosis> {
+        return diagnoseConnection(this.id, () => this.getVersion());
+    }
+}

--- a/src/services/registry.ts
+++ b/src/services/registry.ts
@@ -1,0 +1,32 @@
+import type { Config } from '../config/schema.ts';
+import { BazarrAdapter } from './bazarr.ts';
+import { JellyfinAdapter } from './jellyfin.ts';
+import { ProwlarrAdapter } from './prowlarr.ts';
+import { RadarrAdapter } from './radarr.ts';
+import { SabnzbdAdapter } from './sabnzbd.ts';
+import { SeerrAdapter } from './seerr.ts';
+import { SonarrAdapter } from './sonarr.ts';
+import { TransmissionAdapter } from './transmission.ts';
+import type { ServiceAdapter } from './types.ts';
+
+/**
+ * The one place that knows which config key builds which adapter.
+ *
+ * Alphabetical order makes stack_health's output stable across restarts and
+ * diffable in tests, which matters more than any other ordering would.
+ */
+export function buildAdapters(config: Config): ServiceAdapter[] {
+    const s = config.services;
+    const adapters: ServiceAdapter[] = [];
+
+    if (s.bazarr) adapters.push(new BazarrAdapter(s.bazarr));
+    if (s.jellyfin) adapters.push(new JellyfinAdapter(s.jellyfin));
+    if (s.prowlarr) adapters.push(new ProwlarrAdapter(s.prowlarr));
+    if (s.radarr) adapters.push(new RadarrAdapter(s.radarr));
+    if (s.sabnzbd) adapters.push(new SabnzbdAdapter(s.sabnzbd));
+    if (s.seerr) adapters.push(new SeerrAdapter(s.seerr));
+    if (s.sonarr) adapters.push(new SonarrAdapter(s.sonarr));
+    if (s.transmission) adapters.push(new TransmissionAdapter(s.transmission));
+
+    return adapters;
+}

--- a/src/services/sabnzbd.ts
+++ b/src/services/sabnzbd.ts
@@ -1,0 +1,92 @@
+import type { KeyedServiceConfig, ServiceId } from '../config/schema.ts';
+import { queryParamKey } from '../core/auth.ts';
+import { ServiceError } from '../core/errors.ts';
+import { ServiceHttp } from '../core/http.ts';
+import {
+    diagnoseConnection,
+    type ConnectionDiagnosis,
+    type DiskSpace,
+    type DiskSpaceCapable,
+    type ServiceAdapter
+} from './types.ts';
+
+/**
+ * Hand-written: SABnzbd's API is query-parameter driven and publishes no
+ * OpenAPI document. The key travels in the URL, which is why ServiceHttp never
+ * puts a full URL into an error message.
+ */
+type RawVersion = { version?: string };
+type RawQueue = {
+    queue?: {
+        diskspace1?: string;
+        diskspacetotal1?: string;
+        diskspace2?: string;
+        diskspacetotal2?: string;
+        status?: string;
+    };
+};
+
+const BYTES_PER_GB = 1024 ** 3;
+
+/**
+ * SABnzbd reports disk space as gigabytes in a string — confirmed against a
+ * live 5.0.4, which returned `"4711.95"`. A silent NaN here would surface as
+ * "0 bytes free" in stack_health, which reads as a crisis rather than a bug.
+ */
+const gigabytesToBytes = (value: string | undefined): number | undefined => {
+    if (value === undefined) return undefined;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? Math.round(parsed * BYTES_PER_GB) : undefined;
+};
+
+export class SabnzbdAdapter implements ServiceAdapter, DiskSpaceCapable {
+    readonly id: ServiceId = 'sabnzbd';
+    readonly #http: ServiceHttp;
+
+    constructor(config: KeyedServiceConfig, fetchImpl: typeof fetch = fetch) {
+        this.#http = new ServiceHttp('sabnzbd', config, queryParamKey('apikey', config.api_key), fetchImpl);
+    }
+
+    async getVersion(): Promise<string> {
+        const body = await this.#http.get<RawVersion>('/api?mode=version&output=json');
+        if (!body.version) {
+            throw new ServiceError('UpstreamError', this.id, 'mode=version returned no version field');
+        }
+        return body.version;
+    }
+
+    /**
+     * SABnzbd reports up to two download volumes. Both are surfaced, because a
+     * stack with an incomplete and a complete directory on different disks can
+     * run out of space on either.
+     */
+    async getDiskSpace(): Promise<DiskSpace[]> {
+        const body = await this.#http.get<RawQueue>('/api?mode=queue&output=json');
+        // `string | undefined` rather than optional: exactOptionalPropertyTypes
+        // treats "absent" and "present but undefined" as different types, and
+        // these fields are always present here, sometimes holding undefined.
+        const volumes: { label: string; free: string | undefined; total: string | undefined }[] = [
+            { label: 'SABnzbd download', free: body.queue?.diskspace1, total: body.queue?.diskspacetotal1 },
+            { label: 'SABnzbd secondary', free: body.queue?.diskspace2, total: body.queue?.diskspacetotal2 }
+        ];
+
+        return volumes.flatMap(({ label, free, total }) => {
+            const freeBytes = gigabytesToBytes(free);
+            if (freeBytes === undefined) return [];
+            const totalBytes = gigabytesToBytes(total);
+            return [
+                {
+                    service: this.id,
+                    path: label,
+                    label,
+                    freeSpace: freeBytes,
+                    ...(totalBytes === undefined ? {} : { totalSpace: totalBytes })
+                }
+            ];
+        });
+    }
+
+    async testConnection(): Promise<ConnectionDiagnosis> {
+        return diagnoseConnection(this.id, () => this.getVersion());
+    }
+}

--- a/src/services/seerr.ts
+++ b/src/services/seerr.ts
@@ -1,0 +1,51 @@
+import type { MultiUserServiceConfig, ServiceId } from '../config/schema.ts';
+import { apiKeyHeader } from '../core/auth.ts';
+import { ServiceError } from '../core/errors.ts';
+import { ServiceHttp } from '../core/http.ts';
+import {
+    diagnoseConnection,
+    type ConnectionDiagnosis,
+    type ServiceAdapter,
+    type ServiceUser,
+    type UserDirectoryCapable
+} from './types.ts';
+
+type RawStatus = { version?: string; commitTag?: string };
+type RawUser = { id?: number; displayName?: string; username?: string; email?: string };
+type RawUserPage = { results?: RawUser[] };
+
+/**
+ * Seerr users may have no display name. The email local part is the fallback
+ * its own UI shows, so matching that avoids presenting a name the user has
+ * never seen anywhere else.
+ */
+const nameOf = (u: RawUser): string | undefined => u.displayName ?? u.username ?? u.email?.split('@')[0];
+
+export class SeerrAdapter implements ServiceAdapter, UserDirectoryCapable {
+    readonly id: ServiceId = 'seerr';
+    readonly #http: ServiceHttp;
+
+    constructor(config: MultiUserServiceConfig, fetchImpl: typeof fetch = fetch) {
+        this.#http = new ServiceHttp('seerr', config, apiKeyHeader('X-Api-Key', config.api_key), fetchImpl);
+    }
+
+    async getVersion(): Promise<string> {
+        const status = await this.#http.get<RawStatus>('/api/v1/status');
+        if (!status.version) {
+            throw new ServiceError('UpstreamError', this.id, 'status returned no version field');
+        }
+        return status.version;
+    }
+
+    async listUsers(): Promise<ServiceUser[]> {
+        const page = await this.#http.get<RawUserPage>('/api/v1/user');
+        return (page.results ?? [])
+            .map(u => ({ id: u.id, name: nameOf(u) }))
+            .filter((u): u is { id: number; name: string } => u.id !== undefined && u.name !== undefined)
+            .map(u => ({ id: String(u.id), name: u.name }));
+    }
+
+    async testConnection(): Promise<ConnectionDiagnosis> {
+        return diagnoseConnection(this.id, () => this.getVersion());
+    }
+}

--- a/src/services/sonarr.ts
+++ b/src/services/sonarr.ts
@@ -1,0 +1,85 @@
+import type { KeyedServiceConfig, ServiceId } from '../config/schema.ts';
+import { apiKeyHeader } from '../core/auth.ts';
+import { ServiceError } from '../core/errors.ts';
+import { ServiceHttp } from '../core/http.ts';
+import type { components } from './generated/sonarr.ts';
+import {
+    diagnoseConnection,
+    type ConnectionDiagnosis,
+    type DiskSpace,
+    type DiskSpaceCapable,
+    type HealthCheck,
+    type HealthCheckCapable,
+    type ScanState,
+    type ScanStateCapable,
+    type ServiceAdapter
+} from './types.ts';
+
+type RawStatus = components['schemas']['SystemResource'];
+type RawDiskSpace = components['schemas']['DiskSpaceResource'];
+type RawHealthCheck = components['schemas']['HealthResource'];
+type RawTask = components['schemas']['TaskResource'];
+
+/**
+ * The task that rescans the series library, confirmed against a live Sonarr
+ * 4.0.19 during the Phase 2a capture run.
+ *
+ * Matched exactly, never by pattern — for the same reason as Radarr's
+ * `RefreshMovie`. A live instance runs eleven tasks, and
+ * `RefreshMonitoredDownloads` polls the download queue every minute. Taking the
+ * most recent match reported the library as scanned minutes ago when the real
+ * scan was nine hours old.
+ */
+const LIBRARY_SCAN_TASK = 'RefreshSeries';
+
+export class SonarrAdapter implements ServiceAdapter, DiskSpaceCapable, HealthCheckCapable, ScanStateCapable {
+    readonly id: ServiceId = 'sonarr';
+    readonly #http: ServiceHttp;
+
+    constructor(config: KeyedServiceConfig, fetchImpl: typeof fetch = fetch) {
+        this.#http = new ServiceHttp('sonarr', config, apiKeyHeader('X-Api-Key', config.api_key), fetchImpl);
+    }
+
+    async getVersion(): Promise<string> {
+        const status = await this.#http.get<RawStatus>('/api/v3/system/status');
+        if (!status.version) {
+            throw new ServiceError('UpstreamError', this.id, 'system/status returned no version field');
+        }
+        return status.version;
+    }
+
+    async getDiskSpace(): Promise<DiskSpace[]> {
+        const rows = await this.#http.get<RawDiskSpace[]>('/api/v3/diskspace');
+        // The generated types mark these nullable, not merely optional.
+        return rows.map(r => ({
+            service: this.id,
+            ...(typeof r.path === 'string' ? { path: r.path } : {}),
+            label: r.label ?? '',
+            freeSpace: r.freeSpace ?? 0,
+            ...(typeof r.totalSpace === 'number' ? { totalSpace: r.totalSpace } : {})
+        }));
+    }
+
+    async getFailedHealthChecks(): Promise<HealthCheck[]> {
+        const all = await this.#http.get<RawHealthCheck[]>('/api/v3/health');
+        return all
+            .filter(c => c.type !== 'ok')
+            .map(c => ({
+                service: this.id,
+                source: c.source ?? 'unknown',
+                type: String(c.type ?? 'warning'),
+                message: c.message ?? ''
+            }));
+    }
+
+    async getScanState(): Promise<ScanState> {
+        const tasks = await this.#http.get<RawTask[]>('/api/v3/system/task');
+        const scan = tasks.find(t => t.taskName === LIBRARY_SCAN_TASK);
+        const lastCompleted = scan?.lastExecution;
+        return { service: this.id, ...(typeof lastCompleted === 'string' ? { lastCompleted } : {}) };
+    }
+
+    async testConnection(): Promise<ConnectionDiagnosis> {
+        return diagnoseConnection(this.id, () => this.getVersion());
+    }
+}

--- a/src/services/transmission.ts
+++ b/src/services/transmission.ts
@@ -1,0 +1,84 @@
+import type { ServiceId, TransmissionServiceConfig } from '../config/schema.ts';
+import { transmissionRpc } from '../core/auth.ts';
+import { ServiceError } from '../core/errors.ts';
+import { ServiceHttp } from '../core/http.ts';
+import {
+    diagnoseConnection,
+    type ConnectionDiagnosis,
+    type DiskSpace,
+    type DiskSpaceCapable,
+    type ServiceAdapter
+} from './types.ts';
+
+const RPC_PATH = '/transmission/rpc';
+
+type RpcResponse<T> = { result?: string; arguments?: T };
+type RawSession = {
+    version?: string;
+    'download-dir'?: string;
+    'download-dir-free-space'?: number;
+};
+
+/**
+ * Hand-written: Transmission speaks POST-only JSON-RPC against a single
+ * endpoint, with an `X-Transmission-Session-Id` handshake that the auth
+ * strategy owns. Confirmed against a live 4.1.3.
+ */
+export class TransmissionAdapter implements ServiceAdapter, DiskSpaceCapable {
+    readonly id: ServiceId = 'transmission';
+    readonly #http: ServiceHttp;
+
+    constructor(config: TransmissionServiceConfig, fetchImpl: typeof fetch = fetch) {
+        this.#http = new ServiceHttp(
+            'transmission',
+            config,
+            transmissionRpc({
+                ...(config.username === undefined ? {} : { username: config.username }),
+                ...(config.password === undefined ? {} : { password: config.password })
+            }),
+            fetchImpl
+        );
+    }
+
+    async getVersion(): Promise<string> {
+        const session = await this.#session();
+        if (!session.version) {
+            throw new ServiceError('UpstreamError', this.id, 'session-get returned no version field');
+        }
+        return session.version;
+    }
+
+    async getDiskSpace(): Promise<DiskSpace[]> {
+        const session = await this.#session();
+        const free = session['download-dir-free-space'];
+        if (typeof free !== 'number') return [];
+
+        const path = session['download-dir'] ?? 'download-dir';
+        return [
+            {
+                service: this.id,
+                path,
+                label: 'Transmission download-dir',
+                freeSpace: free
+                // No totalSpace: Transmission reports free space only.
+            }
+        ];
+    }
+
+    async testConnection(): Promise<ConnectionDiagnosis> {
+        return diagnoseConnection(this.id, () => this.getVersion());
+    }
+
+    /**
+     * Transmission answers RPC failures with HTTP 200 and a `result` other than
+     * "success", so checking the status line alone would report a broken call
+     * as healthy.
+     */
+    async #session(): Promise<RawSession> {
+        const body = await this.#http.post<RpcResponse<RawSession>>(RPC_PATH, { method: 'session-get' });
+        if (body.result !== 'success') {
+            throw new ServiceError('UpstreamError', this.id, `session-get failed: ${body.result ?? 'no result field'}`);
+        }
+        return body.arguments ?? {};
+    }
+}

--- a/src/tools/stackHealth.ts
+++ b/src/tools/stackHealth.ts
@@ -7,9 +7,11 @@ import { DetailSchema, LimitSchema, applyLimit, type DetailLevel } from '../core
 import {
     hasDiskSpace,
     hasHealthChecks,
+    hasScanState,
     type ConnectionDiagnosis,
     type DiskSpace,
     type HealthCheck,
+    type ScanState,
     type ServiceAdapter
 } from '../services/types.ts';
 
@@ -19,8 +21,52 @@ export type StackHealthResult = {
     services: ConnectionDiagnosis[];
     disks: Shaped<DiskSpace>;
     failures: Shaped<HealthCheck>;
+    /**
+     * Not run through applyLimit: bounded by the number of configured services,
+     * so it can never exceed eight rows. Wrapping a list that cannot truncate
+     * in a truncation contract is noise in every response.
+     */
+    scans: ScanState[];
     degraded: ServiceId[];
 };
+
+/**
+ * minimal  — is anything broken? A verdict per service, and counts only.
+ * standard — everything except disk paths, the longest strings in the response
+ *            and rarely what the question was about.
+ * full     — everything, paths included.
+ */
+function project(result: StackHealthResult, detail: DetailLevel): StackHealthResult {
+    if (detail === 'full') return result;
+
+    if (detail === 'standard') {
+        return {
+            ...result,
+            disks: {
+                ...result.disks,
+                items: result.disks.items.map(({ path: _path, ...rest }) => rest)
+            }
+        };
+    }
+
+    return {
+        services: result.services.map(s => ({
+            ok: s.ok,
+            service: s.service,
+            latency_ms: s.latency_ms,
+            // Kind and detail, but not the remedy: minimal answers "is it
+            // broken", and the remedy is for someone about to fix it.
+            ...(s.error === undefined ? {} : { error: { kind: s.error.kind, detail: s.error.detail } })
+        })),
+        disks: { ...result.disks, items: [], returned: 0 },
+        failures: { ...result.failures, items: [], returned: 0 },
+        scans: result.scans.map(s => ({
+            service: s.service,
+            ...(s.lastCompleted === undefined ? {} : { lastCompleted: s.lastCompleted })
+        })),
+        degraded: result.degraded
+    };
+}
 
 /**
  * Composes per-service diagnoses into one answer. This tool must work
@@ -36,6 +82,7 @@ export async function buildStackHealth(
     const degraded: ServiceId[] = [];
     const disks: DiskSpace[] = [];
     const failures: HealthCheck[] = [];
+    const scans: ScanState[] = [];
 
     const markDegraded = (id: ServiceId) => {
         if (!degraded.includes(id)) degraded.push(id);
@@ -69,9 +116,10 @@ export async function buildStackHealth(
 
             // A service with neither capability contributes its diagnosis and
             // no rows, rather than being special-cased out of the loop.
-            const [diskResult, healthResult] = await Promise.allSettled([
+            const [diskResult, healthResult, scanResult] = await Promise.allSettled([
                 hasDiskSpace(adapter) ? adapter.getDiskSpace() : Promise.resolve([]),
-                hasHealthChecks(adapter) ? adapter.getFailedHealthChecks() : Promise.resolve([])
+                hasHealthChecks(adapter) ? adapter.getFailedHealthChecks() : Promise.resolve([]),
+                hasScanState(adapter) ? adapter.getScanState() : Promise.resolve(undefined)
             ]);
 
             if (diskResult.status === 'fulfilled') {
@@ -87,25 +135,44 @@ export async function buildStackHealth(
                 logger.warn({ service: adapter.id }, 'health read failed');
                 markDegraded(adapter.id);
             }
+
+            if (scanResult.status === 'fulfilled') {
+                if (scanResult.value !== undefined) scans.push(scanResult.value);
+            } else {
+                logger.warn({ service: adapter.id }, 'scan state read failed');
+                markDegraded(adapter.id);
+            }
         })
     );
 
     // Promise.all resolves in input order but the pushes above race, so sort to
     // make the response stable across calls and diffable in tests.
     services.sort((a, b) => a.service.localeCompare(b.service));
+    scans.sort((a, b) => a.service.localeCompare(b.service));
     degraded.sort();
 
-    const shapedDisks = applyLimit(disks, opts.limit);
+    // One budget across both lists, spent on failures first: a failing health
+    // check is the reason someone called this tool, and a disk row is context.
+    // Applying `limit` to each list independently let `limit: 50` return 100
+    // rows, against a parameter whose only job is bounding context.
     const shapedFailures = applyLimit(failures, opts.limit);
+    const remaining = Math.max(0, opts.limit - shapedFailures.returned);
 
-    // `minimal` drops per-item payloads but keeps the counts honest: a model
-    // must never see returned: 0 and conclude there are no disks.
-    return {
-        services,
-        disks: opts.detail === 'minimal' ? { ...shapedDisks, items: [], returned: 0 } : shapedDisks,
-        failures: shapedFailures,
-        degraded
-    };
+    // applyLimit clamps its limit to a minimum of one, deliberately: a caller
+    // must not be able to ask for zero items and get a silently empty list.
+    // A spent budget is the one case where zero is the honest answer, so it is
+    // handled here rather than by weakening that guard for every other caller.
+    const shapedDisks =
+        remaining === 0
+            ? { items: [], total: disks.length, returned: 0, truncated: disks.length > 0 }
+            : applyLimit(disks, remaining);
+
+    // Counts stay honest at every detail level: a model must never see
+    // returned: 0 and conclude there are no disks.
+    return project(
+        { services, disks: shapedDisks, failures: shapedFailures, scans, degraded },
+        opts.detail
+    );
 }
 
 export function registerStackHealth(server: McpServer, adapters: readonly ServiceAdapter[]): void {
@@ -113,14 +180,16 @@ export function registerStackHealth(server: McpServer, adapters: readonly Servic
         'stack_health',
         {
             description:
-                'Health of every configured service: version, disk space, failing health checks, and which services could not be reached. Returns partial results with a `degraded` list rather than failing when a service is down.',
+                'Health of every configured service: version, disk space, failing health checks, and when each library was last scanned. Returns partial results with a `degraded` list rather than failing when a service is down.',
             inputSchema: z.object({ detail: DetailSchema, limit: LimitSchema })
         },
         async ({ detail, limit }) => {
             const result = await buildStackHealth(adapters, { detail, limit });
+            const neverScanned = result.scans.filter(s => s.lastCompleted === undefined).length;
             const summary =
                 result.degraded.length === 0
-                    ? `All ${result.services.length} configured service(s) healthy.`
+                    ? `All ${result.services.length} configured service(s) healthy.` +
+                      (neverScanned > 0 ? ` ${neverScanned} report no completed library scan.` : '')
                     : `${result.degraded.length} of ${result.services.length} service(s) degraded: ${result.degraded.join(', ')}.`;
 
             return {

--- a/test/adapters.test.ts
+++ b/test/adapters.test.ts
@@ -1,0 +1,360 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import type { KeyedServiceConfig, MultiUserServiceConfig, TransmissionServiceConfig } from '../src/config/schema.ts';
+import { BazarrAdapter } from '../src/services/bazarr.ts';
+import { JellyfinAdapter } from '../src/services/jellyfin.ts';
+import { ProwlarrAdapter } from '../src/services/prowlarr.ts';
+import { SabnzbdAdapter } from '../src/services/sabnzbd.ts';
+import { SeerrAdapter } from '../src/services/seerr.ts';
+import { SonarrAdapter } from '../src/services/sonarr.ts';
+import { TransmissionAdapter } from '../src/services/transmission.ts';
+import {
+    hasDiskSpace,
+    hasHealthChecks,
+    hasScanState,
+    hasUserDirectory,
+    type ServiceAdapter
+} from '../src/services/types.ts';
+import { jsonResponse, serving, servingModes } from './helpers/serve.ts';
+
+/**
+ * These drive the adapters off the **recorded fixtures**, not off shapes
+ * invented in a plan. That is the whole point of the capture gate: if upstream
+ * changes, the fixture changes and these fail.
+ */
+const fixture = (path: string): unknown =>
+    JSON.parse(readFileSync(join(import.meta.dirname, 'fixtures', path), 'utf8'));
+
+const keyed = (port: number): KeyedServiceConfig => ({
+    url: `http://192.0.2.10:${port}`,
+    api_key: 'k',
+    timeout_ms: 10_000,
+    permissions: { safe_write: false, destructive: false }
+});
+
+const multiUser = (port: number): MultiUserServiceConfig => ({
+    ...keyed(port),
+    allow_other_users: false
+});
+
+const transmissionConfig: TransmissionServiceConfig = {
+    url: 'http://192.0.2.10:9091',
+    timeout_ms: 10_000,
+    permissions: { safe_write: false, destructive: false }
+};
+
+const unauthorized = (async () => jsonResponse({}, 401)) as unknown as typeof fetch;
+
+/** Every adapter must diagnose rather than throw — design spec §6/§14. */
+const expectsAuthDiagnosis = (adapter: ServiceAdapter) =>
+    it(`${adapter.id} diagnoses a bad key as AuthFailed rather than throwing`, async () => {
+        const d = await adapter.testConnection();
+        expect(d.ok).toBe(false);
+        expect(d.service).toBe(adapter.id);
+        expect(d.error?.kind).toBe('AuthFailed');
+    });
+
+describe('SonarrAdapter', () => {
+    const routes = {
+        '/api/v3/system/status': fixture('sonarr/system-status.json'),
+        '/api/v3/diskspace': fixture('sonarr/diskspace.json'),
+        '/api/v3/health': fixture('sonarr/health.json'),
+        '/api/v3/system/task': fixture('sonarr/system-task.json')
+    };
+    const adapter = new SonarrAdapter(keyed(8989), serving(routes));
+
+    it('reads the version from the recorded status response', async () => {
+        expect(await adapter.getVersion()).toMatch(/^\d+\.\d+/);
+    });
+
+    it('stamps disk rows with sonarr and keeps the real numbers', async () => {
+        const disks = await adapter.getDiskSpace();
+        expect(disks.length).toBeGreaterThan(0);
+        expect(disks.every(d => d.service === 'sonarr')).toBe(true);
+        expect(disks.every(d => typeof d.freeSpace === 'number')).toBe(true);
+    });
+
+    it('reports RefreshSeries, not the every-minute download poll', async () => {
+        const state = await adapter.getScanState();
+        const tasks = fixture('sonarr/system-task.json') as { taskName?: string; lastExecution?: string }[];
+        const scan = tasks.find(t => t.taskName === 'RefreshSeries');
+        const poll = tasks.find(t => t.taskName === 'RefreshMonitoredDownloads');
+
+        expect(state.lastCompleted).toBe(scan?.lastExecution);
+        expect(state.lastCompleted).not.toBe(poll?.lastExecution);
+    });
+
+    it('advertises disk, health and scan capabilities', () => {
+        expect([hasDiskSpace(adapter), hasHealthChecks(adapter), hasScanState(adapter)]).toEqual([true, true, true]);
+    });
+
+    expectsAuthDiagnosis(new SonarrAdapter(keyed(8989), unauthorized));
+});
+
+describe('ProwlarrAdapter', () => {
+    const adapter = new ProwlarrAdapter(
+        keyed(9696),
+        serving({
+            '/api/v1/system/status': fixture('prowlarr/system-status.json'),
+            '/api/v1/health': fixture('prowlarr/health.json')
+        })
+    );
+
+    it('reads the version from the v1 api', async () => {
+        expect(await adapter.getVersion()).toMatch(/^\d+\.\d+/);
+    });
+
+    it('uses v1, not v3 — Prowlarr never had a v3', async () => {
+        const wrongVersion = new ProwlarrAdapter(
+            keyed(9696),
+            serving({ '/api/v3/system/status': fixture('prowlarr/system-status.json') })
+        );
+        await expect(wrongVersion.getVersion()).rejects.toThrow(/not found/i);
+    });
+
+    it('is health-capable but deliberately not disk-capable', () => {
+        // /api/v1/diskspace returned 404 during the capture run.
+        expect([hasHealthChecks(adapter), hasDiskSpace(adapter)]).toEqual([true, false]);
+    });
+
+    expectsAuthDiagnosis(new ProwlarrAdapter(keyed(9696), unauthorized));
+});
+
+describe('JellyfinAdapter', () => {
+    const routes = {
+        '/System/Info': fixture('jellyfin/system-info.json'),
+        '/Users': fixture('jellyfin/users.json'),
+        '/ScheduledTasks': fixture('jellyfin/scheduled-tasks.json')
+    };
+    const adapter = new JellyfinAdapter(multiUser(8096), serving(routes));
+
+    it('sends the MediaBrowser token header rather than X-Api-Key', async () => {
+        let seen: Headers | undefined;
+        const probe = (async (_i: string, init?: RequestInit) => {
+            seen = new Headers(init?.headers);
+            return jsonResponse({ Version: '10.11.11' });
+        }) as unknown as typeof fetch;
+
+        await new JellyfinAdapter(multiUser(8096), probe).getVersion();
+        expect(seen?.get('Authorization')).toBe('MediaBrowser Token="k"');
+        expect(seen?.get('X-Api-Key')).toBeNull();
+    });
+
+    it('reads the version from System/Info', async () => {
+        expect(await adapter.getVersion()).toMatch(/^\d+\.\d+/);
+    });
+
+    it('lists every user as an id and name pair', async () => {
+        const users = await adapter.listUsers();
+        const raw = fixture('jellyfin/users.json') as unknown[];
+        expect(users).toHaveLength(raw.length);
+        expect(users.every(u => u.id.length > 0 && u.name.length > 0)).toBe(true);
+    });
+
+    it('keys the scan task on Key, because Name is localised', async () => {
+        const state = await adapter.getScanState();
+        const tasks = fixture('jellyfin/scheduled-tasks.json') as {
+            Key?: string;
+            Name?: string;
+            LastExecutionResult?: { EndTimeUtc?: string };
+        }[];
+        const scan = tasks.find(t => t.Key === 'RefreshLibrary');
+
+        expect(state.lastCompleted).toBe(scan?.LastExecutionResult?.EndTimeUtc);
+        // The recorded server is Dutch; matching on Name would find nothing.
+        expect(scan?.Name).not.toBe('Scan Media Library');
+    });
+
+    it('advertises scan state and a user directory, but not disk space', () => {
+        expect([hasScanState(adapter), hasUserDirectory(adapter), hasDiskSpace(adapter)]).toEqual([true, true, false]);
+    });
+
+    expectsAuthDiagnosis(new JellyfinAdapter(multiUser(8096), unauthorized));
+});
+
+describe('SeerrAdapter', () => {
+    const adapter = new SeerrAdapter(
+        multiUser(5055),
+        serving({
+            '/api/v1/status': fixture('seerr/status.json'),
+            '/api/v1/user': fixture('seerr/user.json')
+        })
+    );
+
+    it('reads the version from the status endpoint', async () => {
+        expect(await adapter.getVersion()).toMatch(/^\d+\.\d+/);
+    });
+
+    it('unwraps the paginated results envelope', async () => {
+        const users = await adapter.listUsers();
+        const page = fixture('seerr/user.json') as { results: unknown[] };
+        expect(users).toHaveLength(page.results.length);
+        expect(users.every(u => u.id.length > 0 && u.name.length > 0)).toBe(true);
+    });
+
+    it('falls back to the email local part when a user has no display name', async () => {
+        const bare = new SeerrAdapter(
+            multiUser(5055),
+            serving({ '/api/v1/user': { results: [{ id: 3, email: 'nodisplay@example.test' }] } })
+        );
+        expect(await bare.listUsers()).toEqual([{ id: '3', name: 'nodisplay' }]);
+    });
+
+    it('advertises a user directory', () => {
+        expect(hasUserDirectory(adapter)).toBe(true);
+    });
+
+    expectsAuthDiagnosis(new SeerrAdapter(multiUser(5055), unauthorized));
+});
+
+describe('BazarrAdapter', () => {
+    const adapter = new BazarrAdapter(
+        keyed(6767),
+        serving({
+            '/api/system/status': fixture('bazarr/system-status.json'),
+            '/api/system/health': fixture('bazarr/system-health.json')
+        })
+    );
+
+    it('sends X-API-KEY, spelled differently from every *arr', async () => {
+        let seen: Headers | undefined;
+        const probe = (async (_i: string, init?: RequestInit) => {
+            seen = new Headers(init?.headers);
+            return jsonResponse({ data: { bazarr_version: '1.6.0' } });
+        }) as unknown as typeof fetch;
+
+        await new BazarrAdapter(keyed(6767), probe).getVersion();
+        expect(seen?.get('X-API-KEY')).toBe('k');
+    });
+
+    it('unwraps the data envelope to read bazarr_version', async () => {
+        expect(await adapter.getVersion()).toMatch(/^\d+\.\d+/);
+    });
+
+    it('fails loudly when the envelope itself is missing rather than reading undefined', async () => {
+        const empty = new BazarrAdapter(keyed(6767), serving({ '/api/system/status': {} }));
+        await expect(empty.getVersion()).rejects.toThrow(/no version/i);
+    });
+
+    it('maps health entries into the shared shape', async () => {
+        const withIssue = new BazarrAdapter(
+            keyed(6767),
+            serving({ '/api/system/health': { data: [{ object: 'Sonarr', issue: 'Cannot connect' }] } })
+        );
+        expect(await withIssue.getFailedHealthChecks()).toEqual([
+            { service: 'bazarr', source: 'Sonarr', type: 'warning', message: 'Cannot connect' }
+        ]);
+    });
+
+    it('reports no failures for the recorded healthy instance', async () => {
+        expect(await adapter.getFailedHealthChecks()).toEqual([]);
+    });
+
+    expectsAuthDiagnosis(new BazarrAdapter(keyed(6767), unauthorized));
+});
+
+describe('SabnzbdAdapter', () => {
+    const adapter = new SabnzbdAdapter(
+        keyed(8080),
+        servingModes({
+            version: fixture('sabnzbd/version.json'),
+            queue: fixture('sabnzbd/queue.json')
+        })
+    );
+
+    it('puts the api key in the query string, because SABnzbd has no header auth', async () => {
+        let seen = '';
+        const probe = (async (input: string) => {
+            seen = String(input);
+            return jsonResponse({ version: '5.0.4' });
+        }) as unknown as typeof fetch;
+
+        await new SabnzbdAdapter(keyed(8080), probe).getVersion();
+        expect(new URL(seen).searchParams.get('apikey')).toBe('k');
+        expect(new URL(seen).searchParams.get('output')).toBe('json');
+    });
+
+    it('reads the version from mode=version', async () => {
+        expect(await adapter.getVersion()).toMatch(/^\d+\.\d+/);
+    });
+
+    it('converts the gigabyte strings in the queue payload into bytes', async () => {
+        const disks = await adapter.getDiskSpace();
+        const queue = (fixture('sabnzbd/queue.json') as { queue: { diskspace1: string } }).queue;
+
+        expect(disks.length).toBeGreaterThan(0);
+        expect(disks[0]?.freeSpace).toBe(Math.round(Number(queue.diskspace1) * 1024 ** 3));
+        expect(disks[0]?.service).toBe('sabnzbd');
+    });
+
+    it('returns no rows rather than NaN when the fields are not numeric', async () => {
+        const weird = new SabnzbdAdapter(
+            keyed(8080),
+            servingModes({ queue: { queue: { diskspace1: 'unknown', diskspacetotal1: '1.0' } } })
+        );
+        expect(await weird.getDiskSpace()).toEqual([]);
+    });
+
+    it('advertises disk space but not health checks', () => {
+        expect([hasDiskSpace(adapter), hasHealthChecks(adapter)]).toEqual([true, false]);
+    });
+
+    expectsAuthDiagnosis(new SabnzbdAdapter(keyed(8080), unauthorized));
+});
+
+describe('TransmissionAdapter', () => {
+    const session = fixture('transmission/session-get.json');
+    const adapter = new TransmissionAdapter(transmissionConfig, (async () =>
+        jsonResponse(session)) as unknown as typeof fetch);
+
+    it('posts a session-get RPC call rather than issuing a GET', async () => {
+        let method: string | undefined;
+        let payload: string | undefined;
+        const probe = (async (_i: string, init?: RequestInit) => {
+            method = init?.method;
+            payload = init?.body as string;
+            return jsonResponse(session);
+        }) as unknown as typeof fetch;
+
+        await new TransmissionAdapter(transmissionConfig, probe).getVersion();
+        expect(method).toBe('POST');
+        expect(JSON.parse(payload ?? '{}')).toEqual({ method: 'session-get' });
+    });
+
+    it('completes the 409 session handshake transparently', async () => {
+        let calls = 0;
+        const handshaking = (async () => {
+            calls += 1;
+            if (calls === 1) {
+                return new Response('', { status: 409, headers: { 'X-Transmission-Session-Id': 'sid-1' } });
+            }
+            return jsonResponse(session);
+        }) as unknown as typeof fetch;
+
+        expect(await new TransmissionAdapter(transmissionConfig, handshaking).getVersion()).toMatch(/^\d+\.\d+/);
+        expect(calls).toBe(2);
+    });
+
+    it('treats an RPC-level error as upstream even though HTTP was 200', async () => {
+        const failing = new TransmissionAdapter(transmissionConfig, (async () =>
+            jsonResponse({ result: 'method not allowed' })) as unknown as typeof fetch);
+        await expect(failing.getVersion()).rejects.toThrow(/method not allowed/);
+    });
+
+    it('reports free space with no total, because Transmission does not report one', async () => {
+        const disks = await adapter.getDiskSpace();
+        expect(disks).toHaveLength(1);
+        expect(disks[0]?.service).toBe('transmission');
+        expect(disks[0]?.totalSpace).toBeUndefined();
+        expect(disks[0]?.freeSpace).toBeGreaterThan(0);
+    });
+
+    it('returns no disk rows when free space is absent', async () => {
+        const bare = new TransmissionAdapter(transmissionConfig, (async () =>
+            jsonResponse({ result: 'success', arguments: { version: '4.1.3' } })) as unknown as typeof fetch);
+        expect(await bare.getDiskSpace()).toEqual([]);
+    });
+
+    expectsAuthDiagnosis(new TransmissionAdapter(transmissionConfig, unauthorized));
+});

--- a/test/contract.test.ts
+++ b/test/contract.test.ts
@@ -1,0 +1,195 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Design spec §17 asks contract tests to catch upstream drift before users do.
+ *
+ * This asserts that the response fields each adapter *reads* still exist —
+ * deliberately not that every fixture validates against its whole spec schema.
+ * The generated *arr specs are loose about nullability and upstream adds fields
+ * routinely, so whole-schema validation would go red for drift that cannot
+ * affect us. A check that cries wolf is a check that gets skipped, which costs
+ * exactly the protection §17 is buying.
+ */
+const ROOT = join(import.meta.dirname, '..');
+const read = (path: string): unknown => JSON.parse(readFileSync(join(ROOT, path), 'utf8'));
+
+type Dependency = {
+    /** OpenAPI path, when the service publishes a spec. */
+    path?: string;
+    method?: 'get' | 'post';
+    fixture: string;
+    /** Dotted paths the adapter reads. */
+    fields: string[];
+};
+
+type ServiceContract = { spec?: string; dependencies: Dependency[] };
+
+/** Does the recorded response actually carry this dotted path? */
+export function fixtureHasField(fixture: unknown, dotted: string): boolean {
+    const sample = Array.isArray(fixture) ? fixture[0] : fixture;
+    if (sample === undefined || sample === null) return false;
+
+    let node: unknown = sample;
+    for (const part of dotted.split('.')) {
+        const here = Array.isArray(node) ? node[0] : node;
+        if (here === null || typeof here !== 'object' || !(part in here)) return false;
+        node = (here as Record<string, unknown>)[part];
+    }
+    return true;
+}
+
+const deref = (spec: Record<string, unknown>, node: unknown): unknown => {
+    let current = node;
+    for (let hops = 0; hops < 10; hops += 1) {
+        const ref = (current as Record<string, unknown> | undefined)?.['$ref'];
+        if (typeof ref !== 'string' || !ref.startsWith('#/')) return current;
+        current = ref
+            .slice(2)
+            .split('/')
+            .reduce<unknown>((acc, part) => (acc as Record<string, unknown> | undefined)?.[part], spec);
+    }
+    return current;
+};
+
+/** Declared property names of a 200 response body, unwrapping $refs and arrays. */
+export function resolveResponseFields(spec: unknown, path: string, method: string): Set<string> | undefined {
+    const doc = spec as Record<string, never>;
+    const operation = (doc.paths as Record<string, never> | undefined)?.[path]?.[method];
+    if (operation === undefined) return undefined;
+
+    const responses = (operation as Record<string, never>).responses as Record<string, never> | undefined;
+    const ok = responses?.['200'] ?? responses?.default;
+    const content = (ok as Record<string, never> | undefined)?.content as Record<string, never> | undefined;
+    const media = content?.['application/json'] ?? Object.values(content ?? {})[0];
+
+    let schema = deref(doc, (media as Record<string, never> | undefined)?.schema);
+    if ((schema as Record<string, unknown> | undefined)?.type === 'array') {
+        schema = deref(doc, (schema as Record<string, unknown>).items);
+    }
+
+    const properties = (schema as Record<string, unknown> | undefined)?.properties as
+        | Record<string, unknown>
+        | undefined;
+    return properties === undefined ? undefined : new Set(Object.keys(properties));
+}
+
+/**
+ * Health dependencies are deliberately absent for Radarr, Sonarr and Bazarr:
+ * all three returned `[]` during the capture run because the stack is healthy,
+ * so there is no recorded row to assert against. Design spec §21.7 stays open
+ * rather than being closed on an assumption. Add them the first time a real
+ * instance reports a problem.
+ */
+const CONTRACTS: Record<string, ServiceContract> = {
+    radarr: {
+        spec: 'specs/radarr.json',
+        dependencies: [
+            { path: '/api/v3/system/status', method: 'get', fixture: 'test/fixtures/radarr/system-status.json', fields: ['version'] },
+            { path: '/api/v3/diskspace', method: 'get', fixture: 'test/fixtures/radarr/diskspace.json', fields: ['path', 'label', 'freeSpace', 'totalSpace'] },
+            { path: '/api/v3/system/task', method: 'get', fixture: 'test/fixtures/radarr/system-task.json', fields: ['taskName', 'lastExecution'] }
+        ]
+    },
+    sonarr: {
+        spec: 'specs/sonarr.json',
+        dependencies: [
+            { path: '/api/v3/system/status', method: 'get', fixture: 'test/fixtures/sonarr/system-status.json', fields: ['version'] },
+            { path: '/api/v3/diskspace', method: 'get', fixture: 'test/fixtures/sonarr/diskspace.json', fields: ['path', 'label', 'freeSpace', 'totalSpace'] },
+            { path: '/api/v3/system/task', method: 'get', fixture: 'test/fixtures/sonarr/system-task.json', fields: ['taskName', 'lastExecution'] }
+        ]
+    },
+    prowlarr: {
+        spec: 'specs/prowlarr.json',
+        dependencies: [
+            { path: '/api/v1/system/status', method: 'get', fixture: 'test/fixtures/prowlarr/system-status.json', fields: ['version'] }
+        ]
+    },
+    // No spec: Jellyfin's is vendored, but the adapter uses local narrow types,
+    // so the fixture is what these are checked against.
+    jellyfin: {
+        dependencies: [
+            { fixture: 'test/fixtures/jellyfin/system-info.json', fields: ['Version'] },
+            { fixture: 'test/fixtures/jellyfin/users.json', fields: ['Id', 'Name'] },
+            { fixture: 'test/fixtures/jellyfin/scheduled-tasks.json', fields: ['Key', 'State', 'LastExecutionResult'] }
+        ]
+    },
+    seerr: {
+        dependencies: [
+            { fixture: 'test/fixtures/seerr/status.json', fields: ['version'] },
+            { fixture: 'test/fixtures/seerr/user.json', fields: ['results'] }
+        ]
+    },
+    bazarr: {
+        dependencies: [{ fixture: 'test/fixtures/bazarr/system-status.json', fields: ['data.bazarr_version'] }]
+    },
+    sabnzbd: {
+        dependencies: [
+            { fixture: 'test/fixtures/sabnzbd/version.json', fields: ['version'] },
+            { fixture: 'test/fixtures/sabnzbd/queue.json', fields: ['queue.diskspace1', 'queue.diskspacetotal1'] }
+        ]
+    },
+    transmission: {
+        dependencies: [
+            {
+                fixture: 'test/fixtures/transmission/session-get.json',
+                fields: ['result', 'arguments.version', 'arguments.download-dir', 'arguments.download-dir-free-space']
+            }
+        ]
+    }
+};
+
+describe('adapter contracts', () => {
+    for (const [service, contract] of Object.entries(CONTRACTS)) {
+        describe(service, () => {
+            for (const dep of contract.dependencies) {
+                const label = dep.path ?? dep.fixture.split('/').pop();
+
+                it(`${label} still returns the fields the adapter reads`, () => {
+                    const fixture = read(dep.fixture);
+                    const missing = dep.fields.filter(f => !fixtureHasField(fixture, f));
+                    expect(missing, `missing from the recorded response`).toEqual([]);
+                });
+
+                // Bound outside the closure: narrowing on `contract.spec` does
+                // not survive into a callback TypeScript cannot prove runs now.
+                const spec = contract.spec;
+                const path = dep.path;
+                const method = dep.method ?? 'get';
+
+                if (spec !== undefined && path !== undefined) {
+                    it(`${label} still declares those fields in the vendored spec`, () => {
+                        const declared = resolveResponseFields(read(spec), path, method);
+                        expect(declared, `no ${method} ${path} in ${spec}`).toBeDefined();
+
+                        const missing = dep.fields.filter(f => !declared?.has(f.split('.')[0] ?? f));
+                        expect(missing, 'upstream renamed or removed a field we read').toEqual([]);
+                    });
+                }
+            }
+        });
+    }
+});
+
+describe('fixtureHasField', () => {
+    it('finds a top-level field on an object response', () => {
+        expect(fixtureHasField({ version: '1.0' }, 'version')).toBe(true);
+    });
+
+    it('checks the first element of an array response', () => {
+        expect(fixtureHasField([{ freeSpace: 1 }], 'freeSpace')).toBe(true);
+    });
+
+    it('walks a dotted path', () => {
+        expect(fixtureHasField({ a: { b: 2 } }, 'a.b')).toBe(true);
+    });
+
+    it('reports a missing field', () => {
+        expect(fixtureHasField({ a: 1 }, 'b')).toBe(false);
+    });
+
+    it('treats an empty array as unable to confirm, not as confirmed', () => {
+        // This is why the health dependencies are absent rather than passing.
+        expect(fixtureHasField([], 'anything')).toBe(false);
+    });
+});

--- a/test/helpers/serve.ts
+++ b/test/helpers/serve.ts
@@ -1,0 +1,26 @@
+/**
+ * A fake fetch that answers a path→body map and 404s everything else.
+ *
+ * Adapter tests assert response *mapping*. Transport behaviour — retries, the
+ * circuit breaker, error classification — is covered once in test/http.test.ts
+ * and must not be re-asserted per adapter.
+ */
+export const jsonResponse = (body: unknown, status = 200): Response =>
+    new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+
+export const serving = (routes: Record<string, unknown>): typeof fetch =>
+    (async (input: string | URL | Request) => {
+        const raw = input instanceof Request ? input.url : String(input);
+        const path = new URL(raw).pathname;
+        if (!(path in routes)) return jsonResponse({ message: 'not found' }, 404);
+        return jsonResponse(routes[path]);
+    }) as unknown as typeof fetch;
+
+/** SABnzbd routes on the `mode` query parameter rather than on the path. */
+export const servingModes = (byMode: Record<string, unknown>): typeof fetch =>
+    (async (input: string | URL | Request) => {
+        const raw = input instanceof Request ? input.url : String(input);
+        const mode = new URL(raw).searchParams.get('mode') ?? '';
+        if (!(mode in byMode)) return jsonResponse({ status: false, error: 'unknown mode' }, 404);
+        return jsonResponse(byMode[mode]);
+    }) as unknown as typeof fetch;

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { ConfigSchema } from '../src/config/schema.ts';
+import { buildAdapters } from '../src/services/registry.ts';
+
+const AUTH = { bearer_token: 'a'.repeat(64) };
+const keyed = (port: number) => ({ url: `http://h:${port}`, api_key: 'k' });
+
+describe('buildAdapters', () => {
+    it('builds nothing when no service is configured', () => {
+        expect(buildAdapters(ConfigSchema.parse({ auth: AUTH, services: {} }))).toEqual([]);
+    });
+
+    it('builds only the services that are configured', () => {
+        const config = ConfigSchema.parse({ auth: AUTH, services: { radarr: keyed(7878) } });
+        expect(buildAdapters(config).map(a => a.id)).toEqual(['radarr']);
+    });
+
+    it('builds all eight in a stable, alphabetical order', () => {
+        const config = ConfigSchema.parse({
+            auth: AUTH,
+            services: {
+                radarr: keyed(7878),
+                sonarr: keyed(8989),
+                prowlarr: keyed(9696),
+                bazarr: keyed(6767),
+                sabnzbd: keyed(8080),
+                jellyfin: keyed(8096),
+                seerr: keyed(5055),
+                transmission: { url: 'http://h:9091', username: 'u', password: 'p' }
+            }
+        });
+
+        // Alphabetical, so stack_health output is stable across restarts.
+        expect(buildAdapters(config).map(a => a.id)).toEqual([
+            'bazarr',
+            'jellyfin',
+            'prowlarr',
+            'radarr',
+            'sabnzbd',
+            'seerr',
+            'sonarr',
+            'transmission'
+        ]);
+    });
+
+    it('builds transmission without credentials, which LAN RPC often has none of', () => {
+        const config = ConfigSchema.parse({
+            auth: AUTH,
+            services: { transmission: { url: 'http://h:9091' } }
+        });
+        expect(buildAdapters(config).map(a => a.id)).toEqual(['transmission']);
+    });
+});

--- a/test/stackHealth.test.ts
+++ b/test/stackHealth.test.ts
@@ -6,6 +6,7 @@ import type {
     DiskSpaceCapable,
     HealthCheck,
     HealthCheckCapable,
+    ScanState,
     ServiceAdapter
 } from '../src/services/types.ts';
 import { buildStackHealth, registerStackHealth } from '../src/tools/stackHealth.ts';
@@ -134,8 +135,37 @@ describe('stack_health', () => {
             { detail: 'standard', limit: 3 }
         );
 
-        expect(result.disks).toMatchObject({ total: 7, returned: 3, truncated: true });
+        // One budget across both lists, spent on failures first. Applying the
+        // limit to each independently would have returned 6 rows for limit: 3.
         expect(result.failures).toMatchObject({ total: 4, returned: 3, truncated: true });
+        expect(result.disks).toMatchObject({ total: 7, returned: 0, truncated: true });
+        expect(result.failures.returned + result.disks.returned).toBeLessThanOrEqual(3);
+    });
+
+    it('still reports the true disk total when the budget left no room for rows', async () => {
+        const result = await buildStackHealth(
+            [
+                fakeArr({
+                    diagnosis: healthy,
+                    getDiskSpace: async () => [
+                        { service: 'radarr', path: '/movies', label: 'movies', freeSpace: 1, totalSpace: 2 }
+                    ],
+                    getFailedHealthChecks: async () =>
+                        Array.from({ length: 5 }, (_, i) => ({
+                            service: 'radarr' as const,
+                            source: `S${i}`,
+                            type: 'warning',
+                            message: 'm'
+                        }))
+                })
+            ],
+            { detail: 'standard', limit: 2 }
+        );
+
+        // A starved list must not read as "there are no disks".
+        expect(result.disks.items).toEqual([]);
+        expect(result.disks.total).toBe(1);
+        expect(result.disks.truncated).toBe(true);
     });
 
     it('omits disk detail at minimal but keeps the counts truthful', async () => {
@@ -184,6 +214,95 @@ describe('stack_health', () => {
         expect(result.services.map(s => s.service)).toContain('sabnzbd');
         expect(result.degraded).toEqual([]);
         expect(result.disks.total).toBe(0);
+    });
+
+    it('collects scan state from services that report it', async () => {
+        const scanner: ServiceAdapter & { getScanState: () => Promise<ScanState> } = {
+            id: 'jellyfin',
+            getVersion: async () => '10.11.11',
+            testConnection: async () => ({ ok: true, service: 'jellyfin', latency_ms: 1 }),
+            getScanState: async () => ({
+                service: 'jellyfin',
+                lastCompleted: '2026-08-05T09:07:11Z',
+                running: false
+            })
+        };
+        const result = await buildStackHealth([scanner], std);
+
+        expect(result.scans).toEqual([{ service: 'jellyfin', lastCompleted: '2026-08-05T09:07:11Z', running: false }]);
+    });
+
+    it('degrades rather than failing when a scan-state read throws', async () => {
+        const broken: ServiceAdapter & { getScanState: () => Promise<ScanState> } = {
+            id: 'jellyfin',
+            getVersion: async () => '10.11.11',
+            testConnection: async () => ({ ok: true, service: 'jellyfin', latency_ms: 1 }),
+            getScanState: async () => {
+                throw new Error('boom');
+            }
+        };
+        const result = await buildStackHealth([broken], std);
+
+        expect(result.degraded).toEqual(['jellyfin']);
+        expect(result.scans).toEqual([]);
+        expect(result.services).toHaveLength(1);
+    });
+
+    it('reports an empty scans list rather than omitting the field', async () => {
+        expect((await buildStackHealth([], std)).scans).toEqual([]);
+    });
+
+    it('keeps counts honest at detail: minimal even though items are dropped', async () => {
+        const disks: DiskSpace[] = [
+            { service: 'radarr', path: '/movies', label: 'movies', freeSpace: 1, totalSpace: 2 }
+        ];
+        const failures: HealthCheck[] = [{ service: 'radarr', source: 'S', type: 'warning', message: 'm' }];
+        const result = await buildStackHealth(
+            [
+                fakeArr({
+                    diagnosis: healthy,
+                    getDiskSpace: async () => disks,
+                    getFailedHealthChecks: async () => failures
+                })
+            ],
+            { detail: 'minimal', limit: 50 }
+        );
+
+        // Both lists drop their payloads at minimal — Phase 1 dropped only disks.
+        expect(result.disks.items).toEqual([]);
+        expect(result.failures.items).toEqual([]);
+        expect(result.disks.total).toBe(1);
+        expect(result.failures.total).toBe(1);
+    });
+
+    it('returns disk paths only at detail: full', async () => {
+        const disks: DiskSpace[] = [
+            { service: 'radarr', path: '/movies', label: 'movies', freeSpace: 1, totalSpace: 2 }
+        ];
+        const build = (detail: 'standard' | 'full') =>
+            buildStackHealth([fakeArr({ diagnosis: healthy, getDiskSpace: async () => disks })], {
+                detail,
+                limit: 50
+            });
+
+        expect((await build('full')).disks.items[0]?.path).toBe('/movies');
+        expect((await build('standard')).disks.items[0]?.path).toBeUndefined();
+        // The row survives; only the path is gone.
+        expect((await build('standard')).disks.items[0]?.freeSpace).toBe(1);
+    });
+
+    it('drops the remedy at minimal but keeps the error kind', async () => {
+        const withRemedy: ConnectionDiagnosis = {
+            ok: false,
+            service: 'radarr',
+            latency_ms: 3,
+            error: { kind: 'Unreachable', detail: 'connection refused', remedy: 'Check the service is running.' }
+        };
+        const result = await buildStackHealth([fakeArr({ diagnosis: withRemedy })], { detail: 'minimal', limit: 50 });
+
+        expect(result.services[0]?.error?.kind).toBe('Unreachable');
+        expect(result.services[0]?.error?.remedy).toBeUndefined();
+        expect(result.degraded).toEqual(['radarr']);
     });
 
     it('registers without throwing', () => {


### PR DESCRIPTION
Completes Phase 2a. **Stacked on #21** — base is `test/record-live-fixtures`.

Tasks 7–16: the seven remaining adapters, contract tests, the registry, `stack_health` extended to all eight services with scan staleness, and the docs.

## Adapters

Sonarr, Prowlarr, Jellyfin, Seerr, Bazarr, SABnzbd and Transmission — each implementing **only the capability interfaces it can actually serve**. Prowlarr is deliberately not `DiskSpaceCapable`: its diskspace endpoint 404s, confirmed by the capture run. A method with no fixture is a method `stack_health` calls in production and nothing has tested.

Adapter tests drive off the **recorded fixtures**, not shapes invented in a plan. Upstream drift now surfaces as a failing test rather than as a user's bug report.

Each hand-written adapter carries what the capture established:

- **Bazarr** wraps every payload in a `data` envelope and names its version `bazarr_version`
- **SABnzbd** reports disk space as gigabytes in a string, and reports *two* volumes — both surfaced, because either can fill up
- **Transmission** answers RPC failures with HTTP 200 and a non-success `result`, so the envelope is checked rather than the status line

## Two audit defects fixed here

Both live in `stack_health`, which this task rewrites anyway. Fixing them separately would have meant touching and reviewing the same function twice.

**`detail` had one effective level.** `minimal` emptied disks but left failing checks fully populated, and `full` was byte-identical to `standard`. All three now differ; `minimal` drops both payloads and keeps the counts honest.

**`limit` was applied per list.** `limit: 50` could return 100 rows. Now one budget across both, spent on failing checks first — a failing check is why someone called this tool, a disk row is context. A starved list still reports its true total rather than reading as "there are no disks".

That surfaced something worth keeping: `applyLimit` clamps its limit to a minimum of 1, deliberately, so a caller cannot ask for zero and get a silently empty list back. A spent budget is the one case where zero is the honest answer, so it is handled at the call site rather than by weakening a guard every other caller relies on.

## Contract tests

Assert the response fields each adapter reads — against the vendored spec where one exists, against the fixture otherwise.

Deliberately not whole-schema validation: the generated *arr specs are loose about nullability and upstream adds fields routinely, so that would go red for drift that cannot reach users. A check that cries wolf is a check that gets skipped, which costs exactly the protection §17 is buying.

**Health dependencies are absent** for Radarr, Sonarr and Bazarr. All three returned `[]` because the stack is healthy, so §21.7 stays open rather than being closed on an assumption.

## Docs

Walked the `RELEASING.md` README checklist rather than doing it from memory: status callout, pinned tag, a config example covering all three auth shapes, and every forward reference re-checked against the roadmap.

The adapter guide is rewritten around what now exists — `ServiceHttp`, auth strategies, capability interfaces, the registry, the contract test — and records the two rules the capture taught: don't implement a capability you have no fixture for, and match on stable identifiers rather than display strings. Radarr has three tasks whose names contain "Refresh", and Jellyfin localises its task names.

Also adds the distribution checklist §17 asks for, scoped to 0.3 and later.

## Verified

`lint`, `typecheck`, `test` — **260 passed**, up from 183 — and `build`.

Not yet verified: the built server pointed at a live eight-service stack. That is 2a's actual "done when" and needs a run against real services.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
