### PR TITLE
feat: add a single-flight TTL cache

### DIFF
--- a/src/core/cache.ts
+++ b/src/core/cache.ts
@@ -1,0 +1,66 @@
+/**
+ * Design spec §16, with one deviation recorded in the Phase 3 design §3: this
+ * is a TTL map, **not an LRU**.
+ *
+ * Eviction solves unbounded key growth, and the key space here is about a dozen
+ * entries — one library per service, one health per service. An LRU would be
+ * machinery for a problem this project cannot have, and every line of it would
+ * be untested by any scenario a user can reach.
+ */
+export type Clock = () => number;
+
+/** §16: library reads ~5 min, health ~30 s. */
+export const LIBRARY_TTL_MS = 300_000;
+export const HEALTH_TTL_MS = 30_000;
+
+type Entry<T> = { value: Promise<T>; expiresAt: number };
+
+export class TtlCache {
+    readonly #entries = new Map<string, Entry<unknown>>();
+    readonly #now: Clock;
+
+    constructor(clock: Clock = Date.now) {
+        this.#now = clock;
+    }
+
+    /**
+     * The stored value is the *promise*, not the resolved value. That is what
+     * makes this single-flight: two concurrent callers find the same in-flight
+     * promise and share one fetch rather than both hitting the service.
+     */
+    async get<T>(key: string, ttlMs: number, load: () => Promise<T>): Promise<T> {
+        const existing = this.#entries.get(key);
+        if (existing !== undefined && existing.expiresAt > this.#now()) {
+            return existing.value as Promise<T>;
+        }
+
+        const value = load();
+        this.#entries.set(key, { value, expiresAt: this.#now() + ttlMs });
+
+        try {
+            return await value;
+        } catch (err) {
+            // Never cache a failure. A service restarting during the first call
+            // would otherwise poison every later call until arr-mcp restarts —
+            // the same lesson the identity directory taught in Phase 2.
+            //
+            // Guarded on identity: a later successful load may already have
+            // replaced this entry, and dropping that would be a second bug.
+            if (this.#entries.get(key)?.value === value) this.#entries.delete(key);
+            throw err;
+        }
+    }
+
+    /** The seam for write-invalidation (§16). Nothing calls it until 0.5. */
+    invalidate(key: string): void {
+        this.#entries.delete(key);
+    }
+
+    clear(): void {
+        this.#entries.clear();
+    }
+
+    size(): number {
+        return this.#entries.size;
+    }
+}

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from 'vitest';
+import { HEALTH_TTL_MS, LIBRARY_TTL_MS, TtlCache } from '../src/core/cache.ts';
+
+/** A hand-cranked clock, so expiry is testable without waiting five minutes. */
+const clock = (start = 0) => {
+    let now = start;
+    return { now: () => now, advance: (ms: number) => (now += ms) };
+};
+
+describe('TtlCache', () => {
+    it('loads on a miss and returns the loaded value', async () => {
+        const cache = new TtlCache();
+        expect(await cache.get('k', 1000, async () => 'value')).toBe('value');
+    });
+
+    it('serves a second call from the cache without loading again', async () => {
+        const cache = new TtlCache();
+        const load = vi.fn(async () => 'value');
+
+        await cache.get('k', 1000, load);
+        await cache.get('k', 1000, load);
+
+        expect(load).toHaveBeenCalledTimes(1);
+    });
+
+    it('reloads once the ttl has elapsed', async () => {
+        const c = clock();
+        const cache = new TtlCache(c.now);
+        const load = vi.fn(async () => 'value');
+
+        await cache.get('k', 1000, load);
+        c.advance(1001);
+        await cache.get('k', 1000, load);
+
+        expect(load).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not reload one millisecond before expiry', async () => {
+        const c = clock();
+        const cache = new TtlCache(c.now);
+        const load = vi.fn(async () => 'value');
+
+        await cache.get('k', 1000, load);
+        c.advance(999);
+        await cache.get('k', 1000, load);
+
+        expect(load).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps separate keys separate', async () => {
+        const cache = new TtlCache();
+        expect(await cache.get('a', 1000, async () => 'A')).toBe('A');
+        expect(await cache.get('b', 1000, async () => 'B')).toBe('B');
+    });
+
+    it('shares one in-flight load between concurrent callers', async () => {
+        const cache = new TtlCache();
+        let calls = 0;
+        const slow = async () => {
+            calls += 1;
+            await new Promise(r => setTimeout(r, 20));
+            return 'value';
+        };
+
+        // Both start before either resolves: without single-flight this is two
+        // full library fetches against the same service.
+        const [a, b] = await Promise.all([cache.get('k', 1000, slow), cache.get('k', 1000, slow)]);
+
+        expect([a, b]).toEqual(['value', 'value']);
+        expect(calls).toBe(1);
+    });
+
+    it('does not cache a failed load', async () => {
+        const cache = new TtlCache();
+        let calls = 0;
+        const flaky = async () => {
+            calls += 1;
+            if (calls === 1) throw new Error('service was restarting');
+            return 'value';
+        };
+
+        await expect(cache.get('k', 1000, flaky)).rejects.toThrow('service was restarting');
+        // A service restarting during the first call must not poison every
+        // later call until arr-mcp itself restarts.
+        expect(await cache.get('k', 1000, flaky)).toBe('value');
+    });
+
+    it('rejects every concurrent caller when the shared load fails', async () => {
+        const cache = new TtlCache();
+        const failing = async () => {
+            await new Promise(r => setTimeout(r, 10));
+            throw new Error('down');
+        };
+
+        const results = await Promise.allSettled([
+            cache.get('k', 1000, failing),
+            cache.get('k', 1000, failing)
+        ]);
+
+        expect(results.map(r => r.status)).toEqual(['rejected', 'rejected']);
+    });
+
+    it('drops an entry on invalidate', async () => {
+        const cache = new TtlCache();
+        const load = vi.fn(async () => 'value');
+
+        await cache.get('k', 1000, load);
+        cache.invalidate('k');
+        await cache.get('k', 1000, load);
+
+        expect(load).toHaveBeenCalledTimes(2);
+    });
+
+    it('reports its size, so a leak would be visible', async () => {
+        const cache = new TtlCache();
+        await cache.get('a', 1000, async () => 1);
+        await cache.get('b', 1000, async () => 2);
+
+        expect(cache.size()).toBe(2);
+        cache.clear();
+        expect(cache.size()).toBe(0);
+    });
+
+    it('exposes the ttls the design spec names', () => {
+        expect(LIBRARY_TTL_MS).toBe(300_000);
+        expect(HEALTH_TTL_MS).toBe(30_000);
+    });
+});


### PR DESCRIPTION
Phase 3a, Task 1 of 6. Design spec §16, with one deviation stated in the Phase 3 design §3: **a TTL map, not an LRU.** Eviction solves unbounded key growth, and this key space is about a dozen entries — one library per service, one health per service. An LRU would be machinery for a problem this project cannot have, and every line of it would be untested by any scenario a user can reach.

Three properties carry the weight:

- **Single-flight.** The cache stores the in-flight *promise*, not the resolved value, so two concurrent `get_library` calls share one fetch rather than both hitting Radarr.
- **A failed load is never cached.** A service restarting during the first call would otherwise poison every later call until arr-mcp itself restarted. The delete is guarded on promise identity, so a slow failing load cannot evict a newer good value that already replaced it.
- **The clock is injectable**, so five-minute expiry is testable without waiting five minutes.

`invalidate` exists and nothing calls it until writes arrive in 0.5 — it is the seam, not dead code.

Ships no tool and nothing wires it in yet: caching lives in the tool layer, never in adapters, and an adapter that caches is an adapter whose fixture tests lie.

11 new tests, full suite **429/429**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)