### PR TITLE
refactor: extract title matching into a shared module

### DIFF
--- a/src/core/titleMatch.ts
+++ b/src/core/titleMatch.ts
@@ -2,6 +2,19 @@
  * Title normalisation and ranking, shared by `search_media`, the resolver and
  * `diagnose`. Extracted from searchMedia when the third caller appeared: two
  * copies is a coincidence, three is a module.
+ *
+ * Ranking contract: four tiers, lower is better — RANK_EXACT, RANK_PREFIX,
+ * RANK_SUBSTRING, RANK_NONE. A title that does not contain the query at all
+ * is a strictly worse match than one that does, so it gets its own bottom
+ * tier instead of sharing RANK_SUBSTRING by default. That distinction is not
+ * theoretical: `search_media`'s library sources pre-filter to substring
+ * matches before this ever sees them, but its discover and indexer sources
+ * (Radarr/Sonarr `/lookup`, Prowlarr's indexer search) return whatever the
+ * far end sent back, unfiltered — RANK_NONE is the tier that keeps an
+ * unrelated result from outranking a real one there. Both sides of the
+ * comparison go through `normaliseTitle`, so a leading article on either the
+ * title or the query is stripped before ranking: "matrix" against "The
+ * Matrix" and "the matrix" against "Matrix" both land on RANK_EXACT.
  */
 
 /** Fenced titles carry a boundary prefix; comparison strips it first. */

--- a/src/core/titleMatch.ts
+++ b/src/core/titleMatch.ts
@@ -1,0 +1,39 @@
+/**
+ * Title normalisation and ranking, shared by `search_media`, the resolver and
+ * `diagnose`. Extracted from searchMedia when the third caller appeared: two
+ * copies is a coincidence, three is a module.
+ */
+
+/** Fenced titles carry a boundary prefix; comparison strips it first. */
+export const unfenced = (value: string): string =>
+    value.replace(/^<<untrusted:[^>]*>>/, '').replace(/<<\/untrusted>>$/, '');
+
+const LEADING_ARTICLE = /^(the|a|an)\s+/;
+
+/**
+ * Lowercase, punctuation removed, leading article dropped. The article matters:
+ * people ask for "matrix" and the library holds "The Matrix".
+ */
+export const normaliseTitle = (value: string): string =>
+    unfenced(value)
+        .toLowerCase()
+        .replace(/[^\p{L}\p{N}\s]/gu, '')
+        .replace(/\s+/g, ' ')
+        .trim()
+        .replace(LEADING_ARTICLE, '');
+
+export const RANK_EXACT = 0;
+export const RANK_PREFIX = 1;
+export const RANK_SUBSTRING = 2;
+export const RANK_NONE = 3;
+
+/** Lower is better, so results sort naturally by relevance. */
+export function rankTitle(title: string, query: string): number {
+    const t = normaliseTitle(title);
+    const q = normaliseTitle(query);
+
+    if (t === q) return RANK_EXACT;
+    if (t.startsWith(q)) return RANK_PREFIX;
+    if (t.includes(q)) return RANK_SUBSTRING;
+    return RANK_NONE;
+}

--- a/src/tools/searchMedia.ts
+++ b/src/tools/searchMedia.ts
@@ -3,6 +3,7 @@ import * as z from 'zod/v4';
 import type { ServiceId } from '../config/schema.ts';
 import { gather } from '../core/gather.ts';
 import { DetailSchema, LimitSchema, applyLimit, type DetailLevel } from '../core/shape.ts';
+import { rankTitle, unfenced } from '../core/titleMatch.ts';
 import { hasSearch, type SearchHit, type SearchSource, type ServiceAdapter } from '../services/types.ts';
 
 export type GetSearchResult = {
@@ -23,27 +24,6 @@ const project = (h: SearchHit, detail: DetailLevel): SearchHit => {
     return rest;
 };
 
-const RANK_EXACT = 0;
-const RANK_PREFIX = 1;
-const RANK_SUBSTRING = 2;
-
-/** Fenced titles carry a boundary prefix; comparison strips it before matching. */
-const unfenced = (value: string): string =>
-    value.replace(/^<<untrusted:[^>]*>>/, '').replace(/<<\/untrusted>>$/, '');
-
-/**
- * Ranks a hit against the query: exact, then prefix, then substring — so a
- * truncated search returns the best matches rather than the first service
- * alphabetically.
- */
-function rank(hit: SearchHit, query: string): number {
-    const title = unfenced(hit.title).toLowerCase();
-    const term = query.toLowerCase();
-    if (title === term) return RANK_EXACT;
-    if (title.startsWith(term)) return RANK_PREFIX;
-    return RANK_SUBSTRING;
-}
-
 export async function buildSearchMedia(
     adapters: readonly ServiceAdapter[],
     opts: { query: string; source: SearchSource; detail: DetailLevel; limit: number }
@@ -56,7 +36,9 @@ export async function buildSearchMedia(
     // alphabetical — so limiting an unsorted merge would drop Sonarr's results
     // whenever Radarr returned enough of its own, regardless of relevance.
     items.sort(
-        (a, b) => rank(a, opts.query) - rank(b, opts.query) || unfenced(a.title).localeCompare(unfenced(b.title))
+        (a, b) =>
+            rankTitle(a.title, opts.query) - rankTitle(b.title, opts.query) ||
+            unfenced(a.title).localeCompare(unfenced(b.title))
     );
 
     const shaped = applyLimit(items, opts.limit);

--- a/test/searchTools.test.ts
+++ b/test/searchTools.test.ts
@@ -129,6 +129,54 @@ describe('search_media', () => {
         expect(result.items[0]?.service).toBe('sonarr');
     });
 
+    it('ranks a title carrying its leading article above one that only shares a prefix', async () => {
+        // "The Matrix" normalises to "matrix" and is an exact match; "Matrix
+        // Reloaded" is only a prefix match. Without stripping the article on
+        // the title side the two would tie in the fallback tier and sort by
+        // name instead, putting Matrix Reloaded first.
+        const articled = [
+            { id: 10, title: 'The Matrix', year: 1999, tmdbId: 603, hasFile: true, monitored: true },
+            { id: 11, title: 'Matrix Reloaded', year: 2003, tmdbId: 604, hasFile: true, monitored: true }
+        ];
+        const result = await buildSearchMedia([radarr(articled)], {
+            query: 'matrix',
+            source: 'library',
+            detail: 'full',
+            limit: 50
+        });
+        expect(result.items.map(i => i.id)).toEqual(['10', '11']);
+    });
+
+    it('ranks an indexer release containing the query above one that does not, with no upstream filter to rely on', async () => {
+        // Prowlarr returns whatever the indexer sent back — unlike the
+        // library sources there is no substring pre-filter upstream, so this
+        // is the case that actually exercises RANK_NONE rather than relying
+        // on an adapter to make unrelated results moot.
+        const mixed = [
+            {
+                guid: 'r1',
+                title: 'Completely Unrelated Release',
+                indexer: 'NZBgeek',
+                size: 1_000_000,
+                seeders: 1,
+                publishDate: '2026-08-01T00:00:00Z'
+            },
+            {
+                guid: 'r2',
+                title: 'Some Film 2160p',
+                indexer: 'NZBgeek',
+                size: 1_000_000,
+                seeders: 1,
+                publishDate: '2026-08-01T00:00:00Z'
+            }
+        ];
+        const result = await buildSearchMedia(
+            [new ProwlarrAdapter(keyed(9696), serving({ '/api/v1/search': mixed }))],
+            { query: 'some film', source: 'indexers', detail: 'full', limit: 50 }
+        );
+        expect(result.items.map(i => i.id)).toEqual(['r2', 'r1']);
+    });
+
     it('says what each service contributed even when truncation drops one entirely', async () => {
         const manyExact = repeat(LIBRARY[0]!, 60).map((m, n) => ({ ...m, id: n, title: 'Some Film' }));
         const onePrefix = [{ id: 9, title: 'Some Film Zzz', year: 2026, tvdbId: 1, monitored: true }];

--- a/test/searchTools.test.ts
+++ b/test/searchTools.test.ts
@@ -147,11 +147,13 @@ describe('search_media', () => {
         expect(result.items.map(i => i.id)).toEqual(['10', '11']);
     });
 
-    it('ranks an indexer release containing the query above one that does not, with no upstream filter to rely on', async () => {
-        // Prowlarr returns whatever the indexer sent back — unlike the
-        // library sources there is no substring pre-filter upstream, so this
-        // is the case that actually exercises RANK_NONE rather than relying
-        // on an adapter to make unrelated results moot.
+    it('ranks a substring match above a title with no match, which the old fallback tier could not tell apart', async () => {
+        // Query 'film' is a mid-word substring of 'Some Film 2160p' but not a
+        // prefix of it — do not shorten the title to 'Film 2160p', which
+        // would turn it into a prefix match and silently disarm this test.
+        // Prowlarr's indexer results have no upstream substring pre-filter
+        // (unlike the library sources), so this is the case that actually
+        // exercises RANK_NONE.
         const mixed = [
             {
                 guid: 'r1',
@@ -172,8 +174,14 @@ describe('search_media', () => {
         ];
         const result = await buildSearchMedia(
             [new ProwlarrAdapter(keyed(9696), serving({ '/api/v1/search': mixed }))],
-            { query: 'some film', source: 'indexers', detail: 'full', limit: 50 }
+            { query: 'film', source: 'indexers', detail: 'full', limit: 50 }
         );
+        // Old ranking: neither title is an exact or prefix match against
+        // 'film', so both fall into the same default tier and the tie breaks
+        // alphabetically — 'Completely...' before 'Some...', i.e. r1, r2. New
+        // ranking tells them apart — RANK_SUBSTRING for the title that
+        // actually contains 'film', RANK_NONE for the one that does not —
+        // which reverses the order to r2, r1.
         expect(result.items.map(i => i.id)).toEqual(['r2', 'r1']);
     });
 

--- a/test/titleMatch.test.ts
+++ b/test/titleMatch.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { RANK_EXACT, RANK_NONE, RANK_PREFIX, RANK_SUBSTRING, normaliseTitle, rankTitle, unfenced } from '../src/core/titleMatch.ts';
+
+describe('unfenced', () => {
+    it('strips the boundary so fenced titles compare like plain ones', () => {
+        expect(unfenced('<<untrusted:radarr.title>>Some Film<</untrusted>>')).toBe('Some Film');
+    });
+
+    it('leaves an unfenced value alone', () => {
+        expect(unfenced('Some Film')).toBe('Some Film');
+    });
+});
+
+describe('normaliseTitle', () => {
+    it('lowercases and strips punctuation', () => {
+        expect(normaliseTitle('Spider-Man: Brand New Day!')).toBe('spiderman brand new day');
+    });
+
+    it('strips a leading article, because people omit it when asking', () => {
+        expect(normaliseTitle('The Matrix')).toBe('matrix');
+        expect(normaliseTitle('A Quiet Place')).toBe('quiet place');
+        expect(normaliseTitle('An Education')).toBe('education');
+    });
+
+    it('does not strip an article that is not leading', () => {
+        expect(normaliseTitle('Raising the Bar')).toBe('raising the bar');
+    });
+
+    it('collapses runs of whitespace', () => {
+        expect(normaliseTitle('  Blade   Runner  ')).toBe('blade runner');
+    });
+});
+
+describe('rankTitle', () => {
+    it('ranks an exact match above everything', () => {
+        expect(rankTitle('The Matrix', 'matrix')).toBe(RANK_EXACT);
+    });
+
+    it('ranks a prefix above a substring', () => {
+        expect(rankTitle('Matrix Reloaded', 'matrix')).toBe(RANK_PREFIX);
+        expect(rankTitle('Enter the Matrix', 'matrix')).toBe(RANK_SUBSTRING);
+    });
+
+    it('reports no match rather than pretending', () => {
+        expect(rankTitle('Blade Runner', 'matrix')).toBe(RANK_NONE);
+    });
+
+    it('compares through a fence', () => {
+        expect(rankTitle('<<untrusted:radarr.title>>The Matrix<</untrusted>>', 'matrix')).toBe(RANK_EXACT);
+    });
+
+    it('orders correctly when sorted', () => {
+        const titles = ['Enter the Matrix', 'The Matrix', 'Matrix Reloaded'];
+        titles.sort((a, b) => rankTitle(a, 'matrix') - rankTitle(b, 'matrix'));
+        expect(titles).toEqual(['The Matrix', 'Matrix Reloaded', 'Enter the Matrix']);
+    });
+});

--- a/test/titleMatch.test.ts
+++ b/test/titleMatch.test.ts
@@ -29,6 +29,14 @@ describe('normaliseTitle', () => {
     it('collapses runs of whitespace', () => {
         expect(normaliseTitle('  Blade   Runner  ')).toBe('blade runner');
     });
+
+    it('normalises a query of pure punctuation to the empty string, rather than throwing', () => {
+        expect(normaliseTitle('???')).toBe('');
+    });
+
+    it('leaves a title that is only an article alone, because LEADING_ARTICLE requires trailing whitespace', () => {
+        expect(normaliseTitle('The')).toBe('the');
+    });
 });
 
 describe('rankTitle', () => {


### PR DESCRIPTION
Phase 3a, Task 2 of 6. `search_media` had title normalisation and ranking inline; the identity resolver needs the same logic and `diagnose` will be the third caller. Two copies is a coincidence, three is a module.

## This is not behaviour-preserving, and both changes are deliberate

The plan originally claimed the extraction changed nothing but article handling. Review caught that this was wrong twice over. **Neither change can drop a result** — `rankTitle` is used only in the sort comparator, never as a filter — so both are ordering-only, and both orderings beat what they replace.

**1. Article stripping reorders results via the _title_, not just the query.** Searching `matrix`:

| | old | new |
|---|---|---|
| `The Matrix` | tier 2 (neither exact nor prefix) | **tier 0** — exact after stripping |
| `Matrix Reloaded` | tier 1 (prefix) | tier 1 |

Old put *Matrix Reloaded* first. New puts *The Matrix* first, which is what someone typing "matrix" means. Titles beginning with an article are everywhere, so this is not a corner case.

**2. `rankTitle` can return `RANK_NONE`; the old `rank()` could not** — its fallback was `RANK_SUBSTRING` and it never called `.includes()`. This is reachable: `discover` (`/lookup`) and `indexers` (Prowlarr) apply no substring pre-filter, so a fuzzy hit that does not contain the query now sorts *below* one that does instead of tying with it.

## The tests that pin them

The existing `search_media` tests pass unchanged, but that proved less than it looked — no fixture title began with an article, and nothing exercised multi-item ordering on a non-library source. Both cases now have a test that fails if the behaviour regresses.

The first attempt at the second test did not: its fixture was a *prefix* match, so the assertion held under both algorithms and would have passed with `RANK_NONE` deleted. Rewritten so the two titles tie under the old ranking and split under the new one, producing opposite orders — and verified by folding `RANK_NONE` back into the fallback and confirming the test fails.

**444 tests**, up from 429.

🤖 Generated with [Claude Code](https://claude.com/claude-code)