### PR TITLE
feat: add the identity resolver and library index

### DIFF
--- a/src/core/resolver.ts
+++ b/src/core/resolver.ts
@@ -94,19 +94,40 @@ export class LibraryIndex {
 
         for (const input of inputs) {
             const keys = keysOf(input.kind, input.ids);
-            const existing = keys.map(k => byKey.get(k)).find(v => v !== undefined);
+            // A record can carry ids that already belong to *two* separate
+            // groups — e.g. a second Jellyfin copy holding both the tmdb id
+            // one group formed around and the imdb id another group formed
+            // around. Collecting every distinct match (not just the first)
+            // is what lets them be fused instead of orphaning all but one:
+            // taking only the first match would leave the other group's only
+            // index entry overwritten by the re-index below, unreachable via
+            // `find` but still sitting in `#items` reporting stale presence.
+            const matches = [...new Set(keys.map(k => byKey.get(k)).filter((v): v is MergedItem => v !== undefined))];
 
-            if (existing === undefined) {
+            if (matches.length === 0) {
                 const created: MergedItem = { ...input, presence: 'arr_only' };
                 items.push(created);
                 for (const key of keys) byKey.set(key, created);
                 continue;
             }
 
-            mergeInto(existing, input);
-            // Re-index under every id the merge just learned, so a later record
-            // carrying only the newly-discovered id still finds this group.
-            for (const key of keysOf(existing.kind, existing.ids)) byKey.set(key, existing);
+            // One survivor absorbs the rest. mergeInto reads the *incoming*
+            // record's `acquisition` to decide whether its title wins, so
+            // fusing a loser this way still lets it win the title over the
+            // survivor if the loser is the one carrying acquisition.
+            const survivor = matches[0]!;
+            for (const loser of matches.slice(1)) {
+                mergeInto(survivor, loser);
+                const index = items.indexOf(loser);
+                if (index !== -1) items.splice(index, 1);
+            }
+            mergeInto(survivor, input);
+
+            // Re-index under every id the survivor now knows — from fused
+            // losers and from this input — so a later record carrying any of
+            // them still finds this one group, and no key is left pointing
+            // at a loser that no longer exists in `#items`.
+            for (const key of keysOf(survivor.kind, survivor.ids)) byKey.set(key, survivor);
         }
 
         for (const item of items) {

--- a/src/core/resolver.ts
+++ b/src/core/resolver.ts
@@ -1,0 +1,151 @@
+import type { ServiceId } from '../config/schema.ts';
+import { RANK_NONE, rankTitle } from './titleMatch.ts';
+
+export type ExternalIds = { tmdb?: number; tvdb?: number; imdb?: string };
+
+/**
+ * Named sources rather than a loose map: §8 lists exactly these, and a
+ * `Record<string, number>` accepts a source name that does not exist.
+ *
+ * A film populates some subset of the first five. A series populates `tvdb`
+ * and nothing else — §21.2 established that Sonarr's rating is one flat value,
+ * unrelated to Radarr's per-source map. The two never mix.
+ */
+export type MergedRatings = {
+    imdb?: number;
+    tmdb?: number;
+    rottenTomatoes?: number;
+    trakt?: number;
+    metacritic?: number;
+    tvdb?: number;
+};
+
+export type MergedItem = {
+    kind: 'movie' | 'series';
+    title: string;
+    year?: number;
+    /**
+     * Absent from §4.1's record and required by §5: `genre` is a `get_library`
+     * filter, and no other field in the merged shape could answer one.
+     * Recorded here as a correction to the design rather than bolted on in 3b.
+     */
+    genres?: string[];
+    ids: ExternalIds;
+    acquisition?: { service: ServiceId; monitored: boolean; hasFile: boolean; quality?: string; sizeBytes?: number };
+    playback?: { user: string; watched: boolean; playCount?: number; lastPlayed?: string };
+    ratings?: MergedRatings;
+    /**
+     * §8's diagnostic payload. `arr_only` **with a file** means a broken
+     * Jellyfin import; `jellyfin_only` means media nothing is managing.
+     * Neither is visible from any single service.
+     */
+    presence: 'both' | 'arr_only' | 'jellyfin_only';
+};
+
+export type IndexInput = Omit<MergedItem, 'presence'>;
+
+/**
+ * Namespaced so a film with tmdb 550 never merges with a series carrying
+ * tvdb 550 — unrelated id spaces that happen to collide numerically.
+ */
+const keysOf = (kind: MergedItem['kind'], ids: ExternalIds): string[] => {
+    const out: string[] = [];
+    if (ids.tmdb !== undefined) out.push(`${kind}:tmdb:${ids.tmdb}`);
+    if (ids.tvdb !== undefined) out.push(`${kind}:tvdb:${ids.tvdb}`);
+    if (ids.imdb !== undefined) out.push(`${kind}:imdb:${ids.imdb}`);
+    return out;
+};
+
+function mergeInto(target: MergedItem, input: IndexInput): void {
+    // The *arr title wins: it is the managed one, and the one a user sees in
+    // the service they would go and fix something in.
+    if (input.acquisition !== undefined || target.title === '') target.title = input.title;
+    // `exactOptionalPropertyTypes` forbids assigning a possibly-undefined value
+    // into an optional field, so the incoming value must be known-present.
+    if (target.year === undefined && input.year !== undefined) target.year = input.year;
+    if (target.genres === undefined && input.genres !== undefined) target.genres = input.genres;
+
+    target.ids = { ...target.ids, ...input.ids };
+    if (input.acquisition !== undefined) target.acquisition = input.acquisition;
+    if (input.playback !== undefined) target.playback = input.playback;
+    if (input.ratings !== undefined) target.ratings = { ...target.ratings, ...input.ratings };
+}
+
+/**
+ * §8's shared join. Records merge when **any** strong id matches, which is what
+ * handles Radarr knowing only `tmdbId` while Jellyfin knows only `Imdb`.
+ *
+ * Records sharing no id stay separate. That is correct rather than lossy:
+ * absent a shared identifier there is no evidence they are the same item, and
+ * merging on title similarity is how a remake gets fused with its original.
+ */
+export class LibraryIndex {
+    readonly #items: MergedItem[];
+    readonly #byKey: Map<string, MergedItem>;
+
+    private constructor(items: MergedItem[], byKey: Map<string, MergedItem>) {
+        this.#items = items;
+        this.#byKey = byKey;
+    }
+
+    static build(inputs: readonly IndexInput[]): LibraryIndex {
+        const byKey = new Map<string, MergedItem>();
+        const items: MergedItem[] = [];
+
+        for (const input of inputs) {
+            const keys = keysOf(input.kind, input.ids);
+            const existing = keys.map(k => byKey.get(k)).find(v => v !== undefined);
+
+            if (existing === undefined) {
+                const created: MergedItem = { ...input, presence: 'arr_only' };
+                items.push(created);
+                for (const key of keys) byKey.set(key, created);
+                continue;
+            }
+
+            mergeInto(existing, input);
+            // Re-index under every id the merge just learned, so a later record
+            // carrying only the newly-discovered id still finds this group.
+            for (const key of keysOf(existing.kind, existing.ids)) byKey.set(key, existing);
+        }
+
+        for (const item of items) {
+            item.presence =
+                item.acquisition !== undefined && item.playback !== undefined
+                    ? 'both'
+                    : item.acquisition !== undefined
+                      ? 'arr_only'
+                      : 'jellyfin_only';
+        }
+
+        return new LibraryIndex(items, byKey);
+    }
+
+    /** Undefined for an empty id set: no id is not a wildcard. */
+    find(ids: ExternalIds): MergedItem | undefined {
+        for (const kind of ['movie', 'series'] as const) {
+            for (const key of keysOf(kind, ids)) {
+                const hit = this.#byKey.get(key);
+                if (hit !== undefined) return hit;
+            }
+        }
+        return undefined;
+    }
+
+    /** Ranked by relevance, non-matches excluded rather than ranked last. */
+    search(query: string): MergedItem[] {
+        return this.#items
+            .map(item => ({ item, rank: rankTitle(item.title, query) }))
+            .filter(({ rank }) => rank !== RANK_NONE)
+            .sort((a, b) => a.rank - b.rank || a.item.title.localeCompare(b.item.title))
+            .map(({ item }) => item);
+    }
+
+    all(): MergedItem[] {
+        return this.#items;
+    }
+
+    size(): number {
+        return this.#items.length;
+    }
+}

--- a/test/resolver.test.ts
+++ b/test/resolver.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'vitest';
+import { LibraryIndex, type IndexInput } from '../src/core/resolver.ts';
+
+const arr = (over: Partial<IndexInput> = {}): IndexInput => ({
+    kind: 'movie',
+    title: 'Some Film',
+    year: 2026,
+    ids: { tmdb: 550 },
+    acquisition: { service: 'radarr', monitored: true, hasFile: true },
+    ...over
+});
+
+const jelly = (over: Partial<IndexInput> = {}): IndexInput => ({
+    kind: 'movie',
+    title: 'Some Film',
+    year: 2026,
+    ids: { tmdb: 550 },
+    playback: { user: 'Bartus', watched: true },
+    ...over
+});
+
+describe('LibraryIndex merging', () => {
+    it('merges an *arr and a Jellyfin record sharing a tmdb id', () => {
+        const index = LibraryIndex.build([arr(), jelly()]);
+
+        expect(index.size()).toBe(1);
+        const item = index.find({ tmdb: 550 });
+        expect(item?.acquisition?.service).toBe('radarr');
+        expect(item?.playback?.watched).toBe(true);
+        expect(item?.presence).toBe('both');
+    });
+
+    it('merges series on tvdb', () => {
+        const index = LibraryIndex.build([
+            arr({ kind: 'series', ids: { tvdb: 292157 }, acquisition: { service: 'sonarr', monitored: true, hasFile: true } }),
+            jelly({ kind: 'series', ids: { tvdb: 292157 } })
+        ]);
+
+        expect(index.size()).toBe(1);
+        expect(index.find({ tvdb: 292157 })?.presence).toBe('both');
+    });
+
+    it('merges on imdb when that is the only shared id', () => {
+        // Radarr knows tmdb and imdb; Jellyfin knows only imdb.
+        const index = LibraryIndex.build([
+            arr({ ids: { tmdb: 550, imdb: 'tt0137523' } }),
+            jelly({ ids: { imdb: 'tt0137523' } })
+        ]);
+
+        expect(index.size()).toBe(1);
+        expect(index.find({ tmdb: 550 })?.presence).toBe('both');
+        expect(index.find({ imdb: 'tt0137523' })?.presence).toBe('both');
+    });
+
+    it('keeps records with no shared id separate', () => {
+        // No evidence they are the same item. Merging on title similarity is
+        // how a remake gets fused with its original.
+        const index = LibraryIndex.build([arr({ ids: { tmdb: 550 } }), jelly({ ids: { tmdb: 999 } })]);
+        expect(index.size()).toBe(2);
+    });
+
+    it('does not merge a film with a series that shares an id number', () => {
+        // tmdb 550 and tvdb 550 are unrelated namespaces.
+        const index = LibraryIndex.build([
+            arr({ kind: 'movie', ids: { tmdb: 550 } }),
+            arr({ kind: 'series', ids: { tvdb: 550 } })
+        ]);
+        expect(index.size()).toBe(2);
+    });
+
+    it('finds a merged item by any of its ids', () => {
+        const index = LibraryIndex.build([arr({ ids: { tmdb: 550, imdb: 'tt0137523' } }), jelly({ ids: { imdb: 'tt0137523' } })]);
+
+        expect(index.find({ tmdb: 550 })).toBeDefined();
+        expect(index.find({ imdb: 'tt0137523' })).toBeDefined();
+        expect(index.find({ tmdb: 111 })).toBeUndefined();
+    });
+
+    it('returns undefined for an empty id set rather than an arbitrary item', () => {
+        const index = LibraryIndex.build([arr()]);
+        expect(index.find({})).toBeUndefined();
+    });
+});
+
+describe('LibraryIndex presence', () => {
+    it('classifies an *arr-only item', () => {
+        expect(LibraryIndex.build([arr()]).find({ tmdb: 550 })?.presence).toBe('arr_only');
+    });
+
+    it('classifies a Jellyfin-only item', () => {
+        expect(LibraryIndex.build([jelly()]).find({ tmdb: 550 })?.presence).toBe('jellyfin_only');
+    });
+
+    it('classifies a merged item as both', () => {
+        expect(LibraryIndex.build([arr(), jelly()]).find({ tmdb: 550 })?.presence).toBe('both');
+    });
+
+    it('is what makes a broken import visible', () => {
+        // arr_only *with a file* is the signature §8 calls out: the *arr
+        // believes the file is on disk and Jellyfin cannot see it.
+        const item = LibraryIndex.build([arr({ acquisition: { service: 'radarr', monitored: true, hasFile: true } })]).find({ tmdb: 550 });
+
+        expect(item?.presence).toBe('arr_only');
+        expect(item?.acquisition?.hasFile).toBe(true);
+    });
+});
+
+describe('LibraryIndex merge details', () => {
+    it('prefers the *arr title, which is the managed one', () => {
+        const index = LibraryIndex.build([
+            arr({ title: 'Some Film' }),
+            jelly({ title: 'Some Film (Director&apos;s Cut)' })
+        ]);
+        expect(index.find({ tmdb: 550 })?.title).toBe('Some Film');
+    });
+
+    it('takes a year from whichever record has one', () => {
+        // `exactOptionalPropertyTypes` distinguishes "absent" from "present but
+        // undefined", so blanking out the default's year needs a real `delete`
+        // (an absent key) rather than `{ year: undefined }` (which the type
+        // system rejects as an explicit-undefined value for a `number` field).
+        const arrWithoutYear = arr();
+        delete (arrWithoutYear as { year?: number }).year;
+
+        const index = LibraryIndex.build([arrWithoutYear, jelly({ year: 2026 })]);
+        expect(index.find({ tmdb: 550 })?.year).toBe(2026);
+    });
+
+    it('unions ids across both halves', () => {
+        const index = LibraryIndex.build([arr({ ids: { tmdb: 550 } }), jelly({ ids: { tmdb: 550, imdb: 'tt0137523' } })]);
+        expect(index.find({ tmdb: 550 })?.ids).toEqual({ tmdb: 550, imdb: 'tt0137523' });
+    });
+
+    it('keeps ratings from the record that has them', () => {
+        const index = LibraryIndex.build([arr({ ratings: { imdb: 8.8 } }), jelly()]);
+        expect(index.find({ tmdb: 550 })?.ratings).toEqual({ imdb: 8.8 });
+    });
+
+    it('takes genres from whichever record has them, since get_library filters on them', () => {
+        const index = LibraryIndex.build([arr({ genres: ['Science Fiction'] }), jelly()]);
+        expect(index.find({ tmdb: 550 })?.genres).toEqual(['Science Fiction']);
+    });
+});
+
+describe('LibraryIndex search', () => {
+    const index = LibraryIndex.build([
+        arr({ title: 'The Matrix', ids: { tmdb: 1 } }),
+        arr({ title: 'Matrix Reloaded', ids: { tmdb: 2 } }),
+        arr({ title: 'Enter the Matrix', ids: { tmdb: 3 } }),
+        arr({ title: 'Blade Runner', ids: { tmdb: 4 } })
+    ]);
+
+    it('ranks exact above prefix above substring', () => {
+        expect(index.search('matrix').map(i => i.title)).toEqual([
+            'The Matrix',
+            'Matrix Reloaded',
+            'Enter the Matrix'
+        ]);
+    });
+
+    it('excludes non-matches rather than ranking them last', () => {
+        expect(index.search('matrix').some(i => i.title === 'Blade Runner')).toBe(false);
+    });
+
+    it('returns an empty list for a query matching nothing', () => {
+        expect(index.search('zzzz')).toEqual([]);
+    });
+
+    it('matches through a leading article the caller omitted', () => {
+        expect(index.search('the matrix')[0]?.title).toBe('The Matrix');
+    });
+});
+
+describe('LibraryIndex.all', () => {
+    it('returns every merged item once', () => {
+        const index = LibraryIndex.build([arr(), jelly(), arr({ ids: { tmdb: 999 } })]);
+        expect(index.all()).toHaveLength(2);
+    });
+
+    it('handles an empty input', () => {
+        const index = LibraryIndex.build([]);
+        expect(index.all()).toEqual([]);
+        expect(index.size()).toBe(0);
+    });
+});

--- a/test/resolver.test.ts
+++ b/test/resolver.test.ts
@@ -76,6 +76,31 @@ describe('LibraryIndex merging', () => {
         expect(index.find({ tmdb: 111 })).toBeUndefined();
     });
 
+    it('fuses two already-separate groups when a later record bridges them on different ids', () => {
+        // A Radarr record known only by tmdb, a duplicate Jellyfin library
+        // copy known only by imdb — no shared id yet, so they form two
+        // groups — and a second Jellyfin copy that carries both ids. That
+        // third record cannot be reconciled with only one of the two
+        // existing groups: keeping the first match and discarding the
+        // second would silently orphan it (still counted in `all()`, no
+        // longer reachable by its own id, `presence` computed from half
+        // the evidence). Both groups must fuse into one.
+        const index = LibraryIndex.build([
+            arr({ ids: { tmdb: 1 } }),
+            jelly({ ids: { imdb: 'tt9' } }),
+            jelly({ ids: { tmdb: 1, imdb: 'tt9' } })
+        ]);
+
+        expect(index.size()).toBe(1);
+        expect(index.all()).toHaveLength(1);
+
+        const byTmdb = index.find({ tmdb: 1 });
+        const byImdb = index.find({ imdb: 'tt9' });
+        expect(byTmdb).toBeDefined();
+        expect(byTmdb).toBe(byImdb);
+        expect(byTmdb?.presence).toBe('both');
+    });
+
     it('returns undefined for an empty id set rather than an arbitrary item', () => {
         const index = LibraryIndex.build([arr()]);
         expect(index.find({})).toBeUndefined();
@@ -110,6 +135,20 @@ describe('LibraryIndex merge details', () => {
         const index = LibraryIndex.build([
             arr({ title: 'Some Film' }),
             jelly({ title: 'Some Film (Director&apos;s Cut)' })
+        ]);
+        expect(index.find({ tmdb: 550 })?.title).toBe('Some Film');
+    });
+
+    it('prefers the *arr title even when the Jellyfin record merges in first', () => {
+        // The test above feeds arr() first, so its title is already correct
+        // before jelly() merges in — that passes through mergeInto's no-op
+        // branch (`target.title === ''` is false) and would still pass even
+        // if the *arr-wins rule were deleted. Reversing the input order is
+        // what actually exercises the rule: only mergeInto reading `input`'s
+        // `acquisition` can make the second, *arr record's title win here.
+        const index = LibraryIndex.build([
+            jelly({ title: "Some Film (Director's Cut)" }),
+            arr({ title: 'Some Film' })
         ]);
         expect(index.find({ tmdb: 550 })?.title).toBe('Some Film');
     });


### PR DESCRIPTION
Phase 3a, Task 3 of 6 — the join the phase exists for. Radarr and Sonarr know what you have *acquired*; Jellyfin knows what you have *watched*. Neither knows about the other.

One shared module rather than per-tool logic, because `get_library`, `get_media_details` and `diagnose` all need the same join and duplicating it is how joins drift apart.

## How it merges

Records merge when **any** strong external id matches — that is what handles Radarr knowing only `tmdbId` while Jellyfin knows only `Imdb`. Records sharing no id stay separate: absent a shared identifier there is no evidence they are the same item, and merging on title similarity is how a remake gets fused with its original. Keys are namespaced by kind, so a film with `tmdb: 550` never merges with a series carrying `tvdb: 550`.

Measured on a live stack, the join is not a gamble: 250/250 films carry `tmdbId`, 134/134 series carry `tvdbId`, `imdbId` covers 98%/100%.

`presence` is the payload none of this exists without — `arr_only` **with a file** means a broken Jellyfin import, `jellyfin_only` means media nothing is managing.

## A bug review caught, worth naming

The first implementation took only the **first** matching group when an incoming record matched two. It merged into that one and then re-indexed over the second group's key — leaving the second group unreachable but still in the items array. `size()` and `all()` overcounted, two records claimed the same external id, and the orphan reported a `presence` computed from half the evidence: a fabricated "media nothing is managing" for an item Radarr *is* managing.

Reachable on exactly the partial-id sets that motivate the any-id join — a Radarr entry with only `tmdbId`, a Jellyfin entry with only `Imdb`, and a duplicate Jellyfin copy carrying both.

`build` now collects every matching group and fuses them: losers merge into a survivor, are spliced out, and the full key union is re-indexed. Verified against 3-group inputs and reordered inputs — the survivor is chosen by key type, not arrival order, so the same library gives the same answer regardless of adapter ordering.

A second test was rewritten for the same reason as Task 2's: the *arr-title-wins rule was asserted only by the code that produced it, and deleting the rule left the test green.

**468 tests**, up from 444.

🤖 Generated with [Claude Code](https://claude.com/claude-code)