### PR TITLE
fix: capture Jellyfin search the way the adapter actually calls it

### DIFF
--- a/scripts/capture-fixtures.ts
+++ b/scripts/capture-fixtures.ts
@@ -189,7 +189,10 @@ const ENDPOINTS: Record<ServiceId, Endpoint[]> = {
         { name: 'sessions', path: '/Sessions' },
         {
             name: 'items-search',
-            path: '/Items?searchTerm=a&Recursive=true&IncludeItemTypes=Movie,Series&Limit=5'
+            // Must match what JellyfinAdapter.search actually requests. Without
+            // Fields, Jellyfin returns no ProviderIds at all — which is exactly
+            // what the resolver joins on.
+            path: '/Items?searchTerm=a&Recursive=true&IncludeItemTypes=Movie,Series&Limit=5&Fields=ProviderIds'
         }
     ],
     seerr: [

--- a/test/contract.test.ts
+++ b/test/contract.test.ts
@@ -150,7 +150,14 @@ const CONTRACTS: Record<string, ServiceContract> = {
             { fixture: 'test/fixtures/jellyfin/users.json', fields: ['Id', 'Name'] },
             { fixture: 'test/fixtures/jellyfin/scheduled-tasks.json', fields: ['Key', 'State', 'LastExecutionResult'] },
             { fixture: 'test/fixtures/jellyfin/sessions.json', fields: ['UserId', 'PlayState'] },
-            { fixture: 'test/fixtures/jellyfin/items-search.json', fields: ['Items'] }
+            { fixture: 'test/fixtures/jellyfin/items-search.json', fields: ['Items'] },
+            {
+                // Only assertable now that the capture requests Fields=ProviderIds.
+                // The resolver joins on these; an upstream change here breaks the
+                // three-way join silently.
+                fixture: 'test/fixtures/jellyfin/items-search.json',
+                fields: ['Items.Id', 'Items.Name', 'Items.ProviderIds']
+            }
         ]
     },
     seerr: {

--- a/test/fixtures/jellyfin/items-search.json
+++ b/test/fixtures/jellyfin/items-search.json
@@ -13,6 +13,10 @@
       "CommunityRating": 7.096,
       "RunTimeTicks": 84472920000,
       "ProductionYear": 2024,
+      "ProviderIds": {
+        "Imdb": "tt11563598",
+        "Tmdb": "661539"
+      },
       "IsFolder": false,
       "Type": "Movie",
       "VideoType": "VideoFile",
@@ -54,6 +58,10 @@
       "CommunityRating": 6.45,
       "RunTimeTicks": 69041250000,
       "ProductionYear": 2025,
+      "ProviderIds": {
+        "Imdb": "tt32376165",
+        "Tmdb": "1290159"
+      },
       "IsFolder": false,
       "Type": "Movie",
       "VideoType": "VideoFile",
@@ -91,6 +99,13 @@
       "ChannelId": null,
       "RunTimeTicks": 19800000000,
       "ProductionYear": 2026,
+      "ProviderIds": {
+        "Imdb": "tt27497448",
+        "Tmdb": "224372",
+        "Tvdb": "433631",
+        "TvdbCollection": "7038;",
+        "TvdbSlug": "a-knight-of-the-seven-kingdoms-the-hedge-knight"
+      },
       "IsFolder": true,
       "Type": "Series",
       "Status": "Continuing",
@@ -135,6 +150,10 @@
       "CommunityRating": 6.2,
       "RunTimeTicks": 73274240000,
       "ProductionYear": 2025,
+      "ProviderIds": {
+        "Imdb": "tt33474172",
+        "Tmdb": "1397832"
+      },
       "IsFolder": false,
       "Type": "Movie",
       "VideoType": "VideoFile",
@@ -171,6 +190,12 @@
       "ChannelId": null,
       "RunTimeTicks": 31800000000,
       "ProductionYear": 2024,
+      "ProviderIds": {
+        "Imdb": "tt33079160",
+        "Tmdb": "261034",
+        "Tvdb": "452965",
+        "TvdbSlug": "american-murder-laci-peterson"
+      },
       "IsFolder": true,
       "Type": "Series",
       "Status": "Ended",


### PR DESCRIPTION
Phase 3a, Task 4 of 6.

`JellyfinAdapter.search` requests `Fields=ProviderIds` — without it Jellyfin omits provider ids from search results **entirely**, which is how 0.3.0 shipped a search returning no external ids at all. The capture endpoint never asked for that field, so the recorded fixture had no `ProviderIds` key on any item: fixture and adapter silently disagreed, and the contract test could not guard the one field the identity resolver joins on.

Recaptured against a live Jellyfin 10.11.11. All five items now carry populated provider ids, and the contract test asserts them.

The recapture also confirms a detail that matters: Jellyfin returns these ids as **strings** (`"661539"`) where Radarr and Sonarr use numbers. The adapter's boundary conversion is what stops every join failing silently, and until now no fixture could have caught it regressing.

`Limit=5` in the capture path is deliberate and stays — it bounds the size of a committed fixture. The defect class this fixes is a mismatch in which *fields* come back, not how many items.

Running the capture also rewrote 17 unrelated fixtures where live data had simply moved on. Those were reverted to keep this commit to what it says it does; the fixture diff here adds `ProviderIds` blocks and nothing else.

**469 tests.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)