### PR TITLE
fix: produce VersionUnsupported, which nothing could reach

### DIFF
--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -1,5 +1,6 @@
 import type { ServiceId } from '../config/schema.ts';
 import { ServiceError, type ServiceErrorKind } from '../core/errors.ts';
+import { assertVersionSupported } from './versions.ts';
 
 /**
  * A diagnosis, not a boolean (design spec §6/§14). A connection test that
@@ -286,6 +287,12 @@ export async function diagnoseConnection(
     const started = performance.now();
     try {
         const version = await probe();
+        // §14: a connection test distinguishes version-too-old from every other
+        // failure. Checked here rather than in each adapter, so no adapter can
+        // forget — and after the probe, so an unreachable service reports being
+        // unreachable rather than being the wrong version.
+        if (version !== undefined) assertVersionSupported(id, version);
+
         const diagnosis: ConnectionDiagnosis = {
             ok: true,
             service: id,

--- a/src/services/versions.ts
+++ b/src/services/versions.ts
@@ -1,0 +1,71 @@
+import type { ServiceId } from '../config/schema.ts';
+import { ServiceError } from '../core/errors.ts';
+
+/**
+ * Minimum supported version per service.
+ *
+ * **These are judgement calls about which releases this project supports**, not
+ * facts any capture can settle. They are set conservatively below the versions
+ * on the stack this was developed against — Radarr 6.3.0, Sonarr 4.0.19,
+ * Prowlarr 2.5.2, Bazarr 1.6.0, Jellyfin 10.11.11, Seerr 3.4.1, SABnzbd 5.0.4,
+ * Transmission 4.1.3 — at the point where the API surface we use stabilised.
+ *
+ * Expect to argue with them. Raising one is a breaking change for somebody.
+ */
+export const MINIMUM_VERSIONS: Record<ServiceId, string> = {
+    // v3 API and the diskspace/health/task endpoints as we read them.
+    radarr: '4.0.0',
+    sonarr: '4.0.0',
+    // v1 API; Prowlarr never had a v3.
+    prowlarr: '1.0.0',
+    // `{ data: … }` envelope on /api/system/status.
+    bazarr: '1.4.0',
+    // /ScheduledTasks with LastExecutionResult, and Fields=ProviderIds.
+    jellyfin: '10.8.0',
+    // Seerr forked from Overseerr in February 2026; 1.0 is its first release.
+    seerr: '1.0.0',
+    // output=json on the query-parameter API.
+    sabnzbd: '3.0.0',
+    // RPC session handshake and download-dir-free-space.
+    transmission: '3.0.0'
+};
+
+/** Digits only; a build suffix such as Transmission's "(838877323f)" is dropped. */
+export function parseVersion(raw: string): number[] | undefined {
+    const match = /(\d+(?:\.\d+)*)/.exec(raw.trim().replace(/^v/i, ''));
+    if (match?.[1] === undefined) return undefined;
+    return match[1].split('.').map(Number);
+}
+
+/** Numeric per part — a string compare would put "10" below "9". */
+export function compareVersions(a: number[], b: number[]): number {
+    const length = Math.max(a.length, b.length);
+    for (let i = 0; i < length; i += 1) {
+        const diff = (a[i] ?? 0) - (b[i] ?? 0);
+        if (diff !== 0) return diff;
+    }
+    return 0;
+}
+
+/**
+ * Design spec §14 requires connection tests to distinguish version-too-old
+ * alongside DNS failure, connection refused and a bad key. This is what finally
+ * produces `VersionUnsupported`, which had been in the taxonomy since Phase 1
+ * with nothing able to reach it.
+ */
+export function assertVersionSupported(service: ServiceId, raw: string): void {
+    const floor = MINIMUM_VERSIONS[service];
+    const actual = parseVersion(raw);
+    const minimum = parseVersion(floor);
+
+    // An unparseable version is not evidence of an old one. Refusing to talk to
+    // the service would be worse than the uncertainty, and its own reads will
+    // fail loudly and specifically if the version really is too old.
+    if (actual === undefined || minimum === undefined) return;
+
+    if (compareVersions(actual, minimum) < 0) {
+        throw new ServiceError('VersionUnsupported', service, `reports version ${raw}`, {
+            remedy: `arr-mcp needs ${service} ${floor} or newer. Upgrade the service, or pin an older arr-mcp.`
+        });
+    }
+}

--- a/test/adapters.test.ts
+++ b/test/adapters.test.ts
@@ -5,6 +5,7 @@ import type { KeyedServiceConfig, MultiUserServiceConfig, TransmissionServiceCon
 import { BazarrAdapter } from '../src/services/bazarr.ts';
 import { JellyfinAdapter } from '../src/services/jellyfin.ts';
 import { ProwlarrAdapter } from '../src/services/prowlarr.ts';
+import { RadarrAdapter } from '../src/services/radarr.ts';
 import { SabnzbdAdapter } from '../src/services/sabnzbd.ts';
 import { SeerrAdapter } from '../src/services/seerr.ts';
 import { SonarrAdapter } from '../src/services/sonarr.ts';
@@ -357,4 +358,23 @@ describe('TransmissionAdapter', () => {
     });
 
     expectsAuthDiagnosis(new TransmissionAdapter(transmissionConfig, unauthorized));
+});
+
+describe('version floors', () => {
+    it('reports a below-floor service as VersionUnsupported rather than healthy', async () => {
+        const ancient = (async () => jsonResponse({ appName: 'Radarr', version: '3.0.0.1234' })) as unknown as typeof fetch;
+        const d = await new RadarrAdapter(keyed(7878), ancient).testConnection();
+
+        expect(d.ok).toBe(false);
+        expect(d.error?.kind).toBe('VersionUnsupported');
+        expect(d.error?.remedy).toMatch(/upgrade/i);
+    });
+
+    it('still reports a supported version as healthy', async () => {
+        const current = (async () => jsonResponse({ appName: 'Radarr', version: '6.3.0.10514' })) as unknown as typeof fetch;
+        const d = await new RadarrAdapter(keyed(7878), current).testConnection();
+
+        expect(d.ok).toBe(true);
+        expect(d.version).toBe('6.3.0.10514');
+    });
 });

--- a/test/versions.test.ts
+++ b/test/versions.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import type { ServiceError } from '../src/core/errors.ts';
+import { MINIMUM_VERSIONS, assertVersionSupported, compareVersions, parseVersion } from '../src/services/versions.ts';
+
+const rejection = (fn: () => void): ServiceError => {
+    try {
+        fn();
+        throw new Error('expected a throw');
+    } catch (err) {
+        return err as ServiceError;
+    }
+};
+
+describe('parseVersion', () => {
+    it('parses a plain dotted version', () => {
+        expect(parseVersion('4.0.19')).toEqual([4, 0, 19]);
+    });
+
+    it('parses an *arr four-part version', () => {
+        expect(parseVersion('6.3.0.10514')).toEqual([6, 3, 0, 10514]);
+    });
+
+    it('ignores a build suffix, which Transmission reports', () => {
+        // A live Transmission returns "4.1.3 (838877323f)".
+        expect(parseVersion('4.1.3 (838877323f)')).toEqual([4, 1, 3]);
+    });
+
+    it('ignores a leading v', () => {
+        expect(parseVersion('v1.6.0')).toEqual([1, 6, 0]);
+    });
+
+    it('returns undefined for something that is not a version', () => {
+        expect(parseVersion('unknown')).toBeUndefined();
+        expect(parseVersion('')).toBeUndefined();
+    });
+});
+
+describe('compareVersions', () => {
+    it('orders by the first differing part', () => {
+        expect(compareVersions([4, 1, 0], [4, 0, 9])).toBeGreaterThan(0);
+        expect(compareVersions([3, 9, 9], [4, 0, 0])).toBeLessThan(0);
+    });
+
+    it('treats a missing trailing part as zero', () => {
+        expect(compareVersions([4, 0], [4, 0, 0])).toBe(0);
+        expect(compareVersions([4, 0, 1], [4, 0])).toBeGreaterThan(0);
+    });
+
+    it('compares numerically, not lexically', () => {
+        // The bug a string compare would produce: "10" < "9".
+        expect(compareVersions([1, 10], [1, 9])).toBeGreaterThan(0);
+    });
+});
+
+describe('assertVersionSupported', () => {
+    it('accepts a version above the floor', () => {
+        expect(() => assertVersionSupported('radarr', '6.3.0.10514')).not.toThrow();
+    });
+
+    it('accepts a version exactly at the floor', () => {
+        expect(() => assertVersionSupported('radarr', MINIMUM_VERSIONS.radarr)).not.toThrow();
+    });
+
+    it('rejects a version below the floor as VersionUnsupported', () => {
+        const err = rejection(() => assertVersionSupported('radarr', '3.0.0.0'));
+        expect(err.kind).toBe('VersionUnsupported');
+        expect(err.service).toBe('radarr');
+    });
+
+    it('names both versions in the remedy, so the fix is obvious', () => {
+        const err = rejection(() => assertVersionSupported('radarr', '3.0.0.0'));
+        expect(err.remedy).toContain(MINIMUM_VERSIONS.radarr);
+        expect(err.detail).toContain('3.0.0.0');
+    });
+
+    it('accepts an unparseable version rather than blocking on it', () => {
+        // A service that reports something we cannot parse is not evidence of
+        // an old version, and refusing to talk to it would be worse than the
+        // uncertainty. The adapter's own reads will fail loudly if it is wrong.
+        expect(() => assertVersionSupported('bazarr', 'nightly')).not.toThrow();
+    });
+
+    it('has a floor for every service', () => {
+        const services = ['radarr', 'sonarr', 'prowlarr', 'bazarr', 'jellyfin', 'seerr', 'sabnzbd', 'transmission'];
+        for (const s of services) expect(MINIMUM_VERSIONS[s as keyof typeof MINIMUM_VERSIONS]).toBeTruthy();
+    });
+});


### PR DESCRIPTION
Phase 3a, Task 5 of 6.

`VersionUnsupported` has been in the error taxonomy since Phase 1, and the design requires connection tests to distinguish "your service is too old" from every other failure. **No code path has ever produced it** — the error kind was unreachable. This closes that.

The check lives in `diagnoseConnection`, the shared implementation all eight adapters' `testConnection` already route through. Placed in each adapter, an adapter can forget. It runs *after* the probe resolves, so a service that is unreachable **and** below its floor reports being unreachable — which is the failure you can actually act on.

**An unparseable version passes.** A service reporting something we cannot parse is not evidence of an old version, and refusing to talk to it would be worse than the uncertainty — its own reads will fail loudly and specifically if the version really is too old.

**The floors are judgement calls, not facts**, and are expected to be argued with — raising one is a breaking change for somebody. Each sits conservatively below the corresponding version on the reference stack:

| | floor | reference stack |
|---|---|---|
| Radarr / Sonarr | 4.0.0 | 6.3.0 / 4.0.19 |
| Prowlarr | 1.0.0 | 2.5.2 |
| Bazarr | 1.4.0 | 1.6.0 |
| Jellyfin | 10.8.0 | 10.11.11 |
| Seerr | 1.0.0 | 3.4.1 |
| SABnzbd | 3.0.0 | 5.0.4 |
| Transmission | 3.0.0 | 4.1.3 |

Version strings are compared numerically per part — a string compare would rank `1.10` below `1.9` — and a build suffix is dropped, because Transmission reports `"4.1.3 (838877323f)"`.

No pre-existing test was modified: the diff to `test/adapters.test.ts` is purely additive.

**485 tests**, up from 469.

🤖 Generated with [Claude Code](https://claude.com/claude-code)