### PR TITLE
chore: configure Renovate, grouped and monthly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,17 @@ npm run typecheck  # tsc --noEmit
 npm test           # vitest
 ```
 
+## Dependencies
+
+Renovate opens one grouped PR a month for non-major updates, and immediate PRs
+for security advisories. Two things it deliberately will not do on its own:
+
+- **TypeScript** is pinned with `~` because `typescript-eslint` declares a peer
+  range it has to stay inside. A major bump silently disables linting, so it is
+  a human decision.
+- **Node majors** touch the Dockerfile, the CI workflow and `engines` together,
+  so they wait for approval on the dependency dashboard.
+
 ## Commit messages
 
 [Conventional Commits](https://www.conventionalcommits.org/) — release-please

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "schedule": ["before 5am on the first day of the month"],
+  "timezone": "Europe/Amsterdam",
+  "labels": ["dependencies"],
+  "prConcurrentLimit": 3,
+  "packageRules": [
+    {
+      "description": "One PR for all non-major updates. A solo maintainer reviewing eight separate patch bumps is eight chances to rubber-stamp one.",
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "non-major dependencies"
+    },
+    {
+      "description": "TypeScript is pinned with ~ because typescript-eslint declares a peer range it must stay inside. A major bump here silently disables linting, so it needs a human.",
+      "matchPackageNames": ["typescript"],
+      "enabled": false
+    },
+    {
+      "description": "Node major bumps touch the Dockerfile, CI and engines together.",
+      "matchPackageNames": ["node", "@types/node"],
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "labels": ["security"],
+    "schedule": ["at any time"]
+  }
+}


### PR DESCRIPTION
Phase 3a, Task 6 of 6 — the last foundations task.

Held during Phase 2 because a bot rewriting `package-lock.json` against 31 short-lived branches is a rebase loop. Phase 2 is merged, so that reason has expired.

One grouped PR a month for non-major updates — a solo maintainer reviewing eight separate patch bumps is eight chances to rubber-stamp one. Security advisories bypass the schedule entirely.

Two dependencies are deliberately excluded from automation:

- **TypeScript** is pinned with `~` to stay inside the peer range `typescript-eslint` declares. A bump there would silently disable linting, which is the worst kind of green build — so the rule blocks *every* update type for it, not just majors.
- **Node majors** touch the Dockerfile, the CI workflow and `engines` together, so they wait for approval on the dependency dashboard.

`renovate.json` is a root JSON file, which means the encoding guard now covers it automatically — verified that `rootJsonFiles()` discovers by directory read rather than a hardcoded list, so this is genuinely guarded and not just assumed to be. That guard exists because a BOM in `package.json` once broke a release: npm and tsc tolerate it, `JSON.parse` does not, so everything looks green until the moment it matters.

`renovate-config-validator`: **Config validated successfully.**

**485 tests**, unchanged — this task adds no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)