### PR TITLE
fix: close the findings from Phase 3a's whole-phase review

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,12 +27,17 @@ npm test           # vitest
 
 ## Dependencies
 
-Renovate opens one grouped PR a month for non-major updates, and immediate PRs
-for security advisories. Two things it deliberately will not do on its own:
+Renovate runs monthly, plus immediate PRs for security advisories. Only one
+rule groups updates — non-major bumps land as a single PR — so a **major**
+bump of any dependency other than TypeScript or Node arrives as its own PR,
+same monthly schedule, up to `prConcurrentLimit: 3`. The cadence is monthly;
+it is the "one PR" part that stops being true once a major is involved. Two
+things Renovate deliberately will not do on its own:
 
 - **TypeScript** is pinned with `~` because `typescript-eslint` declares a peer
-  range it has to stay inside. A major bump silently disables linting, so it is
-  a human decision.
+  range it has to stay inside, and `renovate.json` disables Renovate for that
+  package outright — not only for majors. A TypeScript patch will never be
+  proposed either; bumping it, of any kind, is a human decision.
 - **Node majors** touch the Dockerfile, the CI workflow and `engines` together,
   so they wait for approval on the dependency dashboard.
 

--- a/README.md
+++ b/README.md
@@ -120,9 +120,24 @@ releases.
 
 ## Requirements
 
-- A LAN-reachable install of at least one supported service
+- A LAN-reachable install of at least one supported service, at or above its minimum version
 - Docker, or Node 24+ to run from source
 - An MCP client speaking protocol revision `2026-07-28`
+
+| Service | Minimum |
+| --- | --- |
+| Radarr | 4.0.0 |
+| Sonarr | 4.0.0 |
+| Prowlarr | 1.0.0 |
+| Bazarr | 1.4.0 |
+| Jellyfin | 10.8.0 |
+| Seerr | 1.0.0 |
+| SABnzbd | 3.0.0 |
+| Transmission | 3.0.0 |
+
+A service below its floor is reported unhealthy — no disk space, no failing
+health checks, no scan state, not just a version complaint — and
+contributes nothing to `stack_health` until it is upgraded.
 
 ## Security
 

--- a/src/core/cache.ts
+++ b/src/core/cache.ts
@@ -53,7 +53,8 @@ export class TtlCache {
 
     /**
      * The seam for write-invalidation (§16). As of Phase 3a, still nothing in
-     * this tree calls it — the original "nothing calls it until 0.5" was a
+     * production code calls it (only `test/cache.test.ts` exercises it
+     * directly) — the original "nothing calls it until 0.5" was a
      * prediction, not yet a fact this codebase can back up: the earliest
      * planned caller is Phase 3b's library loader, invalidating on every
      * degraded load so a partial library snapshot is not cached for the full

--- a/src/core/cache.ts
+++ b/src/core/cache.ts
@@ -51,7 +51,14 @@ export class TtlCache {
         }
     }
 
-    /** The seam for write-invalidation (§16). Nothing calls it until 0.5. */
+    /**
+     * The seam for write-invalidation (§16). As of Phase 3a, still nothing in
+     * this tree calls it — the original "nothing calls it until 0.5" was a
+     * prediction, not yet a fact this codebase can back up: the earliest
+     * planned caller is Phase 3b's library loader, invalidating on every
+     * degraded load so a partial library snapshot is not cached for the full
+     * five-minute TTL. That is well before 0.5 (writes), not at it.
+     */
     invalidate(key: string): void {
         this.#entries.delete(key);
     }

--- a/src/core/resolver.ts
+++ b/src/core/resolver.ts
@@ -110,7 +110,19 @@ export class LibraryIndex {
             // taking only the first match would leave the other group's only
             // index entry overwritten by the re-index below, unreachable via
             // `find` but still sitting in `#items` reporting stale presence.
-            const matches = [...new Set(keys.map(k => byKey.get(k)).filter((v): v is MergedItem => v !== undefined))];
+            // `byKey` is patched incrementally in this loop (see the re-index
+            // comment below) and can still hold a key pointing at a group
+            // already spliced out of `items` by an earlier iteration. If such
+            // a stale key were allowed to win here, `matches[0]` would be that
+            // ghost: `mergeInto` below would write this input's evidence into
+            // an object outside `items`, no new item would be created because
+            // `matches.length` is not zero, and the evidence would be gone —
+            // present nowhere in the final `all()`. Filtering to objects still
+            // in `items` is what keeps a spliced-out group from ever winning a
+            // later merge.
+            const matches = [...new Set(keys.map(k => byKey.get(k)).filter((v): v is MergedItem => v !== undefined))].filter(m =>
+                items.includes(m)
+            );
 
             if (matches.length === 0) {
                 const created: MergedItem = { ...input, presence: 'arr_only' };

--- a/src/core/resolver.ts
+++ b/src/core/resolver.ts
@@ -165,10 +165,21 @@ export class LibraryIndex {
         return new LibraryIndex(items, finalByKey);
     }
 
-    /** Undefined for an empty id set: no id is not a wildcard. */
-    find(ids: ExternalIds): MergedItem | undefined {
-        for (const kind of ['movie', 'series'] as const) {
-            for (const key of keysOf(kind, ids)) {
+    /**
+     * Undefined for an empty id set: no id is not a wildcard.
+     *
+     * `kind` is optional so today's callers, which do not have one to hand,
+     * keep scanning movie keys before series keys unchanged. A caller that
+     * *does* know which it wants — `diagnose` will, since it already holds
+     * the kind of the thing it is chasing — should pass it: a film and a
+     * series can share the same numeric tmdb/tvdb id (unrelated id spaces
+     * colliding), and without `kind` the first one indexed wins, silently
+     * hiding the other.
+     */
+    find(ids: ExternalIds, kind?: 'movie' | 'series'): MergedItem | undefined {
+        const kinds = kind !== undefined ? [kind] : (['movie', 'series'] as const);
+        for (const k of kinds) {
+            for (const key of keysOf(k, ids)) {
                 const hit = this.#byKey.get(key);
                 if (hit !== undefined) return hit;
             }

--- a/src/core/resolver.ts
+++ b/src/core/resolver.ts
@@ -1,5 +1,5 @@
 import type { ServiceId } from '../config/schema.ts';
-import { RANK_NONE, rankTitle } from './titleMatch.ts';
+import { RANK_NONE, rankTitle, unfenced } from './titleMatch.ts';
 
 export type ExternalIds = { tmdb?: number; tvdb?: number; imdb?: string };
 
@@ -192,7 +192,13 @@ export class LibraryIndex {
         return this.#items
             .map(item => ({ item, rank: rankTitle(item.title, query) }))
             .filter(({ rank }) => rank !== RANK_NONE)
-            .sort((a, b) => a.rank - b.rank || a.item.title.localeCompare(b.item.title))
+            // Every production title is fenced (`<<untrusted:service.field>>…`),
+            // and the fence prefix carries the *service* name. Comparing the
+            // raw strings would tie-break alphabetically by service first —
+            // "all Jellyfin-sourced items, then all *arr-sourced items" — and
+            // only alphabetically by title within each group. unfenced() is
+            // what makes the tiebreak compare the title a person reads.
+            .sort((a, b) => a.rank - b.rank || unfenced(a.item.title).localeCompare(unfenced(b.item.title)))
             .map(({ item }) => item);
     }
 

--- a/src/core/resolver.ts
+++ b/src/core/resolver.ts
@@ -38,8 +38,16 @@ export type MergedItem = {
      * §8's diagnostic payload. `arr_only` **with a file** means a broken
      * Jellyfin import; `jellyfin_only` means media nothing is managing.
      * Neither is visible from any single service.
+     *
+     * `unknown` covers a record with **neither** half of evidence — no
+     * `acquisition` and no `playback`. Real adapter data never produces one
+     * (every input contributes at least one side of the join), but the type
+     * does not forbid it, and the alternative — falling through to
+     * `jellyfin_only` — would assert Jellyfin evidence for a record that was
+     * never seen there. `arr_only` is equally wrong for the same reason.
+     * `unknown` is the only answer that does not fabricate a source.
      */
-    presence: 'both' | 'arr_only' | 'jellyfin_only';
+    presence: 'both' | 'arr_only' | 'jellyfin_only' | 'unknown';
 };
 
 export type IndexInput = Omit<MergedItem, 'presence'>;
@@ -125,21 +133,36 @@ export class LibraryIndex {
 
             // Re-index under every id the survivor now knows — from fused
             // losers and from this input — so a later record carrying any of
-            // them still finds this one group, and no key is left pointing
-            // at a loser that no longer exists in `#items`.
+            // them still finds this one group *during the build*. This is
+            // still an incremental patch, not a removal: it only ever adds or
+            // overwrites keys, so a key that used to point at a group later
+            // absorbed elsewhere (e.g. the loser fused above) can be left
+            // stale here, pointing at an object no longer in `items`.
             for (const key of keysOf(survivor.kind, survivor.ids)) byKey.set(key, survivor);
         }
 
+        // `byKey`, patched incrementally above, can still hold stale entries
+        // from groups that were fused away partway through the loop — a key
+        // set while a loser was still its own group, never revisited once
+        // that group merged into someone else's survivor. Rebuilding from
+        // `items` (the authoritative final set) is what guarantees `find`
+        // can never return an object `all()` does not contain, and it is
+        // also the natural place to compute `presence`: every item here has
+        // reached its final, fully-merged shape.
+        const finalByKey = new Map<string, MergedItem>();
         for (const item of items) {
             item.presence =
                 item.acquisition !== undefined && item.playback !== undefined
                     ? 'both'
                     : item.acquisition !== undefined
                       ? 'arr_only'
-                      : 'jellyfin_only';
+                      : item.playback !== undefined
+                        ? 'jellyfin_only'
+                        : 'unknown';
+            for (const key of keysOf(item.kind, item.ids)) finalByKey.set(key, item);
         }
 
-        return new LibraryIndex(items, byKey);
+        return new LibraryIndex(items, finalByKey);
     }
 
     /** Undefined for an empty id set: no id is not a wildcard. */

--- a/src/core/titleMatch.ts
+++ b/src/core/titleMatch.ts
@@ -45,6 +45,14 @@ export function rankTitle(title: string, query: string): number {
     const t = normaliseTitle(title);
     const q = normaliseTitle(query);
 
+    // An empty query — whether the caller sent '' or something that
+    // normalises down to it, like '???' — matches nothing. Without this,
+    // `t === q` and `t.startsWith(q)` are both true for every title (the
+    // empty string is a prefix of everything), so an empty query would rank
+    // as an exact match against a title that is itself empty, and as a
+    // prefix match against every other title in the library.
+    if (q === '') return RANK_NONE;
+
     if (t === q) return RANK_EXACT;
     if (t.startsWith(q)) return RANK_PREFIX;
     if (t.includes(q)) return RANK_SUBSTRING;

--- a/test/resolver.test.ts
+++ b/test/resolver.test.ts
@@ -188,6 +188,30 @@ describe('LibraryIndex byKey coherence after a bridging fuse', () => {
     });
 });
 
+describe('LibraryIndex — a spliced-out ghost must not win a later merge', () => {
+    it("does not let record four's evidence vanish into an object outside items()", () => {
+        // Same bridging shape as above, plus a fourth record whose only shared
+        // id (`imdb: 'tt7'`) is exactly the key that stopped belonging to any
+        // live item once the third record's bridge fused it away. Mid-build,
+        // `#byKey` still maps that key to the spliced-out ghost. If that ghost
+        // were allowed to win as `matches[0]`, `mergeInto` would write this
+        // record's `playback` into an object `items` does not contain — no
+        // new item gets created (`matches.length` is not zero), so the
+        // evidence is not lost as a stale-but-visible ghost, it is lost
+        // outright: nowhere in `all()`, and `find` on either of its own ids
+        // resolves to nothing.
+        const index = LibraryIndex.build([
+            arr({ ids: { tmdb: 1 } }),
+            jelly({ ids: { tvdb: 5, imdb: 'tt7' } }),
+            jelly({ ids: { tmdb: 1, tvdb: 5, imdb: 'tt9' } }),
+            jelly({ ids: { tmdb: 77, imdb: 'tt7' }, playback: { user: 'ReviewerFour', watched: true } })
+        ]);
+
+        expect(index.find({ tmdb: 77 })).toBeDefined();
+        expect(index.all().some(i => i.playback?.user === 'ReviewerFour')).toBe(true);
+    });
+});
+
 describe('LibraryIndex invariants', () => {
     // Two properties a coherent index must always hold, checked against every
     // id any *input* record ever mentioned — not just the ids the final
@@ -200,12 +224,20 @@ describe('LibraryIndex invariants', () => {
         const all = index.all();
 
         for (const item of all) {
-            if (item.presence === 'arr_only') expect(item.acquisition).toBeDefined();
-            if (item.presence === 'jellyfin_only') expect(item.playback).toBeDefined();
-            if (item.presence === 'both') {
-                expect(item.acquisition).toBeDefined();
-                expect(item.playback).toBeDefined();
-            }
+            // The full biconditional, not just "presence implies fields": an
+            // item holding both fields must be labelled `both`, not merely
+            // `arr_only` or `jellyfin_only` with the other field's presence
+            // left unchecked — a one-directional version of this passes for
+            // an item mislabelled `arr_only` despite carrying `playback` too.
+            const expectedPresence =
+                item.acquisition !== undefined && item.playback !== undefined
+                    ? 'both'
+                    : item.acquisition !== undefined
+                      ? 'arr_only'
+                      : item.playback !== undefined
+                        ? 'jellyfin_only'
+                        : 'unknown';
+            expect(item.presence).toBe(expectedPresence);
         }
 
         const everyId: ExternalIds[] = [];
@@ -366,6 +398,13 @@ describe('LibraryIndex search', () => {
 
         const tieIndex = LibraryIndex.build([zulu, alpha]);
         expect(tieIndex.search('matrix').map(i => unfenced(i.title))).toEqual(['Matrix Alpha', 'Matrix Zulu']);
+
+        // Neither input carries acquisition or playback, so this also
+        // exercises the 'unknown' presence branch — pinned here rather than
+        // left merely reached, so a regression to 'jellyfin_only' (the old
+        // fallthrough) would show up as a failure, not just as a branch this
+        // test happened to execute in passing.
+        for (const item of tieIndex.all()) expect(item.presence).toBe('unknown');
     });
 });
 

--- a/test/resolver.test.ts
+++ b/test/resolver.test.ts
@@ -316,6 +316,11 @@ describe('LibraryIndex search', () => {
         expect(index.search('zzzz')).toEqual([]);
     });
 
+    it('returns an empty list for an empty or punctuation-only query rather than the whole library', () => {
+        expect(index.search('')).toEqual([]);
+        expect(index.search('???')).toEqual([]);
+    });
+
     it('matches through a leading article the caller omitted', () => {
         expect(index.search('the matrix')[0]?.title).toBe('The Matrix');
     });

--- a/test/resolver.test.ts
+++ b/test/resolver.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { LibraryIndex, type IndexInput } from '../src/core/resolver.ts';
+import { LibraryIndex, type ExternalIds, type IndexInput } from '../src/core/resolver.ts';
 
 const arr = (over: Partial<IndexInput> = {}): IndexInput => ({
     kind: 'movie',
@@ -104,6 +104,101 @@ describe('LibraryIndex merging', () => {
     it('returns undefined for an empty id set rather than an arbitrary item', () => {
         const index = LibraryIndex.build([arr()]);
         expect(index.find({})).toBeUndefined();
+    });
+});
+
+describe('LibraryIndex byKey coherence after a bridging fuse', () => {
+    // Three records: an *arr-only film known by tmdb, a Jellyfin-only record
+    // known by tvdb+imdb, and a second Jellyfin record that bridges them by
+    // carrying both. The bridge forces two already-separate groups to fuse
+    // mid-build — exactly the shape that used to leave a stale `#byKey` entry
+    // pointing at a group no longer present in `#items`.
+    const bridged = () =>
+        LibraryIndex.build([
+            arr({ ids: { tmdb: 1 } }),
+            jelly({ ids: { tvdb: 5, imdb: 'tt7' } }),
+            jelly({ ids: { tmdb: 1, tvdb: 5, imdb: 'tt9' } })
+        ]);
+
+    it('fuses into exactly one item', () => {
+        const index = bridged();
+        expect(index.size()).toBe(1);
+        expect(index.all()).toHaveLength(1);
+    });
+
+    it('finds the fused item by every id it still carries, and never a ghost for one it does not', () => {
+        const index = bridged();
+        const [item] = index.all();
+
+        expect(index.find({ tmdb: 1 })).toBe(item);
+        expect(index.find({ tvdb: 5 })).toBe(item);
+        expect(index.find({ imdb: 'tt9' })).toBe(item);
+
+        // tt7 belonged to the record that got absorbed; the survivor's ids no
+        // longer include it (the bridge's tt9 supersedes it on merge), so a
+        // coherent index must not answer for it with an object `all()` does
+        // not contain.
+        expect(index.find({ imdb: 'tt7' })).toBeUndefined();
+    });
+
+    it('reports presence that matches the evidence the fused item actually holds', () => {
+        const index = bridged();
+        const [item] = index.all();
+
+        expect(item?.presence).toBe('both');
+        expect(item?.acquisition).toBeDefined();
+        expect(item?.playback).toBeDefined();
+    });
+});
+
+describe('LibraryIndex invariants', () => {
+    // Two properties a coherent index must always hold, checked against every
+    // id any *input* record ever mentioned — not just the ids the final
+    // merged items still carry. A ghost is by definition reachable only
+    // through a key some now-absorbed record used to own, so checking just
+    // the survivors' own ids (which is all a per-item loop over `all()` could
+    // see) would never exercise the bug this guards against.
+    const assertCoherent = (inputs: readonly IndexInput[]): void => {
+        const index = LibraryIndex.build(inputs);
+        const all = index.all();
+
+        for (const item of all) {
+            if (item.presence === 'arr_only') expect(item.acquisition).toBeDefined();
+            if (item.presence === 'jellyfin_only') expect(item.playback).toBeDefined();
+            if (item.presence === 'both') {
+                expect(item.acquisition).toBeDefined();
+                expect(item.playback).toBeDefined();
+            }
+        }
+
+        const everyId: ExternalIds[] = [];
+        for (const input of inputs) {
+            if (input.ids.tmdb !== undefined) everyId.push({ tmdb: input.ids.tmdb });
+            if (input.ids.tvdb !== undefined) everyId.push({ tvdb: input.ids.tvdb });
+            if (input.ids.imdb !== undefined) everyId.push({ imdb: input.ids.imdb });
+        }
+
+        for (const ids of everyId) {
+            const found = index.find(ids);
+            // Undefined is fine — a superseded id is allowed to stop
+            // resolving. What is never fine is resolving to an object `all()`
+            // does not contain.
+            if (found !== undefined) expect(all).toContain(found);
+        }
+    };
+
+    it('holds for the bridging-fuse reproduction', () => {
+        assertCoherent([
+            arr({ ids: { tmdb: 1 } }),
+            jelly({ ids: { tvdb: 5, imdb: 'tt7' } }),
+            jelly({ ids: { tmdb: 1, tvdb: 5, imdb: 'tt9' } })
+        ]);
+    });
+
+    it('holds for a plain merge, disjoint records, and an empty build', () => {
+        assertCoherent([arr(), jelly()]);
+        assertCoherent([arr({ ids: { tmdb: 550 } }), jelly({ ids: { tmdb: 999 } })]);
+        assertCoherent([]);
     });
 });
 

--- a/test/resolver.test.ts
+++ b/test/resolver.test.ts
@@ -1,23 +1,44 @@
 import { describe, expect, it } from 'vitest';
-import { LibraryIndex, type ExternalIds, type IndexInput } from '../src/core/resolver.ts';
+import type { ServiceId } from '../src/config/schema.ts';
+import { fenceText } from '../src/core/fence.ts';
+import { LibraryIndex, type ExternalIds, type IndexInput, type MergedItem } from '../src/core/resolver.ts';
+import { unfenced } from '../src/core/titleMatch.ts';
 
-const arr = (over: Partial<IndexInput> = {}): IndexInput => ({
-    kind: 'movie',
-    title: 'Some Film',
-    year: 2026,
-    ids: { tmdb: 550 },
-    acquisition: { service: 'radarr', monitored: true, hasFile: true },
-    ...over
-});
+// Production adapters fence every title before it reaches the resolver
+// (radarr.ts and sonarr.ts write it as `<service>.title`, jellyfin.ts as
+// `jellyfin.Name`) — bare-string fixtures are what let the search tiebreak
+// bug (fixed alongside these factories) hide from every existing test.
+// These factories fence too, so the merge and search tests below exercise
+// what the resolver actually receives.
+const fenceArr = (title: string, service: ServiceId = 'radarr'): string => fenceText(title, { service, field: 'title' });
+const fenceJelly = (title: string): string => fenceText(title, { service: 'jellyfin', field: 'Name' });
 
-const jelly = (over: Partial<IndexInput> = {}): IndexInput => ({
-    kind: 'movie',
-    title: 'Some Film',
-    year: 2026,
-    ids: { tmdb: 550 },
-    playback: { user: 'Bartus', watched: true },
-    ...over
-});
+/** Strips the fence so a test can assert against the human-readable title. */
+const plainTitle = (item?: MergedItem): string => unfenced(item?.title ?? '');
+
+const arr = (over: Partial<IndexInput> = {}): IndexInput => {
+    const { title, ...rest } = over;
+    return {
+        kind: 'movie',
+        title: fenceArr(title ?? 'Some Film', rest.acquisition?.service ?? 'radarr'),
+        year: 2026,
+        ids: { tmdb: 550 },
+        acquisition: { service: 'radarr', monitored: true, hasFile: true },
+        ...rest
+    };
+};
+
+const jelly = (over: Partial<IndexInput> = {}): IndexInput => {
+    const { title, ...rest } = over;
+    return {
+        kind: 'movie',
+        title: fenceJelly(title ?? 'Some Film'),
+        year: 2026,
+        ids: { tmdb: 550 },
+        playback: { user: 'Bartus', watched: true },
+        ...rest
+    };
+};
 
 describe('LibraryIndex merging', () => {
     it('merges an *arr and a Jellyfin record sharing a tmdb id', () => {
@@ -116,10 +137,10 @@ describe('LibraryIndex merging', () => {
             arr({ kind: 'series', title: 'The Series', ids: { tmdb: 224372 }, acquisition: { service: 'sonarr', monitored: true, hasFile: true } })
         ]);
 
-        expect(index.find({ tmdb: 224372 }, 'movie')?.title).toBe('The Film');
-        expect(index.find({ tmdb: 224372 }, 'series')?.title).toBe('The Series');
+        expect(plainTitle(index.find({ tmdb: 224372 }, 'movie'))).toBe('The Film');
+        expect(plainTitle(index.find({ tmdb: 224372 }, 'series'))).toBe('The Series');
         // Unspecified kind keeps today's behaviour: first match wins, movie first.
-        expect(index.find({ tmdb: 224372 })?.title).toBe('The Film');
+        expect(plainTitle(index.find({ tmdb: 224372 }))).toBe('The Film');
     });
 });
 
@@ -247,7 +268,7 @@ describe('LibraryIndex merge details', () => {
             arr({ title: 'Some Film' }),
             jelly({ title: 'Some Film (Director&apos;s Cut)' })
         ]);
-        expect(index.find({ tmdb: 550 })?.title).toBe('Some Film');
+        expect(plainTitle(index.find({ tmdb: 550 }))).toBe('Some Film');
     });
 
     it('prefers the *arr title even when the Jellyfin record merges in first', () => {
@@ -261,7 +282,7 @@ describe('LibraryIndex merge details', () => {
             jelly({ title: "Some Film (Director's Cut)" }),
             arr({ title: 'Some Film' })
         ]);
-        expect(index.find({ tmdb: 550 })?.title).toBe('Some Film');
+        expect(plainTitle(index.find({ tmdb: 550 }))).toBe('Some Film');
     });
 
     it('takes a year from whichever record has one', () => {
@@ -301,7 +322,7 @@ describe('LibraryIndex search', () => {
     ]);
 
     it('ranks exact above prefix above substring', () => {
-        expect(index.search('matrix').map(i => i.title)).toEqual([
+        expect(index.search('matrix').map(i => unfenced(i.title))).toEqual([
             'The Matrix',
             'Matrix Reloaded',
             'Enter the Matrix'
@@ -309,7 +330,7 @@ describe('LibraryIndex search', () => {
     });
 
     it('excludes non-matches rather than ranking them last', () => {
-        expect(index.search('matrix').some(i => i.title === 'Blade Runner')).toBe(false);
+        expect(index.search('matrix').some(i => unfenced(i.title) === 'Blade Runner')).toBe(false);
     });
 
     it('returns an empty list for a query matching nothing', () => {
@@ -322,7 +343,29 @@ describe('LibraryIndex search', () => {
     });
 
     it('matches through a leading article the caller omitted', () => {
-        expect(index.search('the matrix')[0]?.title).toBe('The Matrix');
+        expect(plainTitle(index.search('the matrix')[0])).toBe('The Matrix');
+    });
+
+    it('breaks a rank tie by the real title, not by which service fenced it', () => {
+        // Both titles are prefix matches for "matrix", so they tie on rank.
+        // Every production title is fenced, and the fence prefix carries the
+        // *service* name: "<<untrusted:jellyfin..." sorts before
+        // "<<untrusted:radarr..." regardless of the title inside, so a
+        // tiebreak on the raw fenced string would put "Zulu" ahead of
+        // "Alpha" here. Comparing through unfenced() is what fixes that.
+        const zulu: IndexInput = {
+            kind: 'movie',
+            title: fenceText('Matrix Zulu', { service: 'jellyfin', field: 'Name' }),
+            ids: { tmdb: 101 }
+        };
+        const alpha: IndexInput = {
+            kind: 'movie',
+            title: fenceText('Matrix Alpha', { service: 'radarr', field: 'title' }),
+            ids: { tmdb: 102 }
+        };
+
+        const tieIndex = LibraryIndex.build([zulu, alpha]);
+        expect(tieIndex.search('matrix').map(i => unfenced(i.title))).toEqual(['Matrix Alpha', 'Matrix Zulu']);
     });
 });
 

--- a/test/resolver.test.ts
+++ b/test/resolver.test.ts
@@ -105,6 +105,22 @@ describe('LibraryIndex merging', () => {
         const index = LibraryIndex.build([arr()]);
         expect(index.find({})).toBeUndefined();
     });
+
+    it('lets a caller who knows the kind reach a series when a film shares its numeric id', () => {
+        // TMDB's movie and TV id spaces are separate, but a recaptured Jellyfin
+        // fixture shows a Series carrying a numeric Tmdb id too — so the two
+        // can collide by coincidence. Without `kind`, find() scans movie keys
+        // first and the series is unreachable.
+        const index = LibraryIndex.build([
+            arr({ kind: 'movie', title: 'The Film', ids: { tmdb: 224372 } }),
+            arr({ kind: 'series', title: 'The Series', ids: { tmdb: 224372 }, acquisition: { service: 'sonarr', monitored: true, hasFile: true } })
+        ]);
+
+        expect(index.find({ tmdb: 224372 }, 'movie')?.title).toBe('The Film');
+        expect(index.find({ tmdb: 224372 }, 'series')?.title).toBe('The Series');
+        // Unspecified kind keeps today's behaviour: first match wins, movie first.
+        expect(index.find({ tmdb: 224372 })?.title).toBe('The Film');
+    });
 });
 
 describe('LibraryIndex byKey coherence after a bridging fuse', () => {

--- a/test/titleMatch.test.ts
+++ b/test/titleMatch.test.ts
@@ -57,6 +57,17 @@ describe('rankTitle', () => {
         expect(rankTitle('<<untrusted:radarr.title>>The Matrix<</untrusted>>', 'matrix')).toBe(RANK_EXACT);
     });
 
+    it('reports no match for an empty query rather than a universal prefix', () => {
+        // normaliseTitle('') is '', and 'x'.startsWith('') is always true —
+        // without a guard, an empty query would rank every title as a prefix
+        // match, turning search('') into "return the whole library".
+        expect(rankTitle('anything', '')).toBe(RANK_NONE);
+    });
+
+    it('reports no match for a punctuation-only query, which normalises to empty too', () => {
+        expect(rankTitle('anything', '???')).toBe(RANK_NONE);
+    });
+
     it('orders correctly when sorted', () => {
         const titles = ['Enter the Matrix', 'The Matrix', 'Matrix Reloaded'];
         titles.sort((a, b) => rankTitle(a, 'matrix') - rankTitle(b, 'matrix'));

--- a/test/versions.test.ts
+++ b/test/versions.test.ts
@@ -1,6 +1,12 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
+import type { ServiceId } from '../src/config/schema.ts';
 import type { ServiceError } from '../src/core/errors.ts';
 import { MINIMUM_VERSIONS, assertVersionSupported, compareVersions, parseVersion } from '../src/services/versions.ts';
+
+const ROOT = join(import.meta.dirname, '..');
+const read = (path: string): unknown => JSON.parse(readFileSync(join(ROOT, path), 'utf8'));
 
 const rejection = (fn: () => void): ServiceError => {
     try {
@@ -84,4 +90,43 @@ describe('assertVersionSupported', () => {
         const services = ['radarr', 'sonarr', 'prowlarr', 'bazarr', 'jellyfin', 'seerr', 'sabnzbd', 'transmission'];
         for (const s of services) expect(MINIMUM_VERSIONS[s as keyof typeof MINIMUM_VERSIONS]).toBeTruthy();
     });
+
+    it('has a parseable floor for every service', () => {
+        // The reported failure mode of an unparseable floor was wrong —
+        // parseVersion("4..0") returns [4], not undefined. The genuine
+        // silent-disable case is a digit-free floor: parseVersion("four")
+        // returns undefined, assertVersionSupported's `minimum === undefined`
+        // guard returns early, and enforcement is off for that service with a
+        // green suite, since nothing else exercises MINIMUM_VERSIONS' values.
+        for (const [service, floor] of Object.entries(MINIMUM_VERSIONS)) {
+            expect(parseVersion(floor), `${service}'s floor "${floor}" must parse`).toBeDefined();
+        }
+    });
+});
+
+describe('assertVersionSupported against captured evidence', () => {
+    // Every fixture below was captured from the real reference stack this
+    // project was developed against (see the version list in versions.ts's
+    // header comment). Checking each floor against that real version, rather
+    // than a hand-written string, is the "no capability without a fixture"
+    // discipline this project is held to elsewhere applied to the floors
+    // themselves — it is the test that would actually catch a floor
+    // accidentally set above what a real, currently-supported install
+    // reports.
+    const captured: Record<ServiceId, string> = {
+        radarr: (read('test/fixtures/radarr/system-status.json') as { version: string }).version,
+        sonarr: (read('test/fixtures/sonarr/system-status.json') as { version: string }).version,
+        prowlarr: (read('test/fixtures/prowlarr/system-status.json') as { version: string }).version,
+        bazarr: (read('test/fixtures/bazarr/system-status.json') as { data: { bazarr_version: string } }).data.bazarr_version,
+        jellyfin: (read('test/fixtures/jellyfin/system-info.json') as { Version: string }).Version,
+        seerr: (read('test/fixtures/seerr/status.json') as { version: string }).version,
+        sabnzbd: (read('test/fixtures/sabnzbd/version.json') as { version: string }).version,
+        transmission: (read('test/fixtures/transmission/session-get.json') as { arguments: { version: string } }).arguments.version
+    };
+
+    for (const [service, version] of Object.entries(captured)) {
+        it(`accepts ${service}'s captured version (${version})`, () => {
+            expect(() => assertVersionSupported(service as ServiceId, version)).not.toThrow();
+        });
+    }
 });


### PR DESCRIPTION
The final whole-phase review of 3a returned six items to fix before shipping, plus one residual found during re-review. Seven commits, **505 tests** (up from 485).

## The one that mattered

Three findings each deferred as *Minor* turned out to be **one defect**, and the reviewer reproduced it. When a third record bridges two existing groups, the fused-away group stayed reachable through `find()` while being absent from `all()` — reporting `presence: 'arr_only'` despite having no acquisition half at all.

`arr_only` is the broken-import alarm: *"Radarr has a file on disk that Jellyfin cannot see."* Emitting it about a record that only ever had a Jellyfin half is a fabricated alert on the field this entire phase exists to produce. Individually the three looked cosmetic. Together they lie.

`build` now rebuilds the key map from the surviving items rather than patching it incrementally, computes `presence` for every item afterwards, and has an explicit fourth case for a record with neither half — which reports `unknown` rather than inventing evidence in either direction.

A second round found the unfixed half of the same root cause: survivor selection still trusted stale keys, so a spliced-out ghost could win a merge and **swallow an input record entirely** — four records in, one item out, the fourth's evidence nowhere. Reproduced, fixed, and pinned by that exact four-record case.

## Two defects only visible with 3b's call sites in hand

- **`find` ignored kind.** The fixture recaptured in #30 proves Jellyfin `Series` records carry *both* `Tmdb` and `Tvdb`, and TMDB's film and TV id spaces are separate — so a series was unreachable behind a film sharing its number. 3b's `diagnose` would have reported a chain about the wrong show. `find(ids, kind?)` now takes an optional kind; omitting it preserves today's behaviour exactly.
- **An empty query matched everything.** `normaliseTitle('???')` is `''`, and `'x'.startsWith('')` is always true — so `search('???')` returned the whole library ranked as prefix matches. 3b takes `search(q)[0]` unconditionally in two places, which would have turned "nothing matches" into a confident wrong answer about the alphabetically first title.

## A defect the test data was hiding

The resolver's tiebreak compared **fenced** titles. Since the fence carries the service name, relevance ties sorted by *which service supplied the record* — Jellyfin's items ahead of Radarr's, alphabetical only within each. `searchMedia.ts` had this right; the resolver was written from the same idea without the `unfenced` call.

It survived task review because every resolver test used bare titles while all production data is fenced. The test factories now produce fenced titles, and the assertions were adapted rather than loosened — no equality check was downgraded to make the fence fit.

## Also

- Version floors are now checked against **captured evidence**: each fixture's real version must clear its own floor, so a floor set too high fails against recorded data rather than a hand-written string. Plus a guard that every floor is parseable — a digit-free floor would silently disable enforcement for that service.
- **README documents the eight minimum versions**, and that a below-floor service contributes *nothing* to `stack_health` — no disks, no health checks, no scan state. That was a live behaviour change shipped without a word to users.
- `CONTRIBUTING.md` no longer describes a Renovate policy the config does not implement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)