### PR TITLE
feat: read whole libraries from Radarr, Sonarr and Jellyfin

### DIFF
--- a/scripts/capture-fixtures.ts
+++ b/scripts/capture-fixtures.ts
@@ -193,6 +193,63 @@ const ENDPOINTS: Record<ServiceId, Endpoint[]> = {
             // Fields, Jellyfin returns no ProviderIds at all — which is exactly
             // what the resolver joins on.
             path: '/Items?searchTerm=a&Recursive=true&IncludeItemTypes=Movie,Series&Limit=5&Fields=ProviderIds'
+        },
+        {
+            name: 'items-library',
+            // Per-user, because UserData — the watched state — only comes back
+            // when Jellyfin knows who is asking. The id is read from the users
+            // fixture captured a moment earlier.
+            path: captured => {
+                const users = captured.get('users');
+                const id = Array.isArray(users) ? (users[0] as { Id?: string } | undefined)?.Id : undefined;
+                // EnableImages=false is capture-only trim: the adapter reads
+                // none of ImageTags/BackdropImageTags/ImageBlurHashes, and a
+                // flat-colour blurhash is long, alphanumeric-only, and
+                // undelimited — exactly the shape the fixture secret guard in
+                // test/fixtures.test.ts treats as a possible credential.
+                return id === undefined
+                    ? undefined
+                    : `/Items?userId=${id}&Recursive=true&IncludeItemTypes=Movie,Series` +
+                      '&Fields=ProviderIds,Genres&EnableUserData=true&EnableImages=false&Limit=20';
+            },
+            // Watch history is the one genuinely personal thing in the fixture
+            // set — the library titles are already public in radarr/movie.json,
+            // but who has watched what is not. Keys and types are preserved,
+            // which is all the contract test reads; the values are synthetic.
+            //
+            // A live 10.11.11 response carries more per-item watch signal than
+            // Played/PlayCount/LastPlayedDate: PlaybackPositionTicks (exact
+            // resume point), PlayedPercentage and UnplayedItemCount (partial
+            // series progress) and IsFavorite are all real behavioural data
+            // that the adapter never reads, so they are neutralised here too
+            // rather than left to leak past the three fields the adapter does.
+            anonymise: body => {
+                const page = body as { Items?: Row[] };
+                if (!Array.isArray(page.Items)) return body;
+                return {
+                    ...page,
+                    Items: page.Items.map((item, i) => ({
+                        ...item,
+                        UserData:
+                            item.UserData === undefined
+                                ? undefined
+                                : {
+                                      ...(item.UserData as Row),
+                                      Played: i % 2 === 0,
+                                      PlayCount: i % 2 === 0 ? 1 : 0,
+                                      LastPlayedDate: undefined,
+                                      PlaybackPositionTicks: 0,
+                                      IsFavorite: false,
+                                      ...('PlayedPercentage' in (item.UserData as Row)
+                                          ? { PlayedPercentage: i % 2 === 0 ? 100 : 0 }
+                                          : {}),
+                                      ...('UnplayedItemCount' in (item.UserData as Row)
+                                          ? { UnplayedItemCount: i % 2 === 0 ? 0 : 1 }
+                                          : {})
+                                  }
+                    }))
+                };
+            }
         }
     ],
     seerr: [

--- a/src/services/arrRatings.ts
+++ b/src/services/arrRatings.ts
@@ -40,7 +40,20 @@ export function flattenSeriesRating(raw: RawRating | undefined): Record<string, 
     return { tvdb: raw.value };
 }
 
-/** The sources §4.1 names. Anything else an *arr invents is dropped rather than carried. */
+/**
+ * The sources §4.1 names. Anything else an *arr invents is dropped rather than
+ * carried.
+ *
+ * `tvdb` is deliberately absent. Sonarr's rating is flat — `{ votes, value }`,
+ * no source key — and is read via `flattenSeriesRating`, never through this
+ * function; `Sonarr.listLibrary` builds `{ tvdb: raw.tvdb }` by hand instead of
+ * calling `toMergedRatings`. Adding `tvdb` here would look like the fix that
+ * lets Sonarr's mapping "simplify" to reuse this function, but Radarr's
+ * per-source `Record<string, number>` and Sonarr's single flat value are not
+ * the same shape — routing the latter through `KNOWN`'s allowlist would look
+ * up a `tvdb` key that was never in the flattened record, and return
+ * `undefined` for every series rating, silently.
+ */
 const KNOWN = ['imdb', 'tmdb', 'rottenTomatoes', 'trakt', 'metacritic'] as const;
 
 /**

--- a/src/services/arrRatings.ts
+++ b/src/services/arrRatings.ts
@@ -1,3 +1,5 @@
+import type { MergedRatings } from '../core/resolver.ts';
+
 export type RawRating = { value?: number; votes?: number };
 
 /**
@@ -36,4 +38,24 @@ export function flattenRatings(raw: Record<string, RawRating> | undefined): Reco
 export function flattenSeriesRating(raw: RawRating | undefined): Record<string, number> | undefined {
     if (typeof raw?.value !== 'number' || raw.value <= 0) return undefined;
     return { tvdb: raw.value };
+}
+
+/** The sources §4.1 names. Anything else an *arr invents is dropped rather than carried. */
+const KNOWN = ['imdb', 'tmdb', 'rottenTomatoes', 'trakt', 'metacritic'] as const;
+
+/**
+ * `flattenRatings` produces `Record<string, number>` because that is what
+ * `MediaDetails` has carried since Phase 2. The merged record uses named
+ * sources instead, so an unknown source name cannot survive into a filter that
+ * would then match nothing.
+ */
+export function toMergedRatings(flat: Record<string, number> | undefined): MergedRatings | undefined {
+    if (flat === undefined) return undefined;
+
+    const out: MergedRatings = {};
+    for (const key of KNOWN) {
+        const value = flat[key];
+        if (typeof value === 'number') out[key] = value;
+    }
+    return Object.keys(out).length > 0 ? out : undefined;
 }

--- a/src/services/jellyfin.ts
+++ b/src/services/jellyfin.ts
@@ -1,4 +1,5 @@
 import type { MultiUserServiceConfig, ServiceId } from '../config/schema.ts';
+import type { IndexInput } from '../core/resolver.ts';
 import { embyToken } from '../core/auth.ts';
 import { ServiceError } from '../core/errors.ts';
 import { ServiceHttp } from '../core/http.ts';
@@ -16,7 +17,8 @@ import {
     type SearchSource,
     type ServiceAdapter,
     type ServiceUser,
-    type UserDirectoryCapable
+    type UserDirectoryCapable,
+    type UserLibraryCapable
 } from './types.ts';
 
 /**
@@ -77,6 +79,8 @@ type RawItemDetail = {
     Type?: string;
     ProviderIds?: { Tmdb?: string; Tvdb?: string; Imdb?: string };
     MediaSources?: { Size?: number }[];
+    Genres?: string[];
+    UserData?: { Played?: boolean; PlayCount?: number; LastPlayedDate?: string };
 };
 
 /**
@@ -91,7 +95,13 @@ const numericId = (value: string | undefined): number | undefined => {
 };
 
 export class JellyfinAdapter
-    implements ServiceAdapter, ScanStateCapable, UserDirectoryCapable, MediaDetailCapable, SearchCapable
+    implements
+        ServiceAdapter,
+        ScanStateCapable,
+        UserDirectoryCapable,
+        MediaDetailCapable,
+        SearchCapable,
+        UserLibraryCapable
 {
     readonly id: ServiceId = 'jellyfin';
     readonly #http: ServiceHttp;
@@ -263,6 +273,44 @@ export class JellyfinAdapter
                     }
                 };
             });
+    }
+
+    /**
+     * Per-user by construction (§4.3). `EnableUserData` is what makes `Played`
+     * come back at all, and `Fields=ProviderIds` is what makes the join
+     * possible — the same parameter whose absence made every Phase 2 search hit
+     * arrive with no external ids.
+     */
+    async listUserLibrary(user: ServiceUser): Promise<IndexInput[]> {
+        const page = await this.#http.get<{ Items?: RawItemDetail[] }>(
+            `/Items?userId=${encodeURIComponent(user.id)}&Recursive=true&IncludeItemTypes=Movie,Series` +
+                '&Fields=ProviderIds,Genres&EnableUserData=true'
+        );
+
+        return (page.Items ?? []).map(i => {
+            const tmdb = numericId(i.ProviderIds?.Tmdb);
+            const tvdb = numericId(i.ProviderIds?.Tvdb);
+
+            return {
+                kind: i.Type === 'Series' ? ('series' as const) : ('movie' as const),
+                title: fenceText(i.Name ?? '', { service: this.id, field: 'Name' }),
+                ...(i.ProductionYear === undefined ? {} : { year: i.ProductionYear }),
+                ...(i.Genres === undefined
+                    ? {}
+                    : { genres: i.Genres.map(g => fenceText(g, { service: this.id, field: 'Genres' })) }),
+                ids: {
+                    ...(tmdb === undefined ? {} : { tmdb }),
+                    ...(tvdb === undefined ? {} : { tvdb }),
+                    ...(i.ProviderIds?.Imdb === undefined ? {} : { imdb: i.ProviderIds.Imdb })
+                },
+                playback: {
+                    user: user.name,
+                    watched: i.UserData?.Played ?? false,
+                    ...(i.UserData?.PlayCount === undefined ? {} : { playCount: i.UserData.PlayCount }),
+                    ...(i.UserData?.LastPlayedDate === undefined ? {} : { lastPlayed: i.UserData.LastPlayedDate })
+                }
+            };
+        });
     }
 
     async testConnection(): Promise<ConnectionDiagnosis> {

--- a/src/services/radarr.ts
+++ b/src/services/radarr.ts
@@ -3,8 +3,9 @@ import { apiKeyHeader } from '../core/auth.ts';
 import { ServiceError } from '../core/errors.ts';
 import { ServiceHttp } from '../core/http.ts';
 import { fenceText } from '../core/fence.ts';
+import type { IndexInput } from '../core/resolver.ts';
 import { calendarPath, readArrQueue, readRadarrCalendar } from './arrQueue.ts';
-import { flattenRatings, type RawRating } from './arrRatings.ts';
+import { flattenRatings, toMergedRatings, type RawRating } from './arrRatings.ts';
 import {
     diagnoseConnection,
     type CalendarCapable,
@@ -14,6 +15,7 @@ import {
     type DiskSpaceCapable,
     type HealthCheck,
     type HealthCheckCapable,
+    type LibraryCapable,
     type MediaDetailCapable,
     type MediaDetails,
     type QueueCapable,
@@ -36,6 +38,7 @@ type RawMovie = {
     path?: string;
     tmdbId?: number;
     imdbId?: string;
+    genres?: string[];
     ratings?: Record<string, RawRating>;
     movieFile?: { size?: number; quality?: { quality?: { name?: string } } };
 };
@@ -74,7 +77,8 @@ export class RadarrAdapter
         QueueCapable,
         CalendarCapable,
         MediaDetailCapable,
-        SearchCapable
+        SearchCapable,
+        LibraryCapable
 {
     readonly id: ServiceId = 'radarr';
     readonly #http: ServiceHttp;
@@ -202,6 +206,38 @@ export class RadarrAdapter
             ...(m.hasFile === undefined ? {} : { hasFile: m.hasFile }),
             ...(m.monitored === undefined ? {} : { monitored: m.monitored })
         };
+    }
+
+    /**
+     * The whole film library in one call — Radarr has no server-side filter, so
+     * this is the same `/api/v3/movie` read `search` already does. §16's cache
+     * is what makes it affordable, and it lives in the tool layer.
+     */
+    async listLibrary(): Promise<IndexInput[]> {
+        const movies = await this.#http.get<RawMovie[]>('/api/v3/movie');
+
+        return movies.map(m => ({
+            kind: 'movie' as const,
+            title: fenceText(m.title ?? '', { service: this.id, field: 'title' }),
+            ...(m.year === undefined ? {} : { year: m.year }),
+            ...(m.genres === undefined
+                ? {}
+                : { genres: m.genres.map(g => fenceText(g, { service: this.id, field: 'genre' })) }),
+            ids: {
+                ...(m.tmdbId === undefined ? {} : { tmdb: m.tmdbId }),
+                ...(m.imdbId === undefined ? {} : { imdb: m.imdbId })
+            },
+            acquisition: {
+                service: this.id,
+                monitored: m.monitored ?? false,
+                hasFile: m.hasFile ?? false,
+                ...(m.movieFile?.quality?.quality?.name === undefined
+                    ? {}
+                    : { quality: m.movieFile.quality.quality.name }),
+                ...(m.movieFile?.size === undefined ? {} : { sizeBytes: m.movieFile.size })
+            },
+            ...((r => (r === undefined ? {} : { ratings: r }))(toMergedRatings(flattenRatings(m.ratings))))
+        }));
     }
 
     async testConnection(): Promise<ConnectionDiagnosis> {

--- a/src/services/sonarr.ts
+++ b/src/services/sonarr.ts
@@ -4,6 +4,7 @@ import { ServiceError } from '../core/errors.ts';
 import { ServiceHttp } from '../core/http.ts';
 import { fenceText } from '../core/fence.ts';
 import { applyLimit } from '../core/shape.ts';
+import type { IndexInput } from '../core/resolver.ts';
 import { readArrQueue, readSonarrCalendar, sonarrCalendarPath } from './arrQueue.ts';
 import { flattenSeriesRating, type RawRating } from './arrRatings.ts';
 import type { components } from './generated/sonarr.ts';
@@ -16,6 +17,7 @@ import {
     type DiskSpaceCapable,
     type HealthCheck,
     type HealthCheckCapable,
+    type LibraryCapable,
     type MediaDetailCapable,
     type MediaDetails,
     type QueueCapable,
@@ -37,6 +39,7 @@ type RawSeries = {
     path?: string;
     tvdbId?: number;
     imdbId?: string;
+    genres?: string[];
     /** Flat, unlike Radarr's per-source map — see `flattenSeriesRating`. */
     ratings?: RawRating;
     statistics?: { sizeOnDisk?: number; episodeFileCount?: number };
@@ -78,7 +81,8 @@ export class SonarrAdapter
         QueueCapable,
         CalendarCapable,
         MediaDetailCapable,
-        SearchCapable
+        SearchCapable,
+        LibraryCapable
 {
     readonly id: ServiceId = 'sonarr';
     readonly #http: ServiceHttp;
@@ -216,6 +220,37 @@ export class SonarrAdapter
             },
             ...(s.monitored === undefined ? {} : { monitored: s.monitored })
         };
+    }
+
+    async listLibrary(): Promise<IndexInput[]> {
+        const series = await this.#http.get<RawSeries[]>('/api/v3/series');
+
+        return series.map(s => ({
+            kind: 'series' as const,
+            title: fenceText(s.title ?? '', { service: this.id, field: 'title' }),
+            ...(s.year === undefined ? {} : { year: s.year }),
+            ...(s.genres === undefined
+                ? {}
+                : { genres: s.genres.map(g => fenceText(g, { service: this.id, field: 'genre' })) }),
+            ids: {
+                ...(s.tvdbId === undefined ? {} : { tvdb: s.tvdbId }),
+                ...(s.imdbId === undefined ? {} : { imdb: s.imdbId })
+            },
+            acquisition: {
+                service: this.id,
+                monitored: s.monitored ?? false,
+                // A series has no single file, so "has a file" means "has any
+                // episode on disk". No quality either: it is per-episode, which
+                // is why §5.2 makes the quality filter films-only.
+                hasFile: (s.statistics?.episodeFileCount ?? 0) > 0,
+                ...(s.statistics?.sizeOnDisk === undefined ? {} : { sizeBytes: s.statistics.sizeOnDisk })
+            },
+            // Flat, and labelled tvdb. Treating it as a per-source map is the
+            // 0.3.0 defect that reported a source called `votes` worth 164018.
+            ...((r => (r === undefined ? {} : { ratings: r }))(
+                (raw => (raw?.tvdb === undefined ? undefined : { tvdb: raw.tvdb }))(flattenSeriesRating(s.ratings))
+            ))
+        }));
     }
 
     async testConnection(): Promise<ConnectionDiagnosis> {

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -1,4 +1,5 @@
 import type { ServiceId } from '../config/schema.ts';
+import type { IndexInput } from '../core/resolver.ts';
 import { ServiceError, type ServiceErrorKind } from '../core/errors.ts';
 import { assertVersionSupported } from './versions.ts';
 
@@ -265,6 +266,29 @@ export interface SearchCapable {
 
 export const hasSearch = (a: ServiceAdapter): a is ServiceAdapter & SearchCapable =>
     typeof (a as Partial<SearchCapable>).search === 'function';
+
+/**
+ * A whole-library read, shaped for the identity resolver rather than for a
+ * tool. Phase 3 joins three of these into one index; nothing else consumes it.
+ */
+export interface LibraryCapable {
+    listLibrary(): Promise<IndexInput[]>;
+}
+
+export const hasLibrary = (a: ServiceAdapter): a is ServiceAdapter & LibraryCapable =>
+    typeof (a as Partial<LibraryCapable>).listLibrary === 'function';
+
+/**
+ * Separate from LibraryCapable because Jellyfin's half is per-user (§4.3):
+ * watch state does not exist without a user, and a shared signature would let
+ * a caller forget to supply one.
+ */
+export interface UserLibraryCapable {
+    listUserLibrary(user: ServiceUser): Promise<IndexInput[]>;
+}
+
+export const hasUserLibrary = (a: ServiceAdapter): a is ServiceAdapter & UserLibraryCapable =>
+    typeof (a as Partial<UserLibraryCapable>).listUserLibrary === 'function';
 
 export interface DiscoverCapable {
     discover(opts: {

--- a/test/contract.test.ts
+++ b/test/contract.test.ts
@@ -92,7 +92,7 @@ const CONTRACTS: Record<string, ServiceContract> = {
             { fixture: 'test/fixtures/radarr/calendar.json', fields: ['id', 'title', 'hasFile', 'monitored'] },
             {
                 fixture: 'test/fixtures/radarr/movie.json',
-                fields: ['id', 'title', 'year', 'monitored', 'hasFile', 'tmdbId', 'ratings']
+                fields: ['id', 'title', 'year', 'monitored', 'hasFile', 'tmdbId', 'ratings', 'genres']
             },
             { fixture: 'test/fixtures/radarr/movie-lookup.json', fields: ['title', 'tmdbId'] }
             // No `queue` entry: the queue was empty at capture time, and an
@@ -113,7 +113,7 @@ const CONTRACTS: Record<string, ServiceContract> = {
                 // `ratings` here is flat — { votes, value } — not Radarr's
                 // per-source map. §21.2, resolved by the capture run.
                 fixture: 'test/fixtures/sonarr/series.json',
-                fields: ['id', 'title', 'monitored', 'tvdbId', 'ratings', 'statistics']
+                fields: ['id', 'title', 'monitored', 'tvdbId', 'ratings', 'statistics', 'genres']
             },
             {
                 fixture: 'test/fixtures/sonarr/episode.json',
@@ -157,6 +157,10 @@ const CONTRACTS: Record<string, ServiceContract> = {
                 // three-way join silently.
                 fixture: 'test/fixtures/jellyfin/items-search.json',
                 fields: ['Items.Id', 'Items.Name', 'Items.ProviderIds']
+            },
+            {
+                fixture: 'test/fixtures/jellyfin/items-library.json',
+                fields: ['Items.Id', 'Items.Name', 'Items.Type', 'Items.ProviderIds', 'Items.UserData']
             }
         ]
     },

--- a/test/contract.test.ts
+++ b/test/contract.test.ts
@@ -112,8 +112,14 @@ const CONTRACTS: Record<string, ServiceContract> = {
             {
                 // `ratings` here is flat — { votes, value } — not Radarr's
                 // per-source map. §21.2, resolved by the capture run.
+                //
+                // `statistics.episodeFileCount` is read by listLibrary to
+                // derive hasFile — a series has no single file, so this count
+                // stands in for it. Without this entry an upstream rename
+                // would make every series report hasFile: false with a green
+                // suite: the bare `statistics` key would still resolve.
                 fixture: 'test/fixtures/sonarr/series.json',
-                fields: ['id', 'title', 'monitored', 'tvdbId', 'ratings', 'statistics', 'genres']
+                fields: ['id', 'title', 'monitored', 'tvdbId', 'ratings', 'statistics', 'statistics.episodeFileCount', 'genres']
             },
             {
                 fixture: 'test/fixtures/sonarr/episode.json',
@@ -159,8 +165,11 @@ const CONTRACTS: Record<string, ServiceContract> = {
                 fields: ['Items.Id', 'Items.Name', 'Items.ProviderIds']
             },
             {
+                // `Items.Genres` is read by listUserLibrary and fenced into
+                // the merged item's genre list — omitted here, an upstream
+                // rename would silently make every item report no genres.
                 fixture: 'test/fixtures/jellyfin/items-library.json',
-                fields: ['Items.Id', 'Items.Name', 'Items.Type', 'Items.ProviderIds', 'Items.UserData']
+                fields: ['Items.Id', 'Items.Name', 'Items.Type', 'Items.ProviderIds', 'Items.UserData', 'Items.Genres']
             }
         ]
     },

--- a/test/fixtures/jellyfin/items-library.json
+++ b/test/fixtures/jellyfin/items-library.json
@@ -1,0 +1,1024 @@
+{
+  "Items": [
+    {
+      "Name": "#MissingCouple",
+      "ServerId": "03b5e7fd4c8a4de8b4164d4d21b72608",
+      "Id": "65cbd491b1ecb02fdb3d7cbaefab5353",
+      "HasSubtitles": true,
+      "Container": "mkv",
+      "PremiereDate": "2024-10-07T22:00:00.0000000Z",
+      "OfficialRating": "NR",
+      "ChannelId": null,
+      "Genres": [
+        "Thriller",
+        "Crime",
+        "Horror"
+      ],
+      "CommunityRating": 5,
+      "RunTimeTicks": 56381319999,
+      "ProductionYear": 2024,
+      "ProviderIds": {
+        "Imdb": "tt33794261",
+        "Tmdb": "1368213"
+      },
+      "IsFolder": false,
+      "Type": "Movie",
+      "GenreItems": [
+        {
+          "Name": "Thriller",
+          "Id": "4936f5b1a6f84f0b0aa2657368a5b364"
+        },
+        {
+          "Name": "Crime",
+          "Id": "83a9dab21914792744c8fb23b9925dc6"
+        },
+        {
+          "Name": "Horror",
+          "Id": "8b9bd9a3eddad02f2b759b4938fdd0b8"
+        }
+      ],
+      "UserData": {
+        "PlaybackPositionTicks": 0,
+        "PlayCount": 1,
+        "IsFavorite": false,
+        "Played": true,
+        "Key": "1368213",
+        "ItemId": "65cbd491b1ecb02fdb3d7cbaefab5353"
+      },
+      "VideoType": "VideoFile",
+      "ImageBlurHashes": {},
+      "LocationType": "FileSystem",
+      "MediaType": "Video"
+    },
+    {
+      "Name": "3 Body Problem",
+      "ServerId": "03b5e7fd4c8a4de8b4164d4d21b72608",
+      "Id": "cf939e2aa448fbe76b4f5eb80fa0d39f",
+      "PremiereDate": "2024-03-20T23:00:00.0000000Z",
+      "OfficialRating": "TV-MA",
+      "ChannelId": null,
+      "Genres": [
+        "Science Fiction",
+        "Fantasy",
+        "Drama",
+        "Adventure",
+        "Thriller",
+        "Mystery"
+      ],
+      "RunTimeTicks": 33000000000,
+      "ProductionYear": 2024,
+      "ProviderIds": {
+        "Imdb": "tt13016388",
+        "Tmdb": "108545",
+        "Tvdb": "411959",
+        "TvdbSlug": "three-body-problem"
+      },
+      "IsFolder": true,
+      "Type": "Series",
+      "GenreItems": [
+        {
+          "Name": "Science Fiction",
+          "Id": "0430d514c35e1f158fa93f1eeb8361ea"
+        },
+        {
+          "Name": "Fantasy",
+          "Id": "a30dcc65be22eb3c21c03f7c1c7a57d1"
+        },
+        {
+          "Name": "Drama",
+          "Id": "090eac6e9de4fe1fbc194e5b96691277"
+        },
+        {
+          "Name": "Adventure",
+          "Id": "51cec9645b896084d12b259acd05ccb1"
+        },
+        {
+          "Name": "Thriller",
+          "Id": "4936f5b1a6f84f0b0aa2657368a5b364"
+        },
+        {
+          "Name": "Mystery",
+          "Id": "d3a0ead52489743e5a68704142092c71"
+        }
+      ],
+      "UserData": {
+        "UnplayedItemCount": 1,
+        "PlaybackPositionTicks": 0,
+        "PlayCount": 0,
+        "IsFavorite": false,
+        "Played": false,
+        "Key": "411959",
+        "ItemId": "cf939e2aa448fbe76b4f5eb80fa0d39f"
+      },
+      "Status": "Continuing",
+      "AirTime": "03:00",
+      "AirDays": [
+        "Thursday"
+      ],
+      "ImageBlurHashes": {},
+      "LocationType": "FileSystem",
+      "MediaType": "Unknown"
+    },
+    {
+      "Name": "The 100 Year-Old Man Who Climbed Out the Window and Disappeared",
+      "ServerId": "03b5e7fd4c8a4de8b4164d4d21b72608",
+      "Id": "d9d758cc97ae50a0e4bc3ac252a5a298",
+      "HasSubtitles": true,
+      "Container": "mkv",
+      "PremiereDate": "2013-12-24T23:00:00.0000000Z",
+      "CriticRating": 68,
+      "OfficialRating": "NL-12",
+      "ChannelId": null,
+      "Genres": [
+        "Adventure",
+        "Comedy",
+        "Drama"
+      ],
+      "CommunityRating": 6.812,
+      "RunTimeTicks": 68580060000,
+      "ProductionYear": 2013,
+      "ProviderIds": {
+        "Imdb": "tt2113681",
+        "Tmdb": "145247",
+        "TmdbCollection": "501772"
+      },
+      "IsFolder": false,
+      "Type": "Movie",
+      "GenreItems": [
+        {
+          "Name": "Adventure",
+          "Id": "51cec9645b896084d12b259acd05ccb1"
+        },
+        {
+          "Name": "Comedy",
+          "Id": "08d31605d366d63a7a924f944b4417f1"
+        },
+        {
+          "Name": "Drama",
+          "Id": "090eac6e9de4fe1fbc194e5b96691277"
+        }
+      ],
+      "UserData": {
+        "PlaybackPositionTicks": 0,
+        "PlayCount": 1,
+        "IsFavorite": false,
+        "Played": true,
+        "Key": "145247",
+        "ItemId": "d9d758cc97ae50a0e4bc3ac252a5a298"
+      },
+      "VideoType": "VideoFile",
+      "ImageBlurHashes": {},
+      "LocationType": "FileSystem",
+      "MediaType": "Video"
+    },
+    {
+      "Name": "1923",
+      "ServerId": "03b5e7fd4c8a4de8b4164d4d21b72608",
+      "Id": "3edf56dd60d54882848c09bf2e4c7a4f",
+      "PremiereDate": "2022-12-17T23:00:00.0000000Z",
+      "OfficialRating": "TV-MA",
+      "ChannelId": null,
+      "Genres": [
+        "Drama",
+        "Western"
+      ],
+      "RunTimeTicks": 36000000000,
+      "ProductionYear": 2022,
+      "ProviderIds": {
+        "Imdb": "tt18335752",
+        "Tmdb": "157744",
+        "Tvdb": "416491",
+        "TvdbCollection": "7502;",
+        "TvdbSlug": "1923-yellowstone"
+      },
+      "IsFolder": true,
+      "Type": "Series",
+      "GenreItems": [
+        {
+          "Name": "Drama",
+          "Id": "090eac6e9de4fe1fbc194e5b96691277"
+        },
+        {
+          "Name": "Western",
+          "Id": "a64ff36d22e03d8479fbac2360725aea"
+        }
+      ],
+      "UserData": {
+        "UnplayedItemCount": 1,
+        "PlaybackPositionTicks": 0,
+        "PlayCount": 0,
+        "IsFavorite": false,
+        "Played": false,
+        "Key": "416491",
+        "ItemId": "3edf56dd60d54882848c09bf2e4c7a4f"
+      },
+      "Status": "Ended",
+      "AirTime": "03:00",
+      "AirDays": [
+        "Sunday"
+      ],
+      "ImageBlurHashes": {},
+      "LocationType": "FileSystem",
+      "MediaType": "Unknown",
+      "EndDate": "2025-01-05T23:04:00.0000000Z"
+    },
+    {
+      "Name": "The Amateur",
+      "ServerId": "03b5e7fd4c8a4de8b4164d4d21b72608",
+      "Id": "bd506f6de56ad3c3c600ad723982c0a5",
+      "HasSubtitles": true,
+      "Container": "mkv",
+      "PremiereDate": "2025-04-08T22:00:00.0000000Z",
+      "CriticRating": 62,
+      "OfficialRating": "NL-12",
+      "ChannelId": null,
+      "Genres": [
+        "Thriller",
+        "Action"
+      ],
+      "CommunityRating": 6.949,
+      "RunTimeTicks": 73612710000,
+      "ProductionYear": 2025,
+      "ProviderIds": {
+        "Imdb": "tt0899043",
+        "Tmdb": "1087891"
+      },
+      "IsFolder": false,
+      "Type": "Movie",
+      "GenreItems": [
+        {
+          "Name": "Thriller",
+          "Id": "4936f5b1a6f84f0b0aa2657368a5b364"
+        },
+        {
+          "Name": "Action",
+          "Id": "ce06903d834d2c3417e0889dd4049f3b"
+        }
+      ],
+      "UserData": {
+        "PlayedPercentage": 100,
+        "PlaybackPositionTicks": 0,
+        "PlayCount": 1,
+        "IsFavorite": false,
+        "Played": true,
+        "Key": "1087891",
+        "ItemId": "bd506f6de56ad3c3c600ad723982c0a5"
+      },
+      "VideoType": "VideoFile",
+      "ImageBlurHashes": {},
+      "LocationType": "FileSystem",
+      "MediaType": "Video"
+    },
+    {
+      "Name": "American Murder: Laci Peterson",
+      "ServerId": "03b5e7fd4c8a4de8b4164d4d21b72608",
+      "Id": "e8211d1f87a7b235a84010f81a4f10b9",
+      "PremiereDate": "2024-08-13T22:00:00.0000000Z",
+      "ChannelId": null,
+      "Genres": [
+        "Documentary",
+        "Crime"
+      ],
+      "RunTimeTicks": 31800000000,
+      "ProductionYear": 2024,
+      "ProviderIds": {
+        "Imdb": "tt33079160",
+        "Tmdb": "261034",
+        "Tvdb": "452965",
+        "TvdbSlug": "american-murder-laci-peterson"
+      },
+      "IsFolder": true,
+      "Type": "Series",
+      "GenreItems": [
+        {
+          "Name": "Documentary",
+          "Id": "818912eba0fc399e496b109d438effe9"
+        },
+        {
+          "Name": "Crime",
+          "Id": "83a9dab21914792744c8fb23b9925dc6"
+        }
+      ],
+      "UserData": {
+        "UnplayedItemCount": 1,
+        "PlaybackPositionTicks": 0,
+        "PlayCount": 0,
+        "IsFavorite": false,
+        "Played": false,
+        "Key": "452965",
+        "ItemId": "e8211d1f87a7b235a84010f81a4f10b9"
+      },
+      "Status": "Ended",
+      "AirTime": "03:00",
+      "AirDays": [
+        "Wednesday"
+      ],
+      "ImageBlurHashes": {},
+      "LocationType": "FileSystem",
+      "MediaType": "Unknown",
+      "EndDate": "2024-01-13T23:08:00.0000000Z"
+    },
+    {
+      "Name": "Amsterdam Empire",
+      "ServerId": "03b5e7fd4c8a4de8b4164d4d21b72608",
+      "Id": "80e2802357bebfc2467c947dd8eea7dc",
+      "PremiereDate": "2025-10-29T23:00:00.0000000Z",
+      "ChannelId": null,
+      "Genres": [
+        "Drama",
+        "Crime",
+        "Thriller"
+      ],
+      "RunTimeTicks": 26400000000,
+      "ProductionYear": 2025,
+      "ProviderIds": {
+        "Imdb": "tt31835154",
+        "Tmdb": "249586",
+        "Tvdb": "447836",
+        "TvdbSlug": "amsterdam-empire"
+      },
+      "IsFolder": true,
+      "Type": "Series",
+      "GenreItems": [
+        {
+          "Name": "Drama",
+          "Id": "090eac6e9de4fe1fbc194e5b96691277"
+        },
+        {
+          "Name": "Crime",
+          "Id": "83a9dab21914792744c8fb23b9925dc6"
+        },
+        {
+          "Name": "Thriller",
+          "Id": "4936f5b1a6f84f0b0aa2657368a5b364"
+        }
+      ],
+      "UserData": {
+        "UnplayedItemCount": 0,
+        "PlaybackPositionTicks": 0,
+        "PlayCount": 1,
+        "IsFavorite": false,
+        "Played": true,
+        "Key": "447836",
+        "ItemId": "80e2802357bebfc2467c947dd8eea7dc"
+      },
+      "Status": "Continuing",
+      "AirTime": "04:00",
+      "AirDays": [
+        "Thursday"
+      ],
+      "ImageBlurHashes": {},
+      "LocationType": "FileSystem",
+      "MediaType": "Unknown"
+    },
+    {
+      "Name": "Amsterdamned",
+      "ServerId": "03b5e7fd4c8a4de8b4164d4d21b72608",
+      "Id": "28e69e8a9eb65601fa975ac1fcd5bf8a",
+      "HasSubtitles": true,
+      "Container": "mkv",
+      "PremiereDate": "1988-02-10T23:00:00.0000000Z",
+      "OfficialRating": "NL-16",
+      "ChannelId": null,
+      "Genres": [
+        "Action",
+        "Horror",
+        "Thriller"
+      ],
+      "CommunityRating": 6.3,
+      "RunTimeTicks": 67898880000,
+      "ProductionYear": 1988,
+      "ProviderIds": {
+        "Imdb": "tt0094651",
+        "Tmdb": "2093",
+        "TmdbCollection": "1239180"
+      },
+      "IsFolder": false,
+      "Type": "Movie",
+      "GenreItems": [
+        {
+          "Name": "Action",
+          "Id": "ce06903d834d2c3417e0889dd4049f3b"
+        },
+        {
+          "Name": "Horror",
+          "Id": "8b9bd9a3eddad02f2b759b4938fdd0b8"
+        },
+        {
+          "Name": "Thriller",
+          "Id": "4936f5b1a6f84f0b0aa2657368a5b364"
+        }
+      ],
+      "UserData": {
+        "PlaybackPositionTicks": 0,
+        "PlayCount": 0,
+        "IsFavorite": false,
+        "Played": false,
+        "Key": "2093",
+        "ItemId": "28e69e8a9eb65601fa975ac1fcd5bf8a"
+      },
+      "VideoType": "VideoFile",
+      "ImageBlurHashes": {},
+      "LocationType": "FileSystem",
+      "MediaType": "Video"
+    },
+    {
+      "Name": "Amsterdamned II",
+      "ServerId": "03b5e7fd4c8a4de8b4164d4d21b72608",
+      "Id": "fd18f09cb13f87ce5567cf1f6be43c72",
+      "HasSubtitles": true,
+      "Container": "mkv",
+      "PremiereDate": "2025-11-29T23:00:00.0000000Z",
+      "OfficialRating": "NL-12",
+      "ChannelId": null,
+      "Genres": [
+        "Action",
+        "Thriller"
+      ],
+      "CommunityRating": 5.7,
+      "RunTimeTicks": 66100160000,
+      "ProductionYear": 2025,
+      "ProviderIds": {
+        "Imdb": "tt29943172",
+        "Tmdb": "1179684",
+        "TmdbCollection": "1239180"
+      },
+      "IsFolder": false,
+      "Type": "Movie",
+      "GenreItems": [
+        {
+          "Name": "Action",
+          "Id": "ce06903d834d2c3417e0889dd4049f3b"
+        },
+        {
+          "Name": "Thriller",
+          "Id": "4936f5b1a6f84f0b0aa2657368a5b364"
+        }
+      ],
+      "UserData": {
+        "PlaybackPositionTicks": 0,
+        "PlayCount": 1,
+        "IsFavorite": false,
+        "Played": true,
+        "Key": "1179684",
+        "ItemId": "fd18f09cb13f87ce5567cf1f6be43c72"
+      },
+      "VideoType": "VideoFile",
+      "ImageBlurHashes": {},
+      "LocationType": "FileSystem",
+      "MediaType": "Video"
+    },
+    {
+      "Name": "Amy",
+      "ServerId": "03b5e7fd4c8a4de8b4164d4d21b72608",
+      "Id": "70ae426515fa74b379ca5d8fcaa96422",
+      "HasSubtitles": true,
+      "Container": "mkv",
+      "PremiereDate": "2015-07-01T22:00:00.0000000Z",
+      "CriticRating": 96,
+      "OfficialRating": "NL-12",
+      "ChannelId": null,
+      "Genres": [
+        "Documentary",
+        "Music"
+      ],
+      "CommunityRating": 7.6,
+      "RunTimeTicks": 73616960000,
+      "ProductionYear": 2015,
+      "ProviderIds": {
+        "Imdb": "tt2870648",
+        "Tmdb": "331781"
+      },
+      "IsFolder": false,
+      "Type": "Movie",
+      "GenreItems": [
+        {
+          "Name": "Documentary",
+          "Id": "818912eba0fc399e496b109d438effe9"
+        },
+        {
+          "Name": "Music",
+          "Id": "f67b77276f76b0e5413abcedbe777bbe"
+        }
+      ],
+      "UserData": {
+        "PlaybackPositionTicks": 0,
+        "PlayCount": 0,
+        "IsFavorite": false,
+        "Played": false,
+        "Key": "331781",
+        "ItemId": "70ae426515fa74b379ca5d8fcaa96422"
+      },
+      "VideoType": "VideoFile",
+      "ImageBlurHashes": {},
+      "LocationType": "FileSystem",
+      "MediaType": "Video"
+    },
+    {
+      "Name": "Amy Bradley Is Missing",
+      "ServerId": "03b5e7fd4c8a4de8b4164d4d21b72608",
+      "Id": "549e5408cd866e4d9342c6ff762ab2ad",
+      "PremiereDate": "2025-07-15T22:00:00.0000000Z",
+      "ChannelId": null,
+      "Genres": [
+        "Documentary",
+        "Crime"
+      ],
+      "RunTimeTicks": 26400000000,
+      "ProductionYear": 2025,
+      "ProviderIds": {
+        "Imdb": "tt37439438",
+        "Tmdb": "294726",
+        "Tvdb": "465157",
+        "TvdbSlug": "amy-bradley-is-missing"
+      },
+      "IsFolder": true,
+      "Type": "Series",
+      "GenreItems": [
+        {
+          "Name": "Documentary",
+          "Id": "818912eba0fc399e496b109d438effe9"
+        },
+        {
+          "Name": "Crime",
+          "Id": "83a9dab21914792744c8fb23b9925dc6"
+        }
+      ],
+      "UserData": {
+        "UnplayedItemCount": 0,
+        "PlaybackPositionTicks": 0,
+        "PlayCount": 1,
+        "IsFavorite": false,
+        "Played": true,
+        "Key": "465157",
+        "ItemId": "549e5408cd866e4d9342c6ff762ab2ad"
+      },
+      "Status": "Ended",
+      "AirTime": "03:00",
+      "AirDays": [
+        "Wednesday"
+      ],
+      "ImageBlurHashes": {},
+      "LocationType": "FileSystem",
+      "MediaType": "Unknown",
+      "EndDate": "2025-01-15T23:07:00.0000000Z"
+    },
+    {
+      "Name": "Ancient Apocalypse (2022)",
+      "ServerId": "03b5e7fd4c8a4de8b4164d4d21b72608",
+      "Id": "0546221e71d4c9c54f0e4e970e898b08",
+      "PremiereDate": "2022-11-10T23:00:00.0000000Z",
+      "ChannelId": null,
+      "Genres": [
+        "Documentary"
+      ],
+      "RunTimeTicks": 21000000000,
+      "ProductionYear": 2022,
+      "ProviderIds": {
+        "Imdb": "tt22807484",
+        "Tmdb": "212869",
+        "Tvdb": "426211",
+        "TvdbSlug": "ancient-apocalypse-2022"
+      },
+      "IsFolder": true,
+      "Type": "Series",
+      "GenreItems": [
+        {
+          "Name": "Documentary",
+          "Id": "818912eba0fc399e496b109d438effe9"
+        }
+      ],
+      "UserData": {
+        "UnplayedItemCount": 1,
+        "PlaybackPositionTicks": 0,
+        "PlayCount": 0,
+        "IsFavorite": false,
+        "Played": false,
+        "Key": "426211",
+        "ItemId": "0546221e71d4c9c54f0e4e970e898b08"
+      },
+      "Status": "Ended",
+      "AirTime": "09:00",
+      "AirDays": [
+        "Friday"
+      ],
+      "ImageBlurHashes": {},
+      "LocationType": "FileSystem",
+      "MediaType": "Unknown",
+      "EndDate": "2024-01-15T23:10:00.0000000Z"
+    },
+    {
+      "Name": "Apartment 7A",
+      "ServerId": "03b5e7fd4c8a4de8b4164d4d21b72608",
+      "Id": "d945d0ee6a304cb86eb361595ff9333d",
+      "HasSubtitles": true,
+      "Container": "mkv",
+      "PremiereDate": "2024-09-20T00:00:00.0000000Z",
+      "OfficialRating": "R",
+      "ChannelId": null,
+      "Genres": [
+        "Horror",
+        "Thriller"
+      ],
+      "CommunityRating": 6.2,
+      "RunTimeTicks": 63689880000,
+      "ProductionYear": 2024,
+      "ProviderIds": {
+        "Imdb": "tt14371860",
+        "Tmdb": "807339",
+        "TmdbCollection": "264338"
+      },
+      "IsFolder": false,
+      "Type": "Movie",
+      "GenreItems": [
+        {
+          "Name": "Horror",
+          "Id": "8b9bd9a3eddad02f2b759b4938fdd0b8"
+        },
+        {
+          "Name": "Thriller",
+          "Id": "4936f5b1a6f84f0b0aa2657368a5b364"
+        }
+      ],
+      "UserData": {
+        "PlaybackPositionTicks": 0,
+        "PlayCount": 1,
+        "IsFavorite": false,
+        "Played": true,
+        "Key": "807339",
+        "ItemId": "d945d0ee6a304cb86eb361595ff9333d"
+      },
+      "VideoType": "VideoFile",
+      "ImageBlurHashes": {},
+      "LocationType": "FileSystem",
+      "MediaType": "Video"
+    },
+    {
+      "Name": "Apocalypse in the Tropics",
+      "ServerId": "03b5e7fd4c8a4de8b4164d4d21b72608",
+      "Id": "7585be0381737042591059e5fc603445",
+      "HasSubtitles": true,
+      "Container": "mkv",
+      "PremiereDate": "2025-07-03T00:00:00.0000000Z",
+      "CriticRating": 94,
+      "OfficialRating": "PG-13",
+      "ChannelId": null,
+      "Genres": [
+        "Documentary"
+      ],
+      "CommunityRating": 6.3,
+      "RunTimeTicks": 65970559999,
+      "ProductionYear": 2025,
+      "ProviderIds": {
+        "Imdb": "tt30012657",
+        "Tmdb": "1320400"
+      },
+      "IsFolder": false,
+      "Type": "Movie",
+      "GenreItems": [
+        {
+          "Name": "Documentary",
+          "Id": "818912eba0fc399e496b109d438effe9"
+        }
+      ],
+      "UserData": {
+        "PlaybackPositionTicks": 0,
+        "PlayCount": 0,
+        "IsFavorite": false,
+        "Played": false,
+        "Key": "1320400",
+        "ItemId": "7585be0381737042591059e5fc603445"
+      },
+      "VideoType": "VideoFile",
+      "ImageBlurHashes": {},
+      "LocationType": "FileSystem",
+      "MediaType": "Video"
+    },
+    {
+      "Name": "The Apprentice",
+      "ServerId": "03b5e7fd4c8a4de8b4164d4d21b72608",
+      "Id": "cdf1015e99d2bce7b5cc37b231b74253",
+      "HasSubtitles": true,
+      "Container": "mkv",
+      "PremiereDate": "2024-10-09T00:00:00.0000000Z",
+      "CriticRating": 83,
+      "OfficialRating": "NL-14",
+      "ChannelId": null,
+      "Genres": [
+        "History",
+        "Drama"
+      ],
+      "CommunityRating": 6.9,
+      "RunTimeTicks": 73379980000,
+      "ProductionYear": 2024,
+      "ProviderIds": {
+        "Imdb": "tt8368368",
+        "Tmdb": "1182047"
+      },
+      "IsFolder": false,
+      "Type": "Movie",
+      "GenreItems": [
+        {
+          "Name": "History",
+          "Id": "7e6f6b834496507dc07db3b9623caef4"
+        },
+        {
+          "Name": "Drama",
+          "Id": "090eac6e9de4fe1fbc194e5b96691277"
+        }
+      ],
+      "UserData": {
+        "PlaybackPositionTicks": 0,
+        "PlayCount": 1,
+        "IsFavorite": false,
+        "Played": true,
+        "Key": "1182047",
+        "ItemId": "cdf1015e99d2bce7b5cc37b231b74253"
+      },
+      "VideoType": "VideoFile",
+      "ImageBlurHashes": {},
+      "LocationType": "FileSystem",
+      "MediaType": "Video"
+    },
+    {
+      "Name": "Attack on Titan",
+      "ServerId": "03b5e7fd4c8a4de8b4164d4d21b72608",
+      "Id": "d9b4602426bd51fb2ee5737ad3396180",
+      "PremiereDate": "2013-04-06T22:00:00.0000000Z",
+      "OfficialRating": "18",
+      "ChannelId": null,
+      "Genres": [
+        "Horror",
+        "Fantasy",
+        "Drama",
+        "Animation",
+        "Adventure",
+        "Action",
+        "Anime"
+      ],
+      "CommunityRating": 8.3,
+      "RunTimeTicks": 15000000000,
+      "ProductionYear": 2013,
+      "ProviderIds": {
+        "AniDB": "9541",
+        "Imdb": "tt2560140",
+        "Tmdb": "1429",
+        "Tvdb": "267440",
+        "TvdbSlug": "attack-on-titan"
+      },
+      "IsFolder": true,
+      "Type": "Series",
+      "GenreItems": [
+        {
+          "Name": "Horror",
+          "Id": "8b9bd9a3eddad02f2b759b4938fdd0b8"
+        },
+        {
+          "Name": "Fantasy",
+          "Id": "a30dcc65be22eb3c21c03f7c1c7a57d1"
+        },
+        {
+          "Name": "Drama",
+          "Id": "090eac6e9de4fe1fbc194e5b96691277"
+        },
+        {
+          "Name": "Animation",
+          "Id": "074229225b7254292f131f9f49f8dcd6"
+        },
+        {
+          "Name": "Adventure",
+          "Id": "51cec9645b896084d12b259acd05ccb1"
+        },
+        {
+          "Name": "Action",
+          "Id": "ce06903d834d2c3417e0889dd4049f3b"
+        },
+        {
+          "Name": "Anime",
+          "Id": "f89b4d4d7733020ed2721d8fec37f26c"
+        }
+      ],
+      "UserData": {
+        "UnplayedItemCount": 1,
+        "PlaybackPositionTicks": 0,
+        "PlayCount": 0,
+        "IsFavorite": false,
+        "Played": false,
+        "Key": "267440",
+        "ItemId": "d9b4602426bd51fb2ee5737ad3396180"
+      },
+      "Status": "Ended",
+      "AirTime": "00:30",
+      "AirDays": [
+        "Saturday"
+      ],
+      "ImageBlurHashes": {},
+      "LocationType": "FileSystem",
+      "MediaType": "Unknown",
+      "EndDate": "2023-01-04T23:11:00.0000000Z"
+    },
+    {
+      "Name": "Avicii - I'm Tim",
+      "ServerId": "03b5e7fd4c8a4de8b4164d4d21b72608",
+      "Id": "6a7f6ac536286d4d49929fcd361685be",
+      "HasSubtitles": true,
+      "Container": "mkv",
+      "PremiereDate": "2024-06-08T22:00:00.0000000Z",
+      "OfficialRating": "NL-AL",
+      "ChannelId": null,
+      "Genres": [
+        "Documentary",
+        "Music"
+      ],
+      "CommunityRating": 8.103,
+      "RunTimeTicks": 58083200000,
+      "ProductionYear": 2024,
+      "ProviderIds": {
+        "Imdb": "tt32138523",
+        "Tmdb": "1275945"
+      },
+      "IsFolder": false,
+      "Type": "Movie",
+      "GenreItems": [
+        {
+          "Name": "Documentary",
+          "Id": "818912eba0fc399e496b109d438effe9"
+        },
+        {
+          "Name": "Music",
+          "Id": "f67b77276f76b0e5413abcedbe777bbe"
+        }
+      ],
+      "UserData": {
+        "PlaybackPositionTicks": 0,
+        "PlayCount": 1,
+        "IsFavorite": false,
+        "Played": true,
+        "Key": "1275945",
+        "ItemId": "6a7f6ac536286d4d49929fcd361685be"
+      },
+      "VideoType": "VideoFile",
+      "ImageBlurHashes": {},
+      "LocationType": "FileSystem",
+      "MediaType": "Video"
+    },
+    {
+      "Name": "Back to Black",
+      "ServerId": "03b5e7fd4c8a4de8b4164d4d21b72608",
+      "Id": "cf861b4ae4b3c3ea2b5e21106b984838",
+      "HasSubtitles": true,
+      "Container": "mkv",
+      "PremiereDate": "2024-04-10T22:00:00.0000000Z",
+      "CriticRating": 35,
+      "OfficialRating": "NL-12",
+      "ChannelId": null,
+      "Genres": [
+        "Music",
+        "History",
+        "Drama"
+      ],
+      "CommunityRating": 6.675,
+      "RunTimeTicks": 73847110000,
+      "ProductionYear": 2024,
+      "ProviderIds": {
+        "Imdb": "tt21261712",
+        "Tmdb": "998846"
+      },
+      "IsFolder": false,
+      "Type": "Movie",
+      "GenreItems": [
+        {
+          "Name": "Music",
+          "Id": "f67b77276f76b0e5413abcedbe777bbe"
+        },
+        {
+          "Name": "History",
+          "Id": "7e6f6b834496507dc07db3b9623caef4"
+        },
+        {
+          "Name": "Drama",
+          "Id": "090eac6e9de4fe1fbc194e5b96691277"
+        }
+      ],
+      "UserData": {
+        "PlaybackPositionTicks": 0,
+        "PlayCount": 0,
+        "IsFavorite": false,
+        "Played": false,
+        "Key": "998846",
+        "ItemId": "cf861b4ae4b3c3ea2b5e21106b984838"
+      },
+      "VideoType": "VideoFile",
+      "ImageBlurHashes": {},
+      "LocationType": "FileSystem",
+      "MediaType": "Video"
+    },
+    {
+      "Name": "Bad Monkey",
+      "ServerId": "03b5e7fd4c8a4de8b4164d4d21b72608",
+      "Id": "0e812b162bb7ac70065fb339fc8b8c41",
+      "PremiereDate": "2024-08-13T22:00:00.0000000Z",
+      "OfficialRating": "TV-MA",
+      "ChannelId": null,
+      "Genres": [
+        "Drama",
+        "Crime",
+        "Comedy",
+        "Mystery"
+      ],
+      "RunTimeTicks": 27600000000,
+      "ProductionYear": 2024,
+      "ProviderIds": {
+        "Imdb": "tt15203646",
+        "Tmdb": "130853",
+        "Tvdb": "408436",
+        "TvdbSlug": "bad-monkey"
+      },
+      "IsFolder": true,
+      "Type": "Series",
+      "GenreItems": [
+        {
+          "Name": "Drama",
+          "Id": "090eac6e9de4fe1fbc194e5b96691277"
+        },
+        {
+          "Name": "Crime",
+          "Id": "83a9dab21914792744c8fb23b9925dc6"
+        },
+        {
+          "Name": "Comedy",
+          "Id": "08d31605d366d63a7a924f944b4417f1"
+        },
+        {
+          "Name": "Mystery",
+          "Id": "d3a0ead52489743e5a68704142092c71"
+        }
+      ],
+      "UserData": {
+        "UnplayedItemCount": 0,
+        "PlaybackPositionTicks": 0,
+        "PlayCount": 1,
+        "IsFavorite": false,
+        "Played": true,
+        "Key": "408436",
+        "ItemId": "0e812b162bb7ac70065fb339fc8b8c41"
+      },
+      "Status": "Continuing",
+      "AirTime": "00:00",
+      "AirDays": [
+        "Wednesday"
+      ],
+      "ImageBlurHashes": {},
+      "LocationType": "FileSystem",
+      "MediaType": "Unknown"
+    },
+    {
+      "Name": "The Beach Boys",
+      "ServerId": "03b5e7fd4c8a4de8b4164d4d21b72608",
+      "Id": "e2b85a832a2bfc16881b58d5d276fefc",
+      "HasSubtitles": true,
+      "Container": "mkv",
+      "PremiereDate": "2024-05-20T22:00:00.0000000Z",
+      "CriticRating": 89,
+      "OfficialRating": "NL-12",
+      "ChannelId": null,
+      "Genres": [
+        "Documentary",
+        "Music"
+      ],
+      "CommunityRating": 6.576,
+      "RunTimeTicks": 67862380000,
+      "ProductionYear": 2024,
+      "ProviderIds": {
+        "Imdb": "tt31922530",
+        "Tmdb": "1265066"
+      },
+      "IsFolder": false,
+      "Type": "Movie",
+      "GenreItems": [
+        {
+          "Name": "Documentary",
+          "Id": "818912eba0fc399e496b109d438effe9"
+        },
+        {
+          "Name": "Music",
+          "Id": "f67b77276f76b0e5413abcedbe777bbe"
+        }
+      ],
+      "UserData": {
+        "PlaybackPositionTicks": 0,
+        "PlayCount": 0,
+        "IsFavorite": false,
+        "Played": false,
+        "Key": "1265066",
+        "ItemId": "e2b85a832a2bfc16881b58d5d276fefc"
+      },
+      "VideoType": "VideoFile",
+      "ImageBlurHashes": {},
+      "LocationType": "FileSystem",
+      "MediaType": "Video"
+    }
+  ],
+  "TotalRecordCount": 292,
+  "StartIndex": 0
+}

--- a/test/helpers/serve.ts
+++ b/test/helpers/serve.ts
@@ -11,9 +11,15 @@ export const jsonResponse = (body: unknown, status = 200): Response =>
 export const serving = (routes: Record<string, unknown>): typeof fetch =>
     (async (input: string | URL | Request) => {
         const raw = input instanceof Request ? input.url : String(input);
-        const path = new URL(raw).pathname;
-        if (!(path in routes)) return jsonResponse({ message: 'not found' }, 404);
-        return jsonResponse(routes[path]);
+        const url = new URL(raw);
+        // Query string included first, so a route keyed on the full path (e.g.
+        // Jellyfin's `/Items?userId=…`) can be matched exactly rather than only
+        // by its pathname. Falling back to pathname-only keeps every existing
+        // route registered without a query string working unchanged.
+        const withQuery = `${url.pathname}${url.search}`;
+        if (withQuery in routes) return jsonResponse(routes[withQuery]);
+        if (url.pathname in routes) return jsonResponse(routes[url.pathname]);
+        return jsonResponse({ message: 'not found' }, 404);
     }) as unknown as typeof fetch;
 
 /** SABnzbd routes on the `mode` query parameter rather than on the path. */

--- a/test/library-reads.test.ts
+++ b/test/library-reads.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest';
+import type { KeyedServiceConfig, MultiUserServiceConfig } from '../src/config/schema.ts';
+import { JellyfinAdapter } from '../src/services/jellyfin.ts';
+import { RadarrAdapter } from '../src/services/radarr.ts';
+import { SonarrAdapter } from '../src/services/sonarr.ts';
+import { hasLibrary, hasUserLibrary } from '../src/services/types.ts';
+import { serving } from './helpers/serve.ts';
+
+const keyed: KeyedServiceConfig = {
+    url: 'http://192.0.2.10:7878',
+    api_key: 'k',
+    timeout_ms: 10_000,
+    permissions: { safe_write: false, destructive: false }
+};
+const multi: MultiUserServiceConfig = { ...keyed, default_user: 'Someone', allow_other_users: false };
+
+const MOVIES = [
+    {
+        id: 1,
+        title: 'Some Film',
+        year: 2026,
+        monitored: true,
+        hasFile: true,
+        tmdbId: 550,
+        imdbId: 'tt0137523',
+        genres: ['Drama', 'Thriller'],
+        ratings: { imdb: { votes: 100, value: 8.8, type: 'user' }, rottenTomatoes: { votes: 0, value: 96, type: 'user' } },
+        movieFile: { size: 4_000_000_000, quality: { quality: { name: 'Bluray-1080p' } } }
+    }
+];
+
+const SERIES = [
+    {
+        id: 7,
+        title: 'Some Show',
+        year: 2017,
+        monitored: true,
+        tvdbId: 292157,
+        imdbId: 'tt5687612',
+        genres: ['Drama'],
+        ratings: { votes: 164018, value: 8.3 },
+        statistics: { sizeOnDisk: 90_000_000_000, episodeFileCount: 8 }
+    }
+];
+
+const ITEMS = {
+    Items: [
+        {
+            Id: 'abc',
+            Name: 'Some Film',
+            Type: 'Movie',
+            ProductionYear: 2026,
+            Genres: ['Drama'],
+            // Strings, as Jellyfin returns them — Radarr and Sonarr use numbers.
+            ProviderIds: { Tmdb: '550', Imdb: 'tt0137523' },
+            UserData: { Played: true, PlayCount: 2, LastPlayedDate: '2026-08-01T20:00:00Z' }
+        },
+        {
+            Id: 'def',
+            Name: 'Some Show',
+            Type: 'Series',
+            ProviderIds: { Tvdb: '292157' },
+            UserData: { Played: false, PlayCount: 0 }
+        }
+    ]
+};
+
+describe('Radarr.listLibrary', () => {
+    const adapter = () => new RadarrAdapter(keyed, serving({ '/api/v3/movie': MOVIES }));
+
+    it('is discoverable through the capability guard', () => {
+        expect(hasLibrary(adapter())).toBe(true);
+    });
+
+    it('maps a film into an index input', async () => {
+        const [item] = await adapter().listLibrary();
+        expect(item).toMatchObject({
+            kind: 'movie',
+            year: 2026,
+            // Fenced like every other string a service chose (§11). The filter
+            // compares through the fence rather than against it.
+            genres: [
+                '<<untrusted:radarr.genre>>Drama<</untrusted>>',
+                '<<untrusted:radarr.genre>>Thriller<</untrusted>>'
+            ],
+            ids: { tmdb: 550, imdb: 'tt0137523' },
+            acquisition: {
+                service: 'radarr',
+                monitored: true,
+                hasFile: true,
+                quality: 'Bluray-1080p',
+                sizeBytes: 4_000_000_000
+            }
+        });
+    });
+
+    it('fences the title, because it is a name a service chose', async () => {
+        const [item] = await adapter().listLibrary();
+        expect(item?.title).toBe('<<untrusted:radarr.title>>Some Film<</untrusted>>');
+    });
+
+    it('keeps only rating sources the merged type names', async () => {
+        const [item] = await adapter().listLibrary();
+        expect(item?.ratings).toEqual({ imdb: 8.8, rottenTomatoes: 96 });
+    });
+});
+
+describe('Sonarr.listLibrary', () => {
+    const adapter = () => new SonarrAdapter(keyed, serving({ '/api/v3/series': SERIES }));
+
+    it('maps a series, sized from statistics rather than a file', async () => {
+        const [item] = await adapter().listLibrary();
+        expect(item).toMatchObject({
+            kind: 'series',
+            ids: { tvdb: 292157, imdb: 'tt5687612' },
+            acquisition: { service: 'sonarr', monitored: true, sizeBytes: 90_000_000_000 }
+        });
+    });
+
+    it('reports hasFile from the episode file count, which is all a series has', async () => {
+        const [item] = await adapter().listLibrary();
+        expect(item?.acquisition?.hasFile).toBe(true);
+    });
+
+    it('labels the flat Sonarr rating tvdb, never as a per-source map', async () => {
+        // §21.2: reporting this as `{ votes: 164018 }` is what 0.3.0 shipped.
+        const [item] = await adapter().listLibrary();
+        expect(item?.ratings).toEqual({ tvdb: 8.3 });
+    });
+
+    it('reports no quality, because a series quality would be a fiction', async () => {
+        const [item] = await adapter().listLibrary();
+        expect(item?.acquisition?.quality).toBeUndefined();
+    });
+});
+
+describe('Jellyfin.listUserLibrary', () => {
+    const path =
+        '/Items?userId=u1&Recursive=true&IncludeItemTypes=Movie,Series&Fields=ProviderIds,Genres&EnableUserData=true';
+    const adapter = () => new JellyfinAdapter(multi, serving({ [path]: ITEMS }));
+    const user = { id: 'u1', name: 'Someone' };
+
+    it('is discoverable through the capability guard', () => {
+        expect(hasUserLibrary(adapter())).toBe(true);
+    });
+
+    it('converts Jellyfin string ids to numbers, or every join silently fails', async () => {
+        const items = await adapter().listUserLibrary(user);
+        expect(items[0]?.ids).toEqual({ tmdb: 550, imdb: 'tt0137523' });
+    });
+
+    it('maps watch state, which exists nowhere else in the stack', async () => {
+        const items = await adapter().listUserLibrary(user);
+        expect(items[0]?.playback).toEqual({
+            user: 'Someone',
+            watched: true,
+            playCount: 2,
+            lastPlayed: '2026-08-01T20:00:00Z'
+        });
+    });
+
+    it('reports an unwatched item as watched: false rather than omitting it', async () => {
+        const items = await adapter().listUserLibrary(user);
+        expect(items[1]?.playback).toMatchObject({ watched: false, playCount: 0 });
+    });
+
+    it('distinguishes series from films by Type', async () => {
+        const items = await adapter().listUserLibrary(user);
+        expect(items.map(i => i.kind)).toEqual(['movie', 'series']);
+    });
+
+    it('contributes no acquisition half — Jellyfin manages nothing', async () => {
+        const items = await adapter().listUserLibrary(user);
+        expect(items.every(i => i.acquisition === undefined)).toBe(true);
+    });
+});


### PR DESCRIPTION
Phase 3b, Task 1 of 9. Gives the three adapters the whole-library read that feeds 3a's identity resolver. Nothing consumes them yet — Task 2 builds the loader.

Shaped for the resolver rather than for a tool: each method returns `IndexInput`, so `LibraryIndex.build` can merge the three sources on shared external ids without an adapter layer in between.

**Jellyfin's read is per-user by construction.** Watch state does not exist without a user, so a shared signature would let a caller forget to supply one.

**Sonarr's rating stays a flat TVDB value** and its `hasFile` comes from the episode file count — a series has no single file and no single quality, which is why the quality filter will be films-only.

## Two defects the capture-first discipline caught

Writing the mapping from a guess is what put seven defects in 0.3.0. Capturing first found two problems before any of them could ship:

**The anonymiser was leaking watch behaviour.** It scrubbed `Played`, `PlayCount` and `LastPlayedDate` — and left `PlaybackPositionTicks` (exact resume point) and `PlayedPercentage` (partial progress) untouched on real items, heading for a public repository. Now neutralised along with `UnplayedItemCount` and `IsFavorite`: all real behavioural signal the adapter never reads. Keys and types are preserved, which is all the contract test needs.

Library titles are already public in the committed fixtures. Who watched what, and how far, is not.

**Routing Sonarr's rating through `toMergedRatings` would have silently dropped every series rating.** That function's allowlist has no `tvdb` entry, so each series would have come back with no rating at all and a green suite. `KNOWN` now carries a comment saying why `tvdb` is absent, so the next "simplification" doesn't walk into it.

## Contract coverage

Both genuinely new reads are now guarded: `statistics.episodeFileCount`, which drives `hasFile` for every series, and `Items.Genres`. Verified against the committed fixtures rather than assumed — a dotted path that passes for the wrong reason is drift protection that only looks real.

**520 tests**, up from 505.

🤖 Generated with [Claude Code](https://claude.com/claude-code)