### PR TITLE
feat: add the cached library loader

### DIFF
--- a/src/core/cache.ts
+++ b/src/core/cache.ts
@@ -52,13 +52,11 @@ export class TtlCache {
     }
 
     /**
-     * The seam for write-invalidation (§16). As of Phase 3a, still nothing in
-     * production code calls it (only `test/cache.test.ts` exercises it
-     * directly) — the original "nothing calls it until 0.5" was a
-     * prediction, not yet a fact this codebase can back up: the earliest
-     * planned caller is Phase 3b's library loader, invalidating on every
-     * degraded load so a partial library snapshot is not cached for the full
-     * five-minute TTL. That is well before 0.5 (writes), not at it.
+     * The seam for write-invalidation (§16). As of Phase 3b, it is no longer
+     * merely a seam: `LibraryLoader.load` calls it on every degraded load, so
+     * a partial library snapshot is not cached for the full five-minute TTL
+     * — the missing service is usually restarting, and the next call should
+     * find it rather than getting a stale gap for five minutes.
      */
     invalidate(key: string): void {
         this.#entries.delete(key);

--- a/src/core/cache.ts
+++ b/src/core/cache.ts
@@ -27,8 +27,18 @@ export class TtlCache {
      * The stored value is the *promise*, not the resolved value. That is what
      * makes this single-flight: two concurrent callers find the same in-flight
      * promise and share one fetch rather than both hitting the service.
+     *
+     * `shouldCache`, when given, runs on the resolved value and can decline to
+     * keep it — e.g. a library snapshot from a degraded load, not worth five
+     * minutes of cache when the missing service is usually just restarting.
+     * It is not a second `invalidate()` call from the caller's side on
+     * purpose: a bare `invalidate()` after the fact cannot tell "my load lost
+     * a race to a fresher, complete one" from "nothing raced me," and would
+     * delete the good entry in the first case. Deciding here, under the same
+     * identity check the failure path below uses, means only this exact
+     * load's entry is ever dropped.
      */
-    async get<T>(key: string, ttlMs: number, load: () => Promise<T>): Promise<T> {
+    async get<T>(key: string, ttlMs: number, load: () => Promise<T>, shouldCache?: (value: T) => boolean): Promise<T> {
         const existing = this.#entries.get(key);
         if (existing !== undefined && existing.expiresAt > this.#now()) {
             return existing.value as Promise<T>;
@@ -38,7 +48,14 @@ export class TtlCache {
         this.#entries.set(key, { value, expiresAt: this.#now() + ttlMs });
 
         try {
-            return await value;
+            const resolved = await value;
+            if (shouldCache !== undefined && !shouldCache(resolved)) {
+                // Guarded on identity for the same reason as the failure path
+                // below: a later successful load may already have replaced
+                // this entry, and dropping that would be a second bug.
+                if (this.#entries.get(key)?.value === value) this.#entries.delete(key);
+            }
+            return resolved;
         } catch (err) {
             // Never cache a failure. A service restarting during the first call
             // would otherwise poison every later call until arr-mcp restarts —
@@ -52,11 +69,14 @@ export class TtlCache {
     }
 
     /**
-     * The seam for write-invalidation (§16). As of Phase 3b, it is no longer
-     * merely a seam: `LibraryLoader.load` calls it on every degraded load, so
-     * a partial library snapshot is not cached for the full five-minute TTL
-     * — the missing service is usually restarting, and the next call should
-     * find it rather than getting a stale gap for five minutes.
+     * The seam for write-invalidation (§16). Still nothing in production code
+     * calls it as of Phase 3b (only `test/cache.test.ts` exercises it
+     * directly): `LibraryLoader` needed "do not cache a degraded load," but
+     * implemented it via `get`'s `shouldCache` predicate instead of a
+     * follow-up call here, specifically to reuse the identity check that
+     * guards against deleting a fresher entry out from under a concurrent
+     * caller — a plain `invalidate()` call has no way to make that check.
+     * `invalidate` remains the seam for 0.5's write-invalidation.
      */
     invalidate(key: string): void {
         this.#entries.delete(key);

--- a/src/core/resolver.ts
+++ b/src/core/resolver.ts
@@ -214,7 +214,7 @@ export class LibraryIndex {
             .map(({ item }) => item);
     }
 
-    all(): MergedItem[] {
+    all(): readonly MergedItem[] {
         return this.#items;
     }
 

--- a/src/tools/library.ts
+++ b/src/tools/library.ts
@@ -1,0 +1,93 @@
+import type { ServiceId } from '../config/schema.ts';
+import { LIBRARY_TTL_MS, TtlCache } from '../core/cache.ts';
+import { gather, type Source } from '../core/gather.ts';
+import type { IdentityResolver } from '../core/identity.ts';
+import { logger } from '../core/logger.ts';
+import { LibraryIndex, type IndexInput } from '../core/resolver.ts';
+import { hasLibrary, hasUserLibrary, type ServiceAdapter, type ServiceUser } from '../services/types.ts';
+
+export type LibrarySnapshot = {
+    index: LibraryIndex;
+    degraded: ServiceId[];
+    counts: Partial<Record<ServiceId, number>>;
+};
+
+/**
+ * One cached library index, shared by get_library, get_media_details and
+ * diagnose (§8: duplicating the join is how joins drift apart).
+ *
+ * The cache lives here rather than in the adapters, so adapters stay directly
+ * testable against fixtures and caching policy sits in one reviewable place.
+ */
+export class LibraryLoader {
+    readonly #adapters: readonly ServiceAdapter[];
+    readonly #identity: IdentityResolver | undefined;
+    readonly #cache: TtlCache;
+
+    constructor(
+        adapters: readonly ServiceAdapter[],
+        jellyfinIdentity: IdentityResolver | undefined,
+        cache: TtlCache = new TtlCache()
+    ) {
+        this.#adapters = adapters;
+        this.#identity = jellyfinIdentity;
+        this.#cache = cache;
+    }
+
+    async load(user?: string): Promise<LibrarySnapshot> {
+        const resolved = await this.#resolveUser(user);
+
+        // §4.3: the key includes the user id, or one household member's watch
+        // history appears in another's answer — a correctness bug that reads as
+        // a privacy one.
+        const key = `library:${resolved?.id ?? 'none'}`;
+
+        const snapshot = await this.#cache.get(key, LIBRARY_TTL_MS, () => this.#build(resolved));
+
+        // A partial load is not worth five minutes of cache: the missing
+        // service is usually restarting, and the next call should find it.
+        if (snapshot.degraded.length > 0) this.#cache.invalidate(key);
+        return snapshot;
+    }
+
+    /**
+     * Returns undefined when there is no Jellyfin half to fetch, and **throws
+     * when a named user was refused**. Flattening a refusal into `degraded`
+     * would tell the model the service was down, and it would retry forever.
+     */
+    async #resolveUser(requested: string | undefined): Promise<ServiceUser | undefined> {
+        if (this.#identity === undefined) return undefined;
+        try {
+            return await this.#identity.resolve(requested);
+        } catch (err) {
+            if (requested !== undefined) throw err;
+            // No user was asked for and none is configured — a configuration
+            // gap, not a refusal. Build the *arr half and say Jellyfin is
+            // missing from the answer.
+            logger.warn({ service: 'jellyfin', err }, 'no default user; building the library without watch state');
+            return undefined;
+        }
+    }
+
+    async #build(user: ServiceUser | undefined): Promise<LibrarySnapshot> {
+        const sources: Source<IndexInput>[] = this.#adapters
+            .filter(hasLibrary)
+            .map(a => ({ id: a.id, fetch: () => a.listLibrary() }));
+
+        const jellyfin = this.#adapters.find(hasUserLibrary);
+        if (jellyfin !== undefined) {
+            sources.push({
+                id: jellyfin.id,
+                fetch:
+                    user === undefined
+                        ? // Reported as degraded rather than silently absent: the
+                          // answer really is missing a service's contribution.
+                          () => Promise.reject(new Error('no Jellyfin user resolved'))
+                        : () => jellyfin.listUserLibrary(user)
+            });
+        }
+
+        const { items, degraded, counts } = await gather(sources);
+        return { index: LibraryIndex.build(items), degraded, counts };
+    }
+}

--- a/src/tools/library.ts
+++ b/src/tools/library.ts
@@ -1,5 +1,6 @@
 import type { ServiceId } from '../config/schema.ts';
 import { LIBRARY_TTL_MS, TtlCache } from '../core/cache.ts';
+import { ServiceError } from '../core/errors.ts';
 import { gather, type Source } from '../core/gather.ts';
 import type { IdentityResolver } from '../core/identity.ts';
 import { logger } from '../core/logger.ts';
@@ -42,29 +43,45 @@ export class LibraryLoader {
         // a privacy one.
         const key = `library:${resolved?.id ?? 'none'}`;
 
-        const snapshot = await this.#cache.get(key, LIBRARY_TTL_MS, () => this.#build(resolved));
-
         // A partial load is not worth five minutes of cache: the missing
         // service is usually restarting, and the next call should find it.
-        if (snapshot.degraded.length > 0) this.#cache.invalidate(key);
-        return snapshot;
+        // Declined via `shouldCache` rather than a follow-up `invalidate()`:
+        // invalidate has no way to tell "my degraded load lost a race to a
+        // fresher, complete one" from "nothing raced me" — it would delete
+        // the good entry in the first case. `shouldCache` runs on the same
+        // identity check the cache's own failure path uses, so only this
+        // exact load's entry is ever dropped.
+        return this.#cache.get(key, LIBRARY_TTL_MS, () => this.#build(resolved), snapshot => snapshot.degraded.length === 0);
     }
 
     /**
-     * Returns undefined when there is no Jellyfin half to fetch, and **throws
-     * when a named user was refused**. Flattening a refusal into `degraded`
-     * would tell the model the service was down, and it would retry forever.
+     * Returns undefined when there is no Jellyfin half to fetch. The decision
+     * to propagate or degrade turns on the error's *kind*, not on whether a
+     * user was named — naming someone must not turn a plain Jellyfin outage
+     * into a hard failure of the whole library read; the *arr half is still
+     * worth returning:
+     *
+     * - `AuthFailed` always propagates — the model must not retry a refusal.
+     * - `NotFound` propagates only when a user was explicitly requested: the
+     *   caller named someone who does not exist, and degrading would silently
+     *   answer as if nobody had asked. Unrequested, `NotFound` means "no
+     *   default user is configured," a configuration gap that still degrades.
+     * - Everything else — `Unreachable`, `Timeout`, `UpstreamError`, and any
+     *   non-`ServiceError` — degrades regardless of whether a user was named.
      */
     async #resolveUser(requested: string | undefined): Promise<ServiceUser | undefined> {
         if (this.#identity === undefined) return undefined;
         try {
             return await this.#identity.resolve(requested);
         } catch (err) {
-            if (requested !== undefined) throw err;
-            // No user was asked for and none is configured — a configuration
-            // gap, not a refusal. Build the *arr half and say Jellyfin is
-            // missing from the answer.
-            logger.warn({ service: 'jellyfin', err }, 'no default user; building the library without watch state');
+            if (err instanceof ServiceError) {
+                if (err.kind === 'AuthFailed') throw err;
+                if (err.kind === 'NotFound' && requested !== undefined) throw err;
+            }
+            logger.warn(
+                { service: 'jellyfin', err },
+                'jellyfin identity unavailable; building the library without watch state'
+            );
             return undefined;
         }
     }

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -100,6 +100,67 @@ describe('TtlCache', () => {
         expect(results.map(r => r.status)).toEqual(['rejected', 'rejected']);
     });
 
+    it('does not cache a value shouldCache declines', async () => {
+        const cache = new TtlCache();
+        let calls = 0;
+        const load = async () => {
+            calls += 1;
+            return calls === 1 ? 'partial' : 'complete';
+        };
+
+        expect(await cache.get('k', 1000, load, v => v !== 'partial')).toBe('partial');
+        expect(await cache.get('k', 1000, load, v => v !== 'partial')).toBe('complete');
+        expect(calls).toBe(2);
+    });
+
+    it('still caches when shouldCache is omitted', async () => {
+        const cache = new TtlCache();
+        const load = vi.fn(async () => 'value');
+
+        await cache.get('k', 1000, load);
+        await cache.get('k', 1000, load);
+
+        expect(load).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not let a late-resolving, declined load delete a fresher entry that already replaced it', async () => {
+        // The scenario LibraryLoader's first fix (invalidate()) got wrong:
+        // every other test in this file awaits one load before starting the
+        // next, so none of them exercise two loads for the same key in
+        // flight at once. This one does — the first load outlives its own
+        // ttl before resolving, a second caller starts a fresh load in the
+        // gap, and only then does the first (degraded) load resolve.
+        const c = clock();
+        const cache = new TtlCache(c.now);
+
+        let resolveFirst!: (v: { ok: boolean }) => void;
+        const first = cache.get(
+            'k',
+            100,
+            () => new Promise<{ ok: boolean }>(resolve => (resolveFirst = resolve)),
+            v => v.ok
+        );
+
+        // The first load's ttl elapses while it is still pending.
+        c.advance(101);
+
+        // A second caller finds the entry expired and starts its own load,
+        // which completes and is kept.
+        const second = cache.get('k', 100, async () => ({ ok: true }), v => v.ok);
+        await expect(second).resolves.toEqual({ ok: true });
+
+        // The first load finally resolves, declined by shouldCache. It must
+        // not delete the second load's entry — it is not "the" entry for
+        // this key anymore, and the guard on the failure path exists for
+        // exactly this reason.
+        resolveFirst({ ok: false });
+        await expect(first).resolves.toEqual({ ok: false });
+
+        const load = vi.fn(async () => ({ ok: true }));
+        await cache.get('k', 100, load, v => v.ok);
+        expect(load).not.toHaveBeenCalled();
+    });
+
     it('drops an entry on invalidate', async () => {
         const cache = new TtlCache();
         const load = vi.fn(async () => 'value');

--- a/test/library.test.ts
+++ b/test/library.test.ts
@@ -135,6 +135,26 @@ describe('LibraryLoader', () => {
         expect(snapshot.degraded).toEqual(['jellyfin']);
     });
 
+    it('degrades rather than fails when Jellyfin is unreachable, even with a user named', async () => {
+        // Naming a user must not turn a plain outage into a hard failure of
+        // the whole library read — the *arr half is still worth returning.
+        // Before this fix, #resolveUser propagated on `requested !== undefined`
+        // alone, so this exact case (a named user, an Unreachable error) threw.
+        const down = identity(new ServiceError('Unreachable', 'jellyfin', 'connection refused'));
+        const snapshot = await new LibraryLoader([radarr(), jellyfin({})], down).load('Someone');
+
+        expect(snapshot.index.size()).toBe(1);
+        expect(snapshot.degraded).toEqual(['jellyfin']);
+    });
+
+    it('propagates when an explicitly named user does not exist', async () => {
+        // Unlike the no-default-configured case above, a user *was* named —
+        // degrading here would silently answer as if nobody had asked.
+        const ghost = identity(new ServiceError('NotFound', 'jellyfin', 'no user named "Ghost"'));
+        const loader = new LibraryLoader([radarr(), jellyfin({})], ghost);
+        await expect(loader.load('Ghost')).rejects.toThrow(/no user named/);
+    });
+
     it('returns an empty index when nothing is configured', async () => {
         const snapshot = await new LibraryLoader([], undefined).load();
         expect(snapshot.index.size()).toBe(0);

--- a/test/library.test.ts
+++ b/test/library.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ServiceError } from '../src/core/errors.ts';
+import type { IdentityResolver } from '../src/core/identity.ts';
+import type { IndexInput } from '../src/core/resolver.ts';
+import { LibraryLoader } from '../src/tools/library.ts';
+import type { ServiceAdapter, ServiceUser } from '../src/services/types.ts';
+
+const film = (tmdb: number): IndexInput => ({
+    kind: 'movie',
+    title: 'Some Film',
+    ids: { tmdb },
+    acquisition: { service: 'radarr', monitored: true, hasFile: true }
+});
+
+const watched = (tmdb: number, user: string): IndexInput => ({
+    kind: 'movie',
+    title: 'Some Film',
+    ids: { tmdb },
+    playback: { user, watched: true }
+});
+
+const stub = (id: ServiceAdapter['id'], extra: Record<string, unknown>): ServiceAdapter =>
+    ({
+        id,
+        testConnection: async () => ({ ok: true, service: id, latency_ms: 1 }),
+        getVersion: async () => '1.0.0',
+        ...extra
+    }) as unknown as ServiceAdapter;
+
+const radarr = (items = [film(550)]) => stub('radarr', { listLibrary: async () => items });
+const jellyfin = (byUser: Record<string, IndexInput[]>) =>
+    stub('jellyfin', { listUserLibrary: async (u: ServiceUser) => byUser[u.name] ?? [] });
+
+const identity = (user: ServiceUser | Error): IdentityResolver =>
+    ({
+        resolve: async (requested?: string) => {
+            if (user instanceof Error) throw user;
+            if (requested !== undefined && requested !== user.name) {
+                throw new ServiceError('AuthFailed', 'jellyfin', `not permitted to query as "${requested}"`);
+            }
+            return user;
+        }
+    }) as unknown as IdentityResolver;
+
+const someone = { id: 'u1', name: 'Someone' };
+
+describe('LibraryLoader', () => {
+    it('merges the *arr and Jellyfin halves into one index', async () => {
+        const loader = new LibraryLoader(
+            [radarr(), jellyfin({ Someone: [watched(550, 'Someone')] })],
+            identity(someone)
+        );
+
+        const snapshot = await loader.load();
+        expect(snapshot.index.size()).toBe(1);
+        expect(snapshot.index.find({ tmdb: 550 })?.presence).toBe('both');
+    });
+
+    it('reports per-service counts, so a missing half is visible', async () => {
+        const loader = new LibraryLoader(
+            [radarr(), jellyfin({ Someone: [watched(550, 'Someone')] })],
+            identity(someone)
+        );
+        expect((await loader.load()).counts).toEqual({ radarr: 1, jellyfin: 1 });
+    });
+
+    it('serves a second call from the cache', async () => {
+        const listLibrary = vi.fn(async () => [film(550)]);
+        const loader = new LibraryLoader([stub('radarr', { listLibrary })], undefined);
+
+        await loader.load();
+        await loader.load();
+
+        expect(listLibrary).toHaveBeenCalledTimes(1);
+    });
+
+    it('caches per Jellyfin user, so one household member cannot see another', async () => {
+        const byUser = { Someone: [watched(550, 'Someone')], Other: [] };
+        const resolve = vi.fn(async (requested?: string) => ({ id: `id-${requested}`, name: requested ?? 'Someone' }));
+        const loader = new LibraryLoader([radarr(), jellyfin(byUser)], {
+            resolve
+        } as unknown as IdentityResolver);
+
+        const mine = await loader.load('Someone');
+        const theirs = await loader.load('Other');
+
+        expect(mine.index.find({ tmdb: 550 })?.playback?.watched).toBe(true);
+        // Not merely a different answer: the other user's entry must be absent,
+        // not present-and-false, or the cache key is doing nothing.
+        expect(theirs.index.find({ tmdb: 550 })?.playback).toBeUndefined();
+    });
+
+    it('degrades when one service fails rather than failing the call', async () => {
+        const broken = stub('sonarr', {
+            listLibrary: async () => {
+                throw new ServiceError('Unreachable', 'sonarr', 'connection refused');
+            }
+        });
+        const snapshot = await new LibraryLoader([radarr(), broken], undefined).load();
+
+        expect(snapshot.index.size()).toBe(1);
+        expect(snapshot.degraded).toEqual(['sonarr']);
+        expect(snapshot.counts.sonarr).toBeUndefined();
+    });
+
+    it('does not cache a degraded load, so a restarted service recovers', async () => {
+        let calls = 0;
+        const flaky = stub('radarr', {
+            listLibrary: async () => {
+                calls += 1;
+                if (calls === 1) throw new ServiceError('Unreachable', 'radarr', 'restarting');
+                return [film(550)];
+            }
+        });
+        const loader = new LibraryLoader([flaky], undefined);
+
+        expect((await loader.load()).degraded).toEqual(['radarr']);
+        expect((await loader.load()).index.size()).toBe(1);
+    });
+
+    it('propagates an authorization refusal instead of degrading', async () => {
+        // A model told "Jellyfin is down" when it was refused will retry
+        // forever; one told it was refused will not.
+        const loader = new LibraryLoader([radarr(), jellyfin({})], identity(someone));
+        await expect(loader.load('Someone Else')).rejects.toThrow(/not permitted/);
+    });
+
+    it('builds the *arr half alone when no Jellyfin user is configured', async () => {
+        const noDefault = identity(
+            new ServiceError('NotFound', 'jellyfin', 'no user was named and none is configured')
+        );
+        const snapshot = await new LibraryLoader([radarr(), jellyfin({})], noDefault).load();
+
+        expect(snapshot.index.size()).toBe(1);
+        expect(snapshot.degraded).toEqual(['jellyfin']);
+    });
+
+    it('returns an empty index when nothing is configured', async () => {
+        const snapshot = await new LibraryLoader([], undefined).load();
+        expect(snapshot.index.size()).toBe(0);
+        expect(snapshot.degraded).toEqual([]);
+    });
+});

--- a/test/resolver.test.ts
+++ b/test/resolver.test.ts
@@ -419,4 +419,40 @@ describe('LibraryIndex.all', () => {
         expect(index.all()).toEqual([]);
         expect(index.size()).toBe(0);
     });
+
+    it('hands out a snapshot a caller can copy without disturbing the index', () => {
+        // A caller that shares a five-minute cached snapshot across tool
+        // calls (Phase 3b's LibraryLoader) must not be able to corrupt it.
+        // `assertAllIsReadonlyAtCompileTime` below (never invoked — tsc still
+        // checks its body) proves the compiler rejects mutating the array
+        // `all()` hands out directly. This proves that a caller who instead
+        // makes a copy, as `readonly` pushes them to, cannot reach back into
+        // the index through it.
+        const index = LibraryIndex.build([arr(), jelly()]);
+        const copy = [...index.all()];
+        copy.sort(() => -1);
+        copy.pop();
+
+        expect(index.all()).toHaveLength(1);
+        expect(index.size()).toBe(1);
+    });
 });
+
+/**
+ * Never called — its only job is to be type-checked by `npm run typecheck`.
+ * Each line below must fail to compile, proving `LibraryIndex.all()` returns
+ * `readonly MergedItem[]` rather than `MergedItem[]`: a caller that sorts or
+ * splices the array a five-minute cache handed out would corrupt the index
+ * for every later call, and that must be a compile error, not a hope.
+ */
+function assertAllIsReadonlyAtCompileTime(items: readonly MergedItem[]): void {
+    // @ts-expect-error - push is not on a readonly array
+    items.push({} as never);
+    // @ts-expect-error - sort is not on a readonly array
+    items.sort();
+    // @ts-expect-error - splice is not on a readonly array
+    items.splice(0, 1);
+    // @ts-expect-error - index assignment is not on a readonly array
+    items[0] = {} as never;
+}
+void assertAllIsReadonlyAtCompileTime;


### PR DESCRIPTION
Phase 3b, Task 2 of 9. One cached `LibraryIndex` built from three services, shared by every tool that needs the join — `get_library`, `get_media_details` and `diagnose` all sit on this.

The cache lives here rather than in the adapters, so adapters stay directly testable against fixtures and caching policy sits in one reviewable place.

**The cache key includes the Jellyfin user id.** Watch state is per-user; a shared key would put one household member's history into another's answer — a correctness bug that reads as a privacy one. The test asserts the other user's playback is *absent*, not merely `watched: false`, since a key that did nothing would still return "not watched".

## Two defects review caught in the original design

**Naming a user turned a Jellyfin outage into a hard failure.** The first version decided propagate-vs-degrade on whether a user was *requested*, not on what went wrong. But identity resolution passes its authorization check and *then* calls `listUsers()` over the network — so a plain outage threw `Unreachable`, and because a user had been named, the whole library read failed instead of returning the Radarr and Sonarr halves.

It now switches on the error kind:

| kind | behaviour |
|---|---|
| `AuthFailed` | always propagates — a model told "the service is down" when it was *refused* will retry forever |
| `NotFound` | propagates only when a user was explicitly named; otherwise it is the "no `default_user` configured" case and degrades |
| everything else | degrades — the *arr halves are still worth returning |

**`invalidate()` reintroduced a race the cache already knew how to avoid.** `TtlCache.get`'s failure path deletes only after checking promise identity, because a later successful load may already have replaced the entry. `invalidate()` had no such guard and the loader called it, so a late-resolving degraded caller could delete a fresh good entry.

Rather than guard the caller, the decision moved *into* the cache as an optional `shouldCache` predicate. The rule "a partial result is not worth caching" now lives in one place, where the promise identity is known — and `invalidate` goes back to being the unused seam for 0.5 write-invalidation.

Neither defect was reachable by the existing tests: every one awaited a load before starting the next, so nothing exercised two callers in flight at once. The new race test keeps both loads pending simultaneously and fails if the guard is removed.

Also narrows `LibraryIndex.all()` to `readonly MergedItem[]`, deferred from 3a's review until something cached a snapshot — which is exactly what this task does. No production caller needed changing.

**535 tests**, up from 520.

🤖 Generated with [Claude Code](https://claude.com/claude-code)