### PR TITLE
feat: add get_library, the three-way join

### DIFF
--- a/src/tools/getLibrary.ts
+++ b/src/tools/getLibrary.ts
@@ -1,0 +1,190 @@
+import type { McpServer } from '@modelcontextprotocol/server';
+import * as z from 'zod/v4';
+import type { ServiceId } from '../config/schema.ts';
+import type { MergedItem } from '../core/resolver.ts';
+import { DetailSchema, LimitSchema, applyLimit, type DetailLevel } from '../core/shape.ts';
+import { unfenced } from '../core/titleMatch.ts';
+import { UserSchema } from './getPlayback.ts';
+import type { LibraryLoader } from './library.ts';
+
+/** The five §4.1 names a film can carry, plus the one a series can. */
+export const RATING_SOURCES = ['imdb', 'tmdb', 'trakt', 'metacritic', 'rottenTomatoes', 'tvdb'] as const;
+export type RatingSource = (typeof RATING_SOURCES)[number];
+
+/** Films only. `tvdb` is Sonarr's flat value and belongs to series alone (§21.2). */
+const FILM_SOURCES: readonly RatingSource[] = ['imdb', 'tmdb', 'trakt', 'metacritic', 'rottenTomatoes'];
+
+export type LibraryQuery = {
+    detail: DetailLevel;
+    limit: number;
+    kind?: 'movie' | 'series';
+    year?: number;
+    genre?: string;
+    monitored?: boolean;
+    watched?: boolean;
+    watched_by?: string;
+    quality?: string;
+    min_rating?: number;
+    rating_source?: RatingSource;
+    presence?: MergedItem['presence'];
+};
+
+export type GetLibraryResult = {
+    items: MergedItem[];
+    total: number;
+    returned: number;
+    truncated: boolean;
+    degraded: ServiceId[];
+    counts: Partial<Record<ServiceId, number>>;
+    ratingCoverage?: { source: RatingSource; rated: number; unrated: number };
+};
+
+const ratingOf = (item: MergedItem, source: RatingSource): number | undefined => item.ratings?.[source];
+
+/**
+ * §5: "whichever source covers the most of the library". Ties break in the
+ * declared order, so the same library always answers the same way.
+ */
+function bestCoveredSource(items: readonly MergedItem[], kind: LibraryQuery['kind']): RatingSource {
+    if (kind === 'series') return 'tvdb';
+
+    let best: RatingSource = 'imdb';
+    let bestCount = -1;
+    for (const source of FILM_SOURCES) {
+        const count = items.filter(i => ratingOf(i, source) !== undefined).length;
+        if (count > bestCount) {
+            best = source;
+            bestCount = count;
+        }
+    }
+    return best;
+}
+
+/**
+ * §5.2's two documented limits, enforced rather than left to produce an empty
+ * list. A filter that quietly matches nothing is worse than a stated gap: the
+ * model reports "you have no such series" and the user believes it.
+ *
+ * A plain Error, not a ServiceError: no service failed, and ServiceError
+ * requires a ServiceId that would misattribute the fault to one.
+ */
+function rejectImpossibleFilters(opts: LibraryQuery): void {
+    if (opts.kind === 'series' && opts.quality !== undefined) {
+        throw new Error(
+            'quality applies to films only — a series’ quality is per-episode, so a series-level value would be a fiction. Filter get_media_details at detail: full instead.'
+        );
+    }
+    if (opts.kind === 'series' && opts.rating_source !== undefined && opts.rating_source !== 'tvdb') {
+        throw new Error(
+            `rating_source "${opts.rating_source}" applies to films only — Sonarr holds one flat TVDB rating per series. Use rating_source: "tvdb", or drop it.`
+        );
+    }
+}
+
+const project = (item: MergedItem, detail: DetailLevel): MergedItem => {
+    if (detail === 'full') return item;
+    if (detail === 'minimal') {
+        return {
+            kind: item.kind,
+            title: item.title,
+            ...(item.year === undefined ? {} : { year: item.year }),
+            ids: item.ids,
+            presence: item.presence
+        };
+    }
+    const { genres: _g, ...rest } = item;
+    return rest;
+};
+
+export async function buildGetLibrary(loader: LibraryLoader, opts: LibraryQuery): Promise<GetLibraryResult> {
+    rejectImpossibleFilters(opts);
+
+    const { index, degraded, counts } = await loader.load(opts.watched_by);
+
+    const genre = opts.genre?.toLowerCase();
+    const quality = opts.quality?.toLowerCase();
+
+    const filtered = index.all().filter(item => {
+        if (opts.kind !== undefined && item.kind !== opts.kind) return false;
+        if (opts.year !== undefined && item.year !== opts.year) return false;
+        if (genre !== undefined && !(item.genres ?? []).some(g => unfenced(g).toLowerCase() === genre)) return false;
+        if (opts.monitored !== undefined && (item.acquisition?.monitored ?? false) !== opts.monitored) return false;
+        // Absent playback is "not watched", never "excluded": an item Jellyfin
+        // has never seen is exactly what `watched: false` should surface.
+        if (opts.watched !== undefined && (item.playback?.watched ?? false) !== opts.watched) return false;
+        if (opts.presence !== undefined && item.presence !== opts.presence) return false;
+        if (quality !== undefined) {
+            // Series are excluded rather than compared: they have no
+            // series-level quality to compare against.
+            if (item.kind !== 'movie') return false;
+            if ((item.acquisition?.quality ?? '').toLowerCase() !== quality) return false;
+        }
+        return true;
+    });
+
+    if (opts.min_rating === undefined) {
+        const shaped = applyLimit(filtered, opts.limit);
+        return { ...shaped, items: shaped.items.map(i => project(i, opts.detail)), degraded, counts };
+    }
+
+    // §5.1: coverage is measured over everything the other filters kept, before
+    // the rating filter removes anything — that is what makes "184 rated, 66
+    // unrated" answer the question the caller actually asked.
+    const source = opts.rating_source ?? bestCoveredSource(filtered, opts.kind);
+    const rated = filtered.filter(i => ratingOf(i, source) !== undefined);
+    const matching = rated.filter(i => (ratingOf(i, source) as number) >= (opts.min_rating as number));
+
+    const shaped = applyLimit(matching, opts.limit);
+    return {
+        ...shaped,
+        items: shaped.items.map(i => project(i, opts.detail)),
+        degraded,
+        counts,
+        ratingCoverage: { source, rated: rated.length, unrated: filtered.length - rated.length }
+    };
+}
+
+export function registerGetLibrary(server: McpServer, loader: LibraryLoader): void {
+    server.registerTool(
+        'get_library',
+        {
+            description:
+                'Your library, joined across Radarr, Sonarr and Jellyfin on shared external ids. `presence` is what no single service can tell you: `arr_only` with a file means Jellyfin cannot see a file the *arr believes is on disk, and `jellyfin_only` means media nothing is managing. Two limits: `quality` applies to films only (a series’ quality is per-episode), and series carry one flat TVDB rating rather than per-source ratings. A rating filter also reports how much of the library that source actually covers.',
+            inputSchema: z.object({
+                kind: z.enum(['movie', 'series']).optional().describe('Films or series. Omit for both.'),
+                year: z.number().int().optional(),
+                genre: z.string().min(1).optional().describe('Matched case-insensitively against the *arr genres.'),
+                monitored: z.boolean().optional(),
+                watched: z.boolean().optional().describe('Jellyfin watch state. Items Jellyfin has never seen count as unwatched.'),
+                watched_by: UserSchema,
+                quality: z.string().min(1).optional().describe('Films only.'),
+                min_rating: z.number().min(0).max(10).optional(),
+                rating_source: z
+                    .enum(RATING_SOURCES)
+                    .optional()
+                    .describe('Defaults to whichever source covers the most of your library. `tvdb` is series-only.'),
+                presence: z
+                    .enum(['both', 'arr_only', 'jellyfin_only'])
+                    .optional()
+                    .describe('both / arr_only (possible broken import) / jellyfin_only (unmanaged media).'),
+                detail: DetailSchema,
+                limit: LimitSchema
+            })
+        },
+        async input => {
+            const result = await buildGetLibrary(loader, input as LibraryQuery);
+
+            const coverage =
+                result.ratingCoverage === undefined
+                    ? ''
+                    : ` ${result.ratingCoverage.unrated} item(s) carry no ${result.ratingCoverage.source} rating and could not be judged.`;
+            const missing =
+                result.degraded.length === 0 ? '' : ` ${result.degraded.join(', ')} could not be reached.`;
+
+            return {
+                content: [{ type: 'text', text: `${result.returned} of ${result.total} item(s).${coverage}${missing}` }],
+                structuredContent: result
+            };
+        }
+    );
+}

--- a/src/tools/register.ts
+++ b/src/tools/register.ts
@@ -7,11 +7,13 @@ import { hasIndexers, hasSubtitles, type ServiceAdapter } from '../services/type
 import { registerDiscoverMedia } from './discoverMedia.ts';
 import { registerGetCalendar } from './getCalendar.ts';
 import { registerGetIndexers } from './getIndexers.ts';
+import { registerGetLibrary } from './getLibrary.ts';
 import { registerGetMediaDetails } from './getMediaDetails.ts';
 import { registerGetPlayback } from './getPlayback.ts';
 import { registerGetQueue } from './getQueue.ts';
 import { registerGetRequests } from './getRequests.ts';
 import { registerGetSubtitles } from './getSubtitles.ts';
+import { LibraryLoader } from './library.ts';
 import { registerLookupMedia } from './lookupMedia.ts';
 import { registerSearchMedia } from './searchMedia.ts';
 import { registerStackHealth } from './stackHealth.ts';
@@ -25,22 +27,26 @@ export type ToolContext = {
     adapters: readonly ServiceAdapter[];
     jellyfinIdentity: IdentityResolver | undefined;
     seerrIdentity: IdentityResolver | undefined;
+    library: LibraryLoader;
 };
 
 export function buildToolContext(adapters: readonly ServiceAdapter[], config: Config): ToolContext {
     const jellyfin = adapters.find((a): a is JellyfinAdapter => a instanceof JellyfinAdapter);
     const seerr = adapters.find((a): a is SeerrAdapter => a instanceof SeerrAdapter);
 
+    const jellyfinIdentity =
+        jellyfin !== undefined && config.services.jellyfin !== undefined
+            ? new IdentityResolver(jellyfin, config.services.jellyfin)
+            : undefined;
+
     return {
         adapters,
-        jellyfinIdentity:
-            jellyfin !== undefined && config.services.jellyfin !== undefined
-                ? new IdentityResolver(jellyfin, config.services.jellyfin)
-                : undefined,
+        jellyfinIdentity,
         seerrIdentity:
             seerr !== undefined && config.services.seerr !== undefined
                 ? new IdentityResolver(seerr, config.services.seerr)
-                : undefined
+                : undefined,
+        library: new LibraryLoader(adapters, jellyfinIdentity)
     };
 }
 
@@ -54,7 +60,7 @@ export function buildToolContext(adapters: readonly ServiceAdapter[], config: Co
  * not find it missing after a config edit.
  */
 export function registerAllTools(server: McpServer, context: ToolContext): void {
-    const { adapters, jellyfinIdentity, seerrIdentity } = context;
+    const { adapters, jellyfinIdentity, seerrIdentity, library } = context;
     const jellyfin = adapters.find((a): a is JellyfinAdapter => a instanceof JellyfinAdapter);
     const seerr = adapters.find((a): a is SeerrAdapter => a instanceof SeerrAdapter);
 
@@ -66,6 +72,7 @@ export function registerAllTools(server: McpServer, context: ToolContext): void 
     registerGetPlayback(server, jellyfin, jellyfinIdentity);
     registerGetRequests(server, seerr, seerrIdentity);
     registerGetMediaDetails(server, adapters);
+    registerGetLibrary(server, library);
     registerSearchMedia(server, adapters);
     registerLookupMedia(server, adapters);
     registerDiscoverMedia(server, seerr);
@@ -81,6 +88,7 @@ export const TOOL_NAMES = [
     'get_playback',
     'get_requests',
     'get_media_details',
+    'get_library',
     'search_media',
     'lookup_media',
     'discover_media'

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -162,7 +162,7 @@ describe('the advertised tool surface', () => {
      * tool rather than raising an error. This asserts the exact set, so any
      * change to it has to be deliberate enough to edit a test.
      */
-    it('exposes exactly the eleven tools of the frozen surface', async () => {
+    it('exposes exactly the twelve tools of the frozen surface', async () => {
         expect((await listTools()).map(t => t.name).sort()).toEqual([...TOOL_NAMES].sort());
     });
 

--- a/test/getLibrary.test.ts
+++ b/test/getLibrary.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from 'vitest';
+import { LibraryIndex, type IndexInput } from '../src/core/resolver.ts';
+import { LibraryLoader } from '../src/tools/library.ts';
+import { buildGetLibrary } from '../src/tools/getLibrary.ts';
+import type { ServiceAdapter } from '../src/services/types.ts';
+import { repeat } from './helpers/bigFixture.ts';
+import { expectWithinBudget } from './helpers/budget.ts';
+
+const stub = (id: 'radarr' | 'sonarr', items: IndexInput[]): ServiceAdapter =>
+    ({
+        id,
+        testConnection: async () => ({ ok: true, service: id, latency_ms: 1 }),
+        getVersion: async () => '1.0.0',
+        listLibrary: async () => items
+    }) as unknown as ServiceAdapter;
+
+const loaderOf = (items: IndexInput[], id: 'radarr' | 'sonarr' = 'radarr') =>
+    new LibraryLoader([stub(id, items)], undefined);
+
+const film = (over: Partial<IndexInput> = {}): IndexInput => ({
+    kind: 'movie',
+    title: 'Some Film',
+    year: 2026,
+    genres: ['Drama'],
+    ids: { tmdb: 550 },
+    acquisition: { service: 'radarr', monitored: true, hasFile: true, quality: 'Bluray-1080p' },
+    ...over
+});
+
+const base = { detail: 'standard' as const, limit: 50 };
+
+describe('get_library filters', () => {
+    it('returns everything when nothing is filtered', async () => {
+        const result = await buildGetLibrary(loaderOf([film(), film({ ids: { tmdb: 2 } })]), base);
+        expect(result).toMatchObject({ total: 2, returned: 2, truncated: false });
+    });
+
+    it('filters by kind', async () => {
+        const items = [film(), film({ kind: 'series', ids: { tvdb: 9 } })];
+        const result = await buildGetLibrary(loaderOf(items), { ...base, kind: 'series' });
+        expect(result.items.map(i => i.kind)).toEqual(['series']);
+    });
+
+    it('filters by year', async () => {
+        const items = [film(), film({ year: 1999, ids: { tmdb: 2 } })];
+        expect((await buildGetLibrary(loaderOf(items), { ...base, year: 1999 })).total).toBe(1);
+    });
+
+    it('filters by genre, case-insensitively', async () => {
+        const items = [film(), film({ genres: ['Comedy'], ids: { tmdb: 2 } })];
+        expect((await buildGetLibrary(loaderOf(items), { ...base, genre: 'comedy' })).total).toBe(1);
+    });
+
+    it('filters by monitored', async () => {
+        const items = [
+            film(),
+            film({ ids: { tmdb: 2 }, acquisition: { service: 'radarr', monitored: false, hasFile: true } })
+        ];
+        expect((await buildGetLibrary(loaderOf(items), { ...base, monitored: false })).total).toBe(1);
+    });
+
+    it('filters by presence, the question no single service can answer', async () => {
+        const items = [film(), { ...film({ ids: { tmdb: 2 } }), playback: { user: 'Someone', watched: true } }];
+        const result = await buildGetLibrary(loaderOf(items), { ...base, presence: 'arr_only' });
+        expect(result.items.every(i => i.presence === 'arr_only')).toBe(true);
+    });
+
+    it('filters by watched', async () => {
+        const items = [
+            { ...film(), playback: { user: 'Someone', watched: true } },
+            { ...film({ ids: { tmdb: 2 } }), playback: { user: 'Someone', watched: false } }
+        ];
+        expect((await buildGetLibrary(loaderOf(items), { ...base, watched: true })).total).toBe(1);
+    });
+
+    it('treats an item with no playback half as not watched', async () => {
+        // Absent watch state is not evidence of watching, and `watched: false`
+        // must not silently exclude everything Jellyfin has never seen.
+        expect((await buildGetLibrary(loaderOf([film()]), { ...base, watched: false })).total).toBe(1);
+    });
+
+    it('filters films by quality', async () => {
+        const items = [
+            film(),
+            film({ ids: { tmdb: 2 }, acquisition: { service: 'radarr', monitored: true, hasFile: true, quality: 'WEBDL-720p' } })
+        ];
+        const result = await buildGetLibrary(loaderOf(items), { ...base, quality: 'bluray-1080p' });
+        expect(result.total).toBe(1);
+    });
+
+    it('excludes series from a quality filter rather than matching none of them', async () => {
+        const items = [film(), film({ kind: 'series', ids: { tvdb: 9 } })];
+        const result = await buildGetLibrary(loaderOf(items), { ...base, quality: 'bluray-1080p' });
+        expect(result.items.every(i => i.kind === 'movie')).toBe(true);
+    });
+
+    it('refuses a quality filter explicitly scoped to series', async () => {
+        // §5.2: a documented gap beats a filter that quietly matches nothing.
+        await expect(
+            buildGetLibrary(loaderOf([film()]), { ...base, kind: 'series', quality: 'bluray-1080p' })
+        ).rejects.toThrow(/per-episode/);
+    });
+
+    it('combines filters', async () => {
+        const items = [film(), film({ year: 1999, ids: { tmdb: 2 } })];
+        const result = await buildGetLibrary(loaderOf(items), { ...base, kind: 'movie', year: 2026, genre: 'Drama' });
+        expect(result.total).toBe(1);
+    });
+});
+
+describe('get_library rating filtering', () => {
+    const rated = [
+        film({ ids: { tmdb: 1 }, ratings: { imdb: 9.1 } }),
+        film({ ids: { tmdb: 2 }, ratings: { imdb: 6.0 } }),
+        film({ ids: { tmdb: 3 } })
+    ];
+    // The third film has no `ratings` key at all — 26% of a real library.
+
+    it('filters on the named source', async () => {
+        const result = await buildGetLibrary(loaderOf(rated), { ...base, min_rating: 8, rating_source: 'imdb' });
+        expect(result.total).toBe(1);
+    });
+
+    it('reports coverage, so an unrated film is not silently a no', async () => {
+        const result = await buildGetLibrary(loaderOf(rated), { ...base, min_rating: 8, rating_source: 'imdb' });
+        expect(result.ratingCoverage).toEqual({ source: 'imdb', rated: 2, unrated: 1 });
+    });
+
+    it('picks the best-covered source when none is named', async () => {
+        const items = [
+            film({ ids: { tmdb: 1 }, ratings: { imdb: 9.1, metacritic: 90 } }),
+            film({ ids: { tmdb: 2 }, ratings: { imdb: 8.5 } })
+        ];
+        const result = await buildGetLibrary(loaderOf(items), { ...base, min_rating: 8 });
+        expect(result.ratingCoverage).toMatchObject({ source: 'imdb', rated: 2, unrated: 0 });
+    });
+
+    it('measures coverage over the filtered set, not the whole library', async () => {
+        const items = [...rated, film({ year: 1999, ids: { tmdb: 4 } })];
+        const result = await buildGetLibrary(loaderOf(items), {
+            ...base,
+            year: 2026,
+            min_rating: 8,
+            rating_source: 'imdb'
+        });
+        expect(result.ratingCoverage).toEqual({ source: 'imdb', rated: 2, unrated: 1 });
+    });
+
+    it('omits coverage when no rating filter was asked for', async () => {
+        expect((await buildGetLibrary(loaderOf(rated), base)).ratingCoverage).toBeUndefined();
+    });
+
+    it('refuses a per-source rating filter on series', async () => {
+        // §21.2: Sonarr's rating is one flat TVDB value. Returning an empty
+        // list here would read as "no such series exist".
+        await expect(
+            buildGetLibrary(loaderOf([film()]), { ...base, kind: 'series', min_rating: 8, rating_source: 'imdb' })
+        ).rejects.toThrow(/flat TVDB/);
+    });
+
+    it('allows a tvdb-sourced rating filter on series', async () => {
+        const items = [
+            film({ kind: 'series', ids: { tvdb: 1 }, ratings: { tvdb: 8.3 } }),
+            film({ kind: 'series', ids: { tvdb: 2 }, ratings: { tvdb: 6.1 } })
+        ];
+        const result = await buildGetLibrary(loaderOf(items, 'sonarr'), {
+            ...base,
+            kind: 'series',
+            min_rating: 8,
+            rating_source: 'tvdb'
+        });
+        expect(result.total).toBe(1);
+    });
+});
+
+describe('get_library shaping', () => {
+    it('truncates honestly', async () => {
+        const many = repeat(film(), 120).map((f, i) => ({ ...f, ids: { tmdb: i + 1 } }));
+        const result = await buildGetLibrary(loaderOf(many), { ...base, limit: 50 });
+        expect(result).toMatchObject({ total: 120, returned: 50, truncated: true });
+    });
+
+    it('drops ratings and genres at detail: minimal', async () => {
+        const result = await buildGetLibrary(loaderOf([film()]), { ...base, detail: 'minimal' });
+        expect(result.items[0]?.ratings).toBeUndefined();
+        expect(result.items[0]?.genres).toBeUndefined();
+        expect(result.items[0]?.presence).toBe('arr_only');
+    });
+
+    it('keeps presence at every detail level, because it is the point of the tool', async () => {
+        for (const detail of ['minimal', 'standard', 'full'] as const) {
+            const result = await buildGetLibrary(loaderOf([film()]), { ...base, detail });
+            expect(result.items[0]?.presence).toBe('arr_only');
+        }
+    });
+
+    it('asks the loader for the named user, so watched_by reaches the cache key', async () => {
+        // §10 wants per-user isolation proved at this level too: the loader
+        // keys its cache on the resolved user, and a tool that never passes
+        // `watched_by` down would silently answer for the default user.
+        const asked: (string | undefined)[] = [];
+        const loader = {
+            load: async (user?: string) => {
+                asked.push(user);
+                return { index: LibraryIndex.build([]), degraded: [], counts: {} };
+            }
+        } as unknown as LibraryLoader;
+
+        await buildGetLibrary(loader, { ...base, watched: true, watched_by: 'Other' });
+        expect(asked).toEqual(['Other']);
+    });
+
+    it('reports degraded services', async () => {
+        const broken = {
+            id: 'sonarr',
+            testConnection: async () => ({ ok: true, service: 'sonarr', latency_ms: 1 }),
+            getVersion: async () => '1.0.0',
+            listLibrary: async () => {
+                throw new Error('down');
+            }
+        } as unknown as ServiceAdapter;
+
+        const loader = new LibraryLoader([stub('radarr', [film()]), broken], undefined);
+        expect((await buildGetLibrary(loader, base)).degraded).toEqual(['sonarr']);
+    });
+
+    it('stays within budget at the default detail', async () => {
+        const many = repeat(film(), 500).map((f, i) => ({ ...f, ids: { tmdb: i + 1 } }));
+        const result = await buildGetLibrary(loaderOf(many), { ...base, limit: 500 });
+        expectWithinBudget(result, 60_000);
+    });
+});


### PR DESCRIPTION
Phase 3b, Task 3 of 9. The first new tool since 0.3.0 — the surface goes from eleven to twelve.

Your library, joined across Radarr, Sonarr and Jellyfin on shared external ids, then filtered. **`presence` is the filter the phase exists for:** `arr_only` with a file means Jellyfin cannot see a file the *arr believes is on disk; `jellyfin_only` means media nothing is managing. Neither is answerable from any single service.

## A rating filter reports its own coverage

```json
"ratingCoverage": { "source": "imdb", "rated": 184, "unrated": 66 }
```

Measured on a real library, `imdb` covers 74% of films and `rottenTomatoes` 48%. Filtering silently would answer *"you have no films rated 8+"* when a third of the library was never rated at all — a confidently wrong answer, which is the failure this project keeps designing against.

Coverage is measured over everything the **other** filters kept, before the rating filter removes anything. That ordering is what makes the number answer the question actually asked, and the test distinguishes it: computed the other way round the same fixtures give `{rated: 1, unrated: 0}` instead of `{rated: 2, unrated: 1}`.

## Two filters refuse rather than matching nothing

- `quality` on an explicit `kind: 'series'` — a series' quality is per-episode, so a series-level value would be a fiction.
- a per-source `rating_source` on series — Sonarr holds one flat TVDB rating, not a per-source map.

Both throw with an explanation, and both limits are in the tool description a model reads. A filter that quietly matches nothing is worse than a documented gap: the model reports the empty list as fact and the user believes it. With `quality` and no `kind`, films filter normally and series are excluded rather than refused.

Absent playback counts as **not watched**, never as excluded — an item Jellyfin has never seen is exactly what `watched: false` should surface.

## Note

Review caught a defect in this task's own test fixture: the factory's "unrated" film carried a default `imdb: 8.8` through an object spread, so three coverage tests were passing while measuring something else. Removing the default was independently verified not to weaken any other assertion.

**560 tests**, up from 535.

🤖 Generated with [Claude Code](https://claude.com/claude-code)