### PR TITLE
refactor: answer get_media_details from the resolver

### DIFF
--- a/src/tools/getMediaDetails.ts
+++ b/src/tools/getMediaDetails.ts
@@ -2,8 +2,10 @@ import type { McpServer } from '@modelcontextprotocol/server';
 import * as z from 'zod/v4';
 import { ServiceIdSchema, type ServiceId } from '../config/schema.ts';
 import { ServiceError } from '../core/errors.ts';
+import type { MergedItem } from '../core/resolver.ts';
 import { DetailSchema, LimitSchema, type DetailLevel } from '../core/shape.ts';
 import { hasMediaDetails, type MediaDetails, type ServiceAdapter } from '../services/types.ts';
+import type { LibraryLoader } from './library.ts';
 
 /**
  * Unlike the list tools, this one **throws rather than degrades**. A request
@@ -27,26 +29,98 @@ export async function buildGetMediaDetails(
     });
 }
 
-export function registerGetMediaDetails(server: McpServer, adapters: readonly ServiceAdapter[]): void {
+export type MediaDetailsQuery = {
+    query?: string;
+    service?: ServiceId;
+    id?: string;
+    detail: DetailLevel;
+    limit: number;
+};
+
+/**
+ * The resolved form (§5.3): the merged record the join §8 exists for.
+ *
+ * Like the explicit form, it **throws rather than degrading**. A request for
+ * one specific item either produced that item or did not, and an empty success
+ * would read as "the item does not exist".
+ */
+export async function buildResolvedMediaDetails(loader: LibraryLoader, query: string): Promise<MergedItem> {
+    const { index } = await loader.load();
+    const [best] = index.search(query);
+
+    if (best === undefined) {
+        throw new Error(
+            `Nothing in your library matches "${query}". Try search_media, which also looks at what you do not have yet.`
+        );
+    }
+    return best;
+}
+
+/**
+ * Two forms, both deliberate (§5.3). `query` returns the merged record;
+ * `service` + `id` returns one service's raw view, which is how you inspect a
+ * join that looks wrong and what `diagnose` needs when `presence` says the two
+ * halves disagree.
+ */
+export async function resolveMediaDetails(
+    adapters: readonly ServiceAdapter[],
+    loader: LibraryLoader,
+    opts: MediaDetailsQuery
+): Promise<MediaDetails | MergedItem> {
+    // The explicit id wins when both are given: an id is unambiguous and a
+    // title is not.
+    if (opts.service !== undefined && opts.id !== undefined) {
+        return buildGetMediaDetails(adapters, {
+            service: opts.service,
+            id: opts.id,
+            detail: opts.detail,
+            limit: opts.limit
+        });
+    }
+
+    if (opts.query === undefined) {
+        // Not a ServiceError: no service failed, and ServiceError needs a
+        // ServiceId that would misattribute the fault to one.
+        throw new Error('Name either a query (a title) or both service and id.');
+    }
+
+    return buildResolvedMediaDetails(loader, opts.query);
+}
+
+export function registerGetMediaDetails(
+    server: McpServer,
+    adapters: readonly ServiceAdapter[],
+    loader: LibraryLoader
+): void {
     server.registerTool(
         'get_media_details',
         {
             description:
-                'Everything one service knows about one item: quality, size, path, external ids, ratings, and — for a series at detail: full — its episodes. Name the service holding the item; cross-service lookup by title arrives with the identity resolver.',
+                'Everything known about one item. Give a title as `query` for the merged record — acquisition, watch state, ratings and presence joined across services — or `service` plus `id` for one service’s raw view, which is how you inspect a join that looks wrong. A series at detail: full also returns its episodes.',
             inputSchema: z.object({
-                service: ServiceIdSchema.describe('Which service holds the item.'),
-                id: z.string().min(1).describe("The item's id within that service."),
+                query: z.string().min(1).optional().describe('A title. Resolved through the library index.'),
+                service: ServiceIdSchema.optional().describe('With `id`: one service’s own view.'),
+                id: z.string().min(1).optional().describe("The item's id within that service."),
                 detail: DetailSchema,
                 limit: LimitSchema
             })
         },
-        async ({ service, id, detail, limit }) => {
-            const result = await buildGetMediaDetails(adapters, { service, id, detail, limit });
+        async ({ query, service, id, detail, limit }) => {
+            const result = await resolveMediaDetails(adapters, loader, {
+                ...(query === undefined ? {} : { query }),
+                ...(service === undefined ? {} : { service }),
+                ...(id === undefined ? {} : { id }),
+                detail,
+                limit
+            });
+
             const summary =
-                `${result.kind} from ${result.service}` +
-                (result.episodeCount === undefined
-                    ? '.'
-                    : `, ${result.episodes?.length ?? 0} of ${result.episodeCount} episode(s).`);
+                'presence' in result
+                    ? `${result.kind}, present in: ${result.presence}.`
+                    : `${result.kind} from ${result.service}` +
+                      (result.episodeCount === undefined
+                          ? '.'
+                          : `, ${result.episodes?.length ?? 0} of ${result.episodeCount} episode(s).`);
 
             return { content: [{ type: 'text', text: summary }], structuredContent: result };
         }

--- a/src/tools/register.ts
+++ b/src/tools/register.ts
@@ -71,7 +71,7 @@ export function registerAllTools(server: McpServer, context: ToolContext): void 
     registerGetCalendar(server, adapters);
     registerGetPlayback(server, jellyfin, jellyfinIdentity);
     registerGetRequests(server, seerr, seerrIdentity);
-    registerGetMediaDetails(server, adapters);
+    registerGetMediaDetails(server, adapters, library);
     registerGetLibrary(server, library);
     registerSearchMedia(server, adapters);
     registerLookupMedia(server, adapters);

--- a/test/searchTools.test.ts
+++ b/test/searchTools.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import type { KeyedServiceConfig, MultiUserServiceConfig } from '../src/config/schema.ts';
+import type { ServiceAdapter } from '../src/services/types.ts';
 import { ProwlarrAdapter } from '../src/services/prowlarr.ts';
 import { RadarrAdapter } from '../src/services/radarr.ts';
 import { SeerrAdapter } from '../src/services/seerr.ts';
 import { SonarrAdapter } from '../src/services/sonarr.ts';
 import { buildDiscoverMedia } from '../src/tools/discoverMedia.ts';
-import { buildGetMediaDetails } from '../src/tools/getMediaDetails.ts';
+import { buildGetMediaDetails, resolveMediaDetails } from '../src/tools/getMediaDetails.ts';
+import { LibraryLoader } from '../src/tools/library.ts';
 import { buildLookupMedia } from '../src/tools/lookupMedia.ts';
 import { buildSearchMedia } from '../src/tools/searchMedia.ts';
 import { repeat } from './helpers/bigFixture.ts';
@@ -377,6 +379,70 @@ describe('get_media_details', () => {
             limit: 500
         });
         expectWithinBudget(result, 30_000);
+    });
+
+    const RESOLVED = {
+        kind: 'movie' as const,
+        title: '<<untrusted:radarr.title>>The Matrix<</untrusted>>',
+        year: 1999,
+        ids: { tmdb: 603 },
+        acquisition: { service: 'radarr' as const, monitored: true, hasFile: true }
+    };
+
+    const loader = () =>
+        new LibraryLoader(
+            [
+                {
+                    id: 'radarr',
+                    testConnection: async () => ({ ok: true, service: 'radarr', latency_ms: 1 }),
+                    getVersion: async () => '1.0.0',
+                    listLibrary: async () => [RESOLVED]
+                } as unknown as ServiceAdapter
+            ],
+            undefined
+        );
+
+    const query = { detail: 'standard' as const, limit: 50 };
+
+    it('answers a title query from the merged record', async () => {
+        const result = await resolveMediaDetails([], loader(), { ...query, query: 'matrix' });
+        expect(result).toMatchObject({ title: RESOLVED.title, presence: 'arr_only' });
+    });
+
+    it('matches through a leading article the caller omitted', async () => {
+        const result = await resolveMediaDetails([], loader(), { ...query, query: 'the matrix' });
+        expect(result).toMatchObject({ ids: { tmdb: 603 } });
+    });
+
+    it('throws rather than returning an empty success when nothing matches', async () => {
+        // A request for one item either produced it or did not; an empty
+        // success reads as "the item does not exist".
+        await expect(resolveMediaDetails([], loader(), { ...query, query: 'zzzz' })).rejects.toThrow(
+            /nothing in your library matches/i
+        );
+    });
+
+    it('keeps the explicit form, which is how you inspect one side of a join', async () => {
+        const result = await resolveMediaDetails([detailRadarr], loader(), {
+            ...query,
+            service: 'radarr',
+            id: '42'
+        });
+        expect(result).toMatchObject({ service: 'radarr', id: '42' });
+    });
+
+    it('prefers the explicit id when given both — an id is unambiguous and a title is not', async () => {
+        const result = await resolveMediaDetails([detailRadarr], loader(), {
+            ...query,
+            query: 'matrix',
+            service: 'radarr',
+            id: '42'
+        });
+        expect(result).toMatchObject({ service: 'radarr' });
+    });
+
+    it('names the parameters when given neither', async () => {
+        await expect(resolveMediaDetails([detailRadarr], loader(), query)).rejects.toThrow(/query.*service.*id/i);
     });
 });
 


### PR DESCRIPTION
Phase 3b, Task 4 of 9.

Design spec §8 names `get_media_details` a consumer of the identity resolver. Phase 2 shipped it service-scoped — name Radarr *or* Jellyfin, get that service's half — which left it assembling its own view of an item right next to a resolver built for exactly that. That is the second join the resolver exists to prevent.

It now answers a bare title from the merged record: acquisition, watch state, ratings and `presence` together.

**The `service` + `id` form stays, and is not legacy.** It is how you inspect one side of a join that looks wrong — precisely what `diagnose` needs when `presence` says the two halves disagree. Saved prompts are treated as public API, so removing it would break users silently.

Given both, the explicit id wins: an id is unambiguous and a title is not. Given neither, the tool fails naming the parameters rather than guessing — as a plain `Error`, not a `ServiceError`, because no service failed and attaching one would misattribute the fault.

## Why three functions rather than one wider one

`buildGetMediaDetails` already had seven tests reading `result.service` and `result.ratings` off its return value. Widening it to `MediaDetails | MergedItem` would have turned every one into a typecheck failure over a change that is not about them.

So it stays byte-identical, `buildResolvedMediaDetails` handles the merged form, and a thin dispatcher chooses between them — the union exists only there. **All seven pre-existing tests pass untouched**; the only removed line in the test file is an import.

The two response shapes are unambiguously discriminable: a merged record carries `presence`, a service view carries top-level `service` and `id`. A consumer never has to guess which it received.

**566 tests**, up from 560.

🤖 Generated with [Claude Code](https://claude.com/claude-code)