### PR TITLE
fix: let a failure tell the model what to do about it

### DIFF
--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -58,9 +58,16 @@ export class ServiceError extends Error {
     }
 
     /**
-     * Now identical to `.message` — kept as the named, documented surface so
-     * a call site reads as "the text a model may see" rather than "whatever
-     * `Error.prototype` happens to expose".
+     * Deliberately just an alias for `.message` — it is `.message` that now
+     * carries the remedy (see the class doc comment), so there is nothing
+     * left for this method to add. Nothing in this codebase calls it; it is
+     * kept anyway as the named, documented surface so a call site reads as
+     * "the text a model may see" rather than "whatever `Error.prototype`
+     * happens to expose". A dead-but-plausible-looking method is exactly
+     * what let the remedy go unreachable before (nothing called it, and
+     * nothing noticed) — if this is ever removed, remove it because it is
+     * unused, not because it looks redundant with `.message`; it is
+     * *supposed* to be redundant with `.message`.
      */
     toModelText(): string {
         return this.message;
@@ -84,20 +91,36 @@ function safeHost(url: string): string {
     }
 }
 
+/** A plain endpoint-vocabulary word, or a REST version segment such as `v3`. */
+const WORD_SEGMENT = /^([A-Za-z]+|v\d+)$/i;
+
+/**
+ * An integer id, or a GUID — hyphenated or not (Jellyfin's are 32 raw hex
+ * characters, no hyphens). Requiring a digit alongside the hex letters keeps
+ * an incidental all-letter word that happens to be hex-shaped (`face`,
+ * `cafe`, `dead`) from being misread as an id.
+ */
+const ID_SEGMENT = /^(\d+|(?=[0-9a-f-]*\d)[0-9a-f]{4,}(-[0-9a-f]{4,})*)$/i;
+
 /**
  * The only signal a 404 carries about *why* is the path it was for. Every
  * real by-id endpoint in this codebase (Radarr `/api/v3/movie/{id}`, Sonarr
- * `/api/v3/series/{id}`) ends the path in a bare integer; every collection or
- * status endpoint (`/api/v3/movie`, `/api/v3/system/status`) ends in a plain
- * word. A trailing segment that is neither — a GUID, a hash, a slug — is
- * genuinely ambiguous from the path alone, so it gets a remedy that says so
- * instead of confidently guessing one cause.
+ * `/api/v3/series/{id}`, and — critically — Jellyfin's
+ * `/Users/{userId}/Items/Resume`, where the id sits mid-path, not last) has
+ * an id-shaped segment *somewhere*; a collection or status endpoint
+ * (`/api/v3/movie`, `/api/v3/system/status`) is made entirely of
+ * endpoint-vocabulary words. Position must not matter — classifying only the
+ * last segment is exactly what missed the Jellyfin case — so every segment is
+ * inspected, and an id anywhere outweighs the rest of the path being
+ * word-shaped. A segment that is neither a recognisable word nor a
+ * recognisable id (a hash, a slug) makes the path genuinely ambiguous, so it
+ * gets a remedy that says so instead of confidently guessing one cause.
  */
 function classifyNotFoundPath(pathname: string): 'item' | 'collection' | 'ambiguous' {
-    const last = pathname.split('/').filter(Boolean).at(-1);
-    if (last === undefined) return 'collection';
-    if (/^\d+$/.test(last)) return 'item';
-    if (/^[A-Za-z]+$/.test(last)) return 'collection';
+    const segments = pathname.split('/').filter(Boolean);
+    if (segments.length === 0) return 'collection';
+    if (segments.some(s => ID_SEGMENT.test(s))) return 'item';
+    if (segments.every(s => WORD_SEGMENT.test(s))) return 'collection';
     return 'ambiguous';
 }
 

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -84,9 +84,34 @@ function safeHost(url: string): string {
     }
 }
 
+/**
+ * The only signal a 404 carries about *why* is the path it was for. Every
+ * real by-id endpoint in this codebase (Radarr `/api/v3/movie/{id}`, Sonarr
+ * `/api/v3/series/{id}`) ends the path in a bare integer; every collection or
+ * status endpoint (`/api/v3/movie`, `/api/v3/system/status`) ends in a plain
+ * word. A trailing segment that is neither — a GUID, a hash, a slug — is
+ * genuinely ambiguous from the path alone, so it gets a remedy that says so
+ * instead of confidently guessing one cause.
+ */
+function classifyNotFoundPath(pathname: string): 'item' | 'collection' | 'ambiguous' {
+    const last = pathname.split('/').filter(Boolean).at(-1);
+    if (last === undefined) return 'collection';
+    if (/^\d+$/.test(last)) return 'item';
+    if (/^[A-Za-z]+$/.test(last)) return 'collection';
+    return 'ambiguous';
+}
+
+const NOT_FOUND_REMEDY: Record<ReturnType<typeof classifyNotFoundPath>, string> = {
+    item: 'This id does not exist at that service — verify it (e.g. via search) rather than a guess, before assuming the base URL is wrong.',
+    collection: 'Wrong base path — check the URL does not include a trailing path or reverse-proxy prefix.',
+    ambiguous:
+        'Could not tell from the URL alone whether this is a missing id or a wrong base path — verify the id is correct, and separately that the URL has no trailing path or reverse-proxy prefix.'
+};
+
 export function classifyHttpStatus(status: number, service: ServiceId, url: string): ServiceError | undefined {
     if (status < 400) return undefined;
-    const at = `HTTP ${status} at ${safePath(url)}`;
+    const pathname = safePath(url);
+    const at = `HTTP ${status} at ${pathname}`;
 
     if (status === 401 || status === 403) {
         return new ServiceError('AuthFailed', service, at, {
@@ -95,7 +120,7 @@ export function classifyHttpStatus(status: number, service: ServiceId, url: stri
     }
     if (status === 404) {
         return new ServiceError('NotFound', service, at, {
-            remedy: 'Wrong base path — check the URL does not include a trailing path or reverse-proxy prefix.'
+            remedy: NOT_FOUND_REMEDY[classifyNotFoundPath(pathname)]
         });
     }
     if (status === 429) {

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -19,11 +19,20 @@ const PROSE: Record<ServiceErrorKind, string> = {
     UpstreamError: 'upstream error'
 };
 
+function formatServiceError(kind: ServiceErrorKind, service: ServiceId, detail: string, remedy?: string): string {
+    const base = `${service} ${PROSE[kind]}: ${detail}`;
+    return remedy ? `${base} — ${remedy}` : base;
+}
+
 /**
  * A model told *why* something failed reports it; a model handed an opaque
- * error invents an explanation (design spec §15). `toModelText` is the only
- * string that ever reaches the model — it never includes a stack trace, and
- * never the underlying cause, which stays available for logs via `.cause`.
+ * error invents an explanation (design spec §15). The remedy therefore lives
+ * in `.message` itself, not only in `toModelText()`: every path that throws
+ * this error is caught somewhere as a plain `Error`, and the only field a
+ * generic catcher reads is `.message` — including the MCP SDK's own tool
+ * dispatch loop, which builds its error result from `error.message` alone.
+ * `.message` never includes a stack trace, and never the underlying cause,
+ * which stays available for logs via `.cause`.
  */
 export class ServiceError extends Error {
     readonly kind: ServiceErrorKind;
@@ -37,7 +46,10 @@ export class ServiceError extends Error {
         detail: string,
         opts?: { remedy?: string; cause?: unknown }
     ) {
-        super(`${service} ${PROSE[kind]}: ${detail}`, opts?.cause !== undefined ? { cause: opts.cause } : undefined);
+        super(
+            formatServiceError(kind, service, detail, opts?.remedy),
+            opts?.cause !== undefined ? { cause: opts.cause } : undefined
+        );
         this.name = 'ServiceError';
         this.kind = kind;
         this.service = service;
@@ -45,9 +57,13 @@ export class ServiceError extends Error {
         this.remedy = opts?.remedy;
     }
 
+    /**
+     * Now identical to `.message` — kept as the named, documented surface so
+     * a call site reads as "the text a model may see" rather than "whatever
+     * `Error.prototype` happens to expose".
+     */
     toModelText(): string {
-        const base = `${this.service} ${PROSE[this.kind]}: ${this.detail}`;
-        return this.remedy ? `${base} — ${this.remedy}` : base;
+        return this.message;
     }
 }
 

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -10,5 +10,18 @@ export const logger = pino({
     // is about (radarr, sonarr, …), which is what the config UI's per-service
     // log stream filters on in Phase 5. Binding both to `service` emits a
     // duplicate JSON key and silently loses one of them.
-    base: { app: 'arr-mcp' }
+    base: { app: 'arr-mcp' },
+    serializers: {
+        // pino's default `err` serializer spreads every own enumerable
+        // property, and `ServiceError.message` embeds `.remedy` (see
+        // core/errors.ts) — without this, `remedy` would appear twice in
+        // every logged error: once inline in `message`, once as its own
+        // field. `kind`/`service`/`detail` stay, since those are structured
+        // fields the config UI's log streams can filter on and are not
+        // themselves duplicated prose.
+        err: err => {
+            const { remedy: _remedy, ...rest } = pino.stdSerializers.err(err);
+            return rest;
+        }
+    }
 });

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -227,4 +227,42 @@ describe('a thrown ServiceError reaches the client with its remedy', () => {
         expect(result.isError).toBe(true);
         expect(result.content?.[0]?.text).toMatch(/API key is wrong/i);
     });
+
+    /**
+     * The reported bug, reproduced end to end: a request for a Radarr id that
+     * does not exist. Confirmed live against the published 0.3.1 container as
+     * `radarr not found: HTTP 404 at /api/v3/movie/999999` with no remedy at
+     * all. With both fixes in, the model is told a remedy, and the right one —
+     * a missing id, not a misconfigured base URL.
+     */
+    it('tells the model to check the id, not the base URL, for a 404 on a nonexistent Radarr id', async () => {
+        const notFound: typeof fetch = async () =>
+            new Response(JSON.stringify({ message: 'NotFound' }), {
+                status: 404,
+                headers: { 'content-type': 'application/json' }
+            });
+        const withRadarr = buildApp({ config, adapters: [new RadarrAdapter(radarrConfig, notFound)] });
+
+        const callTool = {
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'tools/call',
+            params: {
+                name: 'get_media_details',
+                arguments: { service: 'radarr', id: '999999', detail: 'standard', limit: 50 }
+            }
+        };
+        const res = await withRadarr.request(
+            'http://localhost:6060/mcp',
+            rpc(callTool, { Authorization: `Bearer ${TOKEN}` })
+        );
+
+        const payload = await rpcPayload(res);
+        const result = payload.result as { isError?: boolean; content?: { type: string; text: string }[] };
+        const text = result.content?.[0]?.text ?? '';
+        expect(result.isError).toBe(true);
+        expect(text).toContain('HTTP 404 at /api/v3/movie/999999');
+        expect(text).not.toMatch(/base path/i);
+        expect(text).toMatch(/id/i);
+    });
 });

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { buildApp } from '../src/app.ts';
 import { ConfigSchema } from '../src/config/schema.ts';
+import { RadarrAdapter } from '../src/services/radarr.ts';
 import { TOOL_NAMES } from '../src/tools/register.ts';
 
 const TOKEN = 'a'.repeat(64);
@@ -16,6 +17,12 @@ const rpc = (body: unknown, headers: Record<string, string> = {}) => ({
 });
 
 const toolsList = { jsonrpc: '2.0', id: 1, method: 'tools/list' };
+
+/** Parses the JSON-RPC payload out of the SDK's response, which may frame it as SSE. */
+const rpcPayload = async (res: Response): Promise<{ result?: Record<string, unknown> }> => {
+    const body = await res.text();
+    return JSON.parse(body.slice(body.indexOf('{'), body.lastIndexOf('}') + 1)) as { result?: Record<string, unknown> };
+};
 
 describe('GET /healthz', () => {
     it('is reachable without a token — it is a container probe, not an API', async () => {
@@ -176,5 +183,48 @@ describe('the advertised tool surface', () => {
     it('gives every tool a description, which is the only documentation a model reads', async () => {
         const undocumented = (await listTools()).filter(t => (t.description ?? '').length < 40);
         expect(undocumented.map(t => t.name)).toEqual([]);
+    });
+});
+
+describe('a thrown ServiceError reaches the client with its remedy', () => {
+    const radarrConfig = {
+        url: 'http://192.0.2.10:7878',
+        api_key: 'k',
+        timeout_ms: 10_000,
+        permissions: { safe_write: false, destructive: false }
+    };
+
+    /**
+     * This is the exact path a live tool call takes: registerGetMediaDetails
+     * throws a ServiceError, the MCP SDK's own dispatch loop catches it and
+     * builds the tool result from `error.message` alone
+     * (`@modelcontextprotocol/server`'s `createToolError`) — it never calls
+     * `toModelText()`. A remedy that does not reach `.message` is dropped here,
+     * not in application code, which is why the fix has to live in the error
+     * class rather than in a tool-layer catch.
+     */
+    it('surfaces the remedy for an auth failure through get_media_details', async () => {
+        const unauthorized: typeof fetch = async () =>
+            new Response(JSON.stringify({ message: 'Unauthorized' }), {
+                status: 401,
+                headers: { 'content-type': 'application/json' }
+            });
+        const withRadarr = buildApp({ config, adapters: [new RadarrAdapter(radarrConfig, unauthorized)] });
+
+        const callTool = {
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'tools/call',
+            params: { name: 'get_media_details', arguments: { service: 'radarr', id: '42', detail: 'standard', limit: 50 } }
+        };
+        const res = await withRadarr.request(
+            'http://localhost:6060/mcp',
+            rpc(callTool, { Authorization: `Bearer ${TOKEN}` })
+        );
+
+        const payload = await rpcPayload(res);
+        const result = payload.result as { isError?: boolean; content?: { type: string; text: string }[] };
+        expect(result.isError).toBe(true);
+        expect(result.content?.[0]?.text).toMatch(/API key is wrong/i);
     });
 });

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -84,6 +84,34 @@ describe('classifyHttpStatus', () => {
         expect(classifyHttpStatus(404, 'radarr', 'http://h/api/v3/system/status')?.remedy).toMatch(/base path/i);
     });
 
+    it('gives a 404 on Radarr’s real get-by-id path a missing-item remedy, not the base-path one', () => {
+        // The reported bug, live: GET /api/v3/movie/{id} for an id that does
+        // not exist. Nothing about the base URL is wrong here.
+        const remedy = classifyHttpStatus(404, 'radarr', 'http://h/api/v3/movie/999999')?.remedy;
+        expect(remedy).not.toMatch(/base path/i);
+        expect(remedy).toMatch(/id/i);
+    });
+
+    it('gives a 404 on Sonarr’s real get-by-id path the same missing-item remedy', () => {
+        const remedy = classifyHttpStatus(404, 'sonarr', 'http://h/api/v3/series/42')?.remedy;
+        expect(remedy).not.toMatch(/base path/i);
+        expect(remedy).toMatch(/id/i);
+    });
+
+    it('keeps the base-path remedy for a 404 on a collection endpoint with no id', () => {
+        // GET /api/v3/movie (the collection itself, no trailing id) 404ing
+        // means the base path is wrong — that route always exists.
+        expect(classifyHttpStatus(404, 'radarr', 'http://h/api/v3/movie')?.remedy).toMatch(/base path/i);
+    });
+
+    it('hedges rather than guessing when the trailing path segment is neither an id nor a collection name', () => {
+        // A GUID-shaped segment (letters and digits both) is not confidently
+        // either shape from the path alone.
+        const remedy = classifyHttpStatus(404, 'jellyfin', 'http://h/Users/8a1e21b1a1b04c1b8a1e21b1a1b04c1b')?.remedy;
+        expect(remedy).toMatch(/id/i);
+        expect(remedy).toMatch(/base path|url/i);
+    });
+
     it('names the path but not the host in the detail, so keys in query strings cannot leak', () => {
         const err = classifyHttpStatus(401, 'radarr', 'http://h:7878/api/v3/system/status?apikey=secret');
         expect(err?.detail).toContain('/api/v3/system/status');

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -30,6 +30,36 @@ describe('ServiceError.toModelText', () => {
     });
 });
 
+/**
+ * The MCP SDK's own catch around a tool handler reads `error.message`, not
+ * `toModelText()` — nothing in this codebase calls `toModelText()` in a
+ * throwing path. A remedy that lives only there never reaches a caller. The
+ * remedy therefore has to live in `.message` itself, which every catcher of a
+ * thrown Error already reads.
+ */
+describe('ServiceError.message', () => {
+    it('includes the remedy, since .message is what a thrown error is caught as', () => {
+        const err = new ServiceError('AuthFailed', 'radarr', 'HTTP 401 at /api/v3/system/status', {
+            remedy: 'The API key is wrong. Radarr → Settings → General.'
+        });
+        expect(err.message).toBe(
+            'radarr auth failed: HTTP 401 at /api/v3/system/status — The API key is wrong. Radarr → Settings → General.'
+        );
+    });
+
+    it('matches toModelText() exactly — one sanctioned string, not two that can drift', () => {
+        const err = new ServiceError('AuthFailed', 'radarr', 'HTTP 401 at /api/v3/system/status', {
+            remedy: 'The API key is wrong. Radarr → Settings → General.'
+        });
+        expect(err.message).toBe(err.toModelText());
+    });
+
+    it('omits the trailing dash when there is no remedy', () => {
+        const err = new ServiceError('UpstreamError', 'radarr', 'boom');
+        expect(err.message).toBe('radarr upstream error: boom');
+    });
+});
+
 describe('classifyHttpStatus', () => {
     it.each([
         [401, 'AuthFailed'],

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -86,7 +86,8 @@ describe('classifyHttpStatus', () => {
 
     it('gives a 404 on Radarr’s real get-by-id path a missing-item remedy, not the base-path one', () => {
         // The reported bug, live: GET /api/v3/movie/{id} for an id that does
-        // not exist. Nothing about the base URL is wrong here.
+        // not exist. Nothing about the base URL is wrong here. The id is the
+        // *last* path segment.
         const remedy = classifyHttpStatus(404, 'radarr', 'http://h/api/v3/movie/999999')?.remedy;
         expect(remedy).not.toMatch(/base path/i);
         expect(remedy).toMatch(/id/i);
@@ -98,16 +99,44 @@ describe('classifyHttpStatus', () => {
         expect(remedy).toMatch(/id/i);
     });
 
-    it('keeps the base-path remedy for a 404 on a collection endpoint with no id', () => {
-        // GET /api/v3/movie (the collection itself, no trailing id) 404ing
-        // means the base path is wrong — that route always exists.
+    it('gives the missing-item remedy when the id is in the middle of the path, not just the end', () => {
+        // Real Jellyfin path used by get_playback (jellyfin.ts):
+        // `/Users/${userId}/Items/Resume` — the id sits between two words, and
+        // the trailing segment ("Resume") looks exactly like a collection.
+        // Classifying on the last segment alone would blame the base URL for
+        // what is far more likely a stale or wrong user id.
+        const remedy = classifyHttpStatus(
+            404,
+            'jellyfin',
+            'http://h/Users/8a1e21b1a1b04c1b8a1e21b1a1b04c1b/Items/Resume'
+        )?.remedy;
+        expect(remedy).not.toMatch(/base path/i);
+        expect(remedy).toMatch(/id/i);
+    });
+
+    it('keeps the base-path remedy for a 404 on a collection endpoint with no id anywhere in the path', () => {
+        // GET /api/v3/movie (the collection itself, no id segment at all)
+        // 404ing means the base path is wrong — that route always exists.
+        // Also exercises a version segment ("v3") staying endpoint-vocabulary
+        // rather than being read as an opaque id-shaped token.
         expect(classifyHttpStatus(404, 'radarr', 'http://h/api/v3/movie')?.remedy).toMatch(/base path/i);
     });
 
-    it('hedges rather than guessing when the trailing path segment is neither an id nor a collection name', () => {
-        // A GUID-shaped segment (letters and digits both) is not confidently
-        // either shape from the path alone.
-        const remedy = classifyHttpStatus(404, 'jellyfin', 'http://h/Users/8a1e21b1a1b04c1b8a1e21b1a1b04c1b')?.remedy;
+    it('keeps the base-path remedy for SABnzbd’s single fixed endpoint', () => {
+        // SABnzbd never puts an id in the path — ids travel as query
+        // parameters (?name=...) — so a 404 here is unambiguously the base
+        // path, and that must not change.
+        expect(classifyHttpStatus(404, 'sabnzbd', 'http://h/api')?.remedy).toMatch(/base path/i);
+    });
+
+    it('keeps the base-path remedy for Transmission’s single fixed RPC endpoint', () => {
+        expect(classifyHttpStatus(404, 'transmission', 'http://h/transmission/rpc')?.remedy).toMatch(/base path/i);
+    });
+
+    it('hedges rather than guessing when a path segment is neither an id nor endpoint vocabulary', () => {
+        // A hyphenated slug is not a plain word (collection-shaped) and not a
+        // number or GUID (id-shaped) — genuinely unclear from the path alone.
+        const remedy = classifyHttpStatus(404, 'radarr', 'http://h/api/v3/movie/the-matrix-1999')?.remedy;
         expect(remedy).toMatch(/id/i);
         expect(remedy).toMatch(/base path|url/i);
     });

--- a/test/identity.test.ts
+++ b/test/identity.test.ts
@@ -4,9 +4,11 @@ import { IdentityResolver } from '../src/core/identity.ts';
 import type { ServiceAdapter, ServiceUser, UserDirectoryCapable } from '../src/services/types.ts';
 
 /**
- * `ServiceError.message` carries kind and detail; the remedy lives only in
- * `toModelText()`. Assertions about *what the user is told to do* therefore
- * have to look at the error object, not at the thrown message.
+ * `.message` and `.remedy` both carry the remedy text now (`.message`
+ * includes it inline; `.remedy` is the field alone). This helper unwraps to
+ * the `ServiceError` itself so a test can assert on `.remedy` specifically —
+ * useful when a test cares about the remedy's wording in isolation, not
+ * about the whole formatted string.
  */
 async function rejection(promise: Promise<unknown>): Promise<ServiceError> {
     try {
@@ -139,8 +141,9 @@ describe('IdentityResolver', () => {
         const err = await rejection(r.resolve('Guest'));
         expect(err.kind).toBe('AuthFailed');
         expect(err.remedy).toMatch(/every user's history/);
-        // The remedy is not in `message` by design, so a tool that surfaces
-        // only the message would drop the one sentence the user needs.
+        // .message (what a tool that only surfaces the caught error's message
+        // sees) must carry the same sentence, not just the .remedy field.
+        expect(err.message).toMatch(/every user's history/);
         expect(err.toModelText()).toMatch(/every user's history/);
     });
 });


### PR DESCRIPTION
Two defects found by running the published **0.3.1** container against a real stack. Not part of the phase plan — fixed now because `diagnose` is built on this machinery next, and its entire value is telling a user what to do about a failure.

## A remedy never reached the model

`ServiceError.toModelText()` carries this comment:

> A model told *why* something failed reports it; a model handed an opaque error invents an explanation. `toModelText` is the only string that ever reaches the model.

**Nothing called it.** Every thrown error surfaced `.message` — `${service} ${prose}: ${detail}` — and the remedy was dropped. Live, before:

```
radarr not found: HTTP 404 at /api/v3/movie/999999
```

The remedy is now baked into the message at construction, so every path that surfaces `.message` carries it. The alternative — formatting at the tool layer — was rejected because it requires every current *and future* throwing tool to remember, which is exactly the fragility this codebase keeps designing against.

The structured `stack_health` path was never affected: it copies `kind`, `detail` and `remedy` into a diagnosis rather than reading `.message`.

`toModelText()` is kept as a documented alias, with a comment saying so — if it is ever removed, it should be removed for being unused, not for looking redundant.

## A 404 on a valid path blamed the wrong thing

Every 404 returned *"Wrong base path — check the URL does not include a trailing path or reverse-proxy prefix."* Right for a misconfigured base URL; wrong for a valid endpoint with an id that does not exist, which is what a user hits when a model guesses an id — and it sends them to inspect a reverse proxy that is working fine.

Now classified by path shape:

| path | verdict |
|---|---|
| `/api/v3/movie/999999` | this id does not exist |
| `/Users/{guid}/Items/Resume` | this id does not exist |
| `/api/v3/movie`, `/api`, `/transmission/rpc` | wrong base path |
| `/api/v3/movie/the-matrix-1999` | hedges — names both possibilities |

The first attempt inspected only the **last** path segment, which missed `get_playback`'s Jellyfin call where the id sits mid-path and the final segment is the word `Resume` — reintroducing the exact bug being fixed, on a different shape. It now examines every segment, with no special case for any service: position must not matter, because a rule that names one path is a rule that misses the next one.

Version segments are safe: `v3` is not hex, so it cannot be misread as an id and every *arr collection path keeps the base-path remedy. An api key in a query string still never reaches an error — only the pathname is used.

Logs no longer print the remedy twice.

**578 tests**, up from 566.

🤖 Generated with [Claude Code](https://claude.com/claude-code)