### PR TITLE
feat: add the diagnosis chain

### DIFF
--- a/src/tools/diagnose/chain.ts
+++ b/src/tools/diagnose/chain.ts
@@ -103,7 +103,10 @@ const mentions = (haystack: string, item: MergedItem): boolean => {
     const words = titleWords(item);
     if (words.length === 0) return false;
 
-    const hayWords = tokenize(haystack);
+    // Same asymmetry class as N3: the needle is unfenced before tokenising,
+    // so the haystack must be too — otherwise `<<untrusted:service.field>>`
+    // itself, the service id and the field name become haystack tokens.
+    const hayWords = tokenize(unfenced(haystack));
     const haySet = new Set(hayWords);
     if (!words.every(w => haySet.has(w))) return false;
 
@@ -402,6 +405,14 @@ function fileRemedy(ev: Evidence, queueStatus: StepStatus, indexerStatus: StepSt
  * correctly stops that from outranking a green chain, but going silent about
  * a real, active failure is over-correction in the other direction (N7): it
  * is worth a mention, just not the verdict.
+ *
+ * The wording asserts a file already exists — true only when `fileIsOk`, so
+ * callers gate this on that before including it. Without the gate, a
+ * `request`/`managed` verdict for something with genuinely no file yet
+ * (`monitored: false` *and* `hasFile: false`, with an unrelated queue row
+ * happening to fault) would read "…is not monitored. (Also: Download
+ * failed… This does not block the file already on disk…)" — asserting a
+ * file that was never confirmed to exist.
  */
 const queueAside = (queueResult: QueueResult): string =>
     queueResult.remedy === undefined || queueResult.step.status !== 'blocked'
@@ -476,14 +487,26 @@ export function buildChain(query: string, ev: Evidence): Diagnosis {
     // why playback fails when the file is sitting right there. From this
     // point on only Jellyfin's visibility of that file matters.
     const fileIsOk = byStage.get('file')?.status === 'ok';
+    // `fileIsOk` means something different for a series than for a movie.
+    // A movie's `hasFile` is unambiguous: this exact file is or is not on
+    // disk. A series' `hasFile` (`sonarr.ts`: `episodeFileCount > 0`) is
+    // "any episode has a file" — true for a show sitting on seasons 1-4
+    // while season 5, the actual question, has never arrived. Excluding
+    // request/managed there would silently drop the single most common
+    // series diagnosis — "monitoring got turned off" / "the new-season
+    // request is still pending" — under a confident "is available in
+    // Jellyfin and playable", with no remedy and no mention. So the
+    // exclusion applies only where the signal it depends on is actually
+    // unambiguous: movies.
+    const excludeRequestManaged = fileIsOk && item.kind === 'movie';
 
     let verdictStage: Stage | undefined;
     let certaintyPath: Stage[];
 
-    if (!fileIsOk && isBlocked('request')) {
+    if (!excludeRequestManaged && isBlocked('request')) {
         verdictStage = 'request';
         certaintyPath = ['request'];
-    } else if (!fileIsOk && isBlocked('managed')) {
+    } else if (!excludeRequestManaged && isBlocked('managed')) {
         verdictStage = 'managed';
         certaintyPath = ['request', 'managed'];
     } else if (isBlocked('file')) {
@@ -516,7 +539,7 @@ export function buildChain(query: string, ev: Evidence): Diagnosis {
         certaintyPath = ['file', 'library', 'scan'];
     } else {
         verdictStage = undefined; // playable
-        certaintyPath = fileIsOk ? ['file', 'library'] : ['request', 'managed', 'file', 'library'];
+        certaintyPath = excludeRequestManaged ? ['file', 'library'] : ['request', 'managed', 'file', 'library'];
     }
 
     const unchecked = certaintyPath.filter(s => byStage.get(s)?.status === 'unknown');
@@ -525,7 +548,13 @@ export function buildChain(query: string, ev: Evidence): Diagnosis {
     const caveat = certain
         ? ''
         : ` Could not check: ${[...new Set(unchecked.map(s => byStage.get(s)?.service ?? s))].join(', ')}.`;
-    const aside = queueAside(queueResult);
+    // Gated on `fileIsOk`, not on which stage ended up as the verdict: the
+    // sentence claims a file exists, so it must only appear when one was
+    // actually confirmed — true regardless of whether that confirmed file
+    // then made request/managed moot (`excludeRequestManaged`) or not (the
+    // series case above, where `request`/`managed` can still be the verdict
+    // even with a file on disk).
+    const aside = fileIsOk ? queueAside(queueResult) : '';
 
     if (verdictStage === undefined) {
         const libStep = byStage.get('library');

--- a/src/tools/diagnose/chain.ts
+++ b/src/tools/diagnose/chain.ts
@@ -1,0 +1,278 @@
+import type { ServiceId } from '../../config/schema.ts';
+import type { MergedItem } from '../../core/resolver.ts';
+import type { IndexerRejection, QueueItem, RequestStatus, ScanState } from '../../services/types.ts';
+
+export type Stage = 'resolve' | 'request' | 'managed' | 'file' | 'queue' | 'indexers' | 'library' | 'scan';
+export type StepStatus = 'ok' | 'blocked' | 'unknown' | 'skipped';
+
+export type Step = { stage: Stage; service?: ServiceId; status: StepStatus; detail: string };
+
+/**
+ * `undefined` and `null` mean different things throughout, and the distinction
+ * is the whole of §6.1: **undefined is "could not look", null is "looked and
+ * found nothing"**. Collapsing them is how a diagnosis becomes confidently
+ * wrong about a service that was down.
+ */
+export type Evidence = {
+    item: MergedItem | undefined;
+    request: { status: RequestStatus | 'unknown' } | null | undefined;
+    queue: QueueItem[] | undefined;
+    rejections: IndexerRejection[] | undefined;
+    scan: ScanState | undefined;
+    /**
+     * A third state beyond looked/could-not-look: **never configured**. Without
+     * it, a stack with no Jellyfin gets "Jellyfin cannot see it" — a claim
+     * about a service the user does not run.
+     */
+    jellyfinConfigured: boolean;
+    degraded: ServiceId[];
+};
+
+export type Diagnosis = {
+    query: string;
+    resolved?: { title: string; year?: number; kind: 'movie' | 'series'; ids: MergedItem['ids'] };
+    steps: Step[];
+    verdict: { stage: Stage | 'playable'; summary: string; remedy?: string; certain: boolean };
+    degraded: ServiceId[];
+};
+
+/** Reported in this order — it is the order the pipeline actually runs in. */
+const DISPLAY_ORDER: readonly Stage[] = [
+    'resolve',
+    'request',
+    'managed',
+    'file',
+    'queue',
+    'indexers',
+    'library',
+    'scan'
+];
+
+/**
+ * The verdict is chosen in a *different* order, and the difference is the one
+ * judgement call in this module: **a missing file is a symptom, and a stalled
+ * download or a dead indexer is its cause**. Answering "it has no file" when
+ * the real answer is "your news server is refusing connections" is technically
+ * true and useless.
+ */
+const VERDICT_ORDER: readonly Stage[] = [
+    'resolve',
+    'request',
+    'managed',
+    'queue',
+    'indexers',
+    'file',
+    'library',
+    'scan'
+];
+
+const SKIPPED = (stage: Stage, detail: string): Step => ({ stage, status: 'skipped', detail });
+
+/** Words a title and a release name are likely to share, after normalisation. */
+const mentions = (haystack: string, item: MergedItem): boolean => {
+    const words = item.title
+        .replace(/^<<untrusted:[^>]*>>/, '')
+        .replace(/<<\/untrusted>>$/, '')
+        .toLowerCase()
+        .split(/[^\p{L}\p{N}]+/u)
+        .filter(w => w.length > 3);
+    if (words.length === 0) return false;
+
+    const hay = haystack.toLowerCase();
+    return words.every(w => hay.includes(w));
+};
+
+function requestStep(ev: Evidence): Step {
+    if (ev.request === undefined) return { stage: 'request', service: 'seerr', status: 'unknown', detail: 'Seerr could not be reached.' };
+    if (ev.request === null) return SKIPPED('request', 'No request recorded — not everything arrives through Seerr.');
+
+    if (ev.request.status === 'declined') {
+        return { stage: 'request', service: 'seerr', status: 'blocked', detail: 'The request was declined.' };
+    }
+    if (ev.request.status === 'pending') {
+        return { stage: 'request', service: 'seerr', status: 'blocked', detail: 'The request is still awaiting approval.' };
+    }
+    return { stage: 'request', service: 'seerr', status: 'ok', detail: `The request is ${ev.request.status}.` };
+}
+
+function queueStep(ev: Evidence, item: MergedItem): Step {
+    if (ev.queue === undefined) return { stage: 'queue', status: 'unknown', detail: 'No download client could be reached.' };
+
+    const mine = ev.queue.filter(q => mentions(q.title, item));
+    if (mine.length === 0) return SKIPPED('queue', 'Nothing matching it is in any download queue.');
+
+    const failed = mine.find(q => q.errorMessage !== undefined || /stall|fail|error|paused/i.test(q.status));
+    if (failed !== undefined) {
+        return {
+            stage: 'queue',
+            service: failed.service,
+            status: 'blocked',
+            detail: `Download ${failed.status}${failed.errorMessage === undefined ? '' : `: ${failed.errorMessage}`}.`
+        };
+    }
+
+    const active = mine[0] as QueueItem;
+    const eta = active.etaSeconds === undefined ? '' : ` — about ${Math.round(active.etaSeconds / 60)} minute(s) left`;
+    return { stage: 'queue', service: active.service, status: 'blocked', detail: `Still downloading${eta}.` };
+}
+
+function indexerStep(ev: Evidence, item: MergedItem): Step {
+    if (ev.rejections === undefined) return { stage: 'indexers', service: 'prowlarr', status: 'unknown', detail: 'Prowlarr could not be reached.' };
+
+    const mine = ev.rejections.filter(r => (r.query === undefined ? false : mentions(r.query, item)));
+    if (mine.length === 0) return SKIPPED('indexers', 'No recent indexer failures mention it.');
+
+    const first = mine[0] as IndexerRejection;
+    return {
+        stage: 'indexers',
+        service: 'prowlarr',
+        status: 'blocked',
+        detail: `${mine.length} recent indexer failure(s), most recently ${first.indexer}: ${first.reason}.`
+    };
+}
+
+function libraryStep(ev: Evidence, item: MergedItem): Step {
+    if (!ev.jellyfinConfigured) return SKIPPED('library', 'Jellyfin is not configured.');
+    if (ev.degraded.includes('jellyfin')) {
+        // Never "it is not in Jellyfin" when Jellyfin was not asked (§6.1).
+        return { stage: 'library', service: 'jellyfin', status: 'unknown', detail: 'Jellyfin could not be reached, so its library was not checked.' };
+    }
+    if (item.presence === 'both' || item.presence === 'jellyfin_only') {
+        return { stage: 'library', service: 'jellyfin', status: 'ok', detail: 'Present in the Jellyfin library.' };
+    }
+    if (item.acquisition?.hasFile === true) {
+        return {
+            stage: 'library',
+            service: 'jellyfin',
+            status: 'blocked',
+            detail: `${item.acquisition.service} has a file on disk that Jellyfin cannot see.`
+        };
+    }
+    return SKIPPED('library', 'Not in Jellyfin, and there is no file for it to have found.');
+}
+
+function scanStep(ev: Evidence): Step {
+    if (!ev.jellyfinConfigured) return SKIPPED('scan', 'Jellyfin is not configured.');
+    if (ev.scan === undefined) return { stage: 'scan', service: 'jellyfin', status: 'unknown', detail: 'Jellyfin’s scan state could not be read.' };
+    if (ev.scan.running === true) return { stage: 'scan', service: 'jellyfin', status: 'blocked', detail: 'A library scan is running now — check again once it finishes.' };
+    if (ev.scan.lastCompleted === undefined) return { stage: 'scan', service: 'jellyfin', status: 'unknown', detail: 'Jellyfin reports no completed library scan.' };
+    return { stage: 'scan', service: 'jellyfin', status: 'ok', detail: `Last library scan completed ${ev.scan.lastCompleted}.` };
+}
+
+const REMEDIES: Partial<Record<Stage, string>> = {
+    resolve: 'Try search_media — it also looks at what you do not have yet — or request it through Seerr.',
+    request: 'Approve or re-submit the request in Seerr.',
+    managed: 'Add it to Radarr or Sonarr, or turn monitoring on for it.',
+    file: 'Trigger a search in Radarr or Sonarr — nothing is downloading and no indexer reported a failure.',
+    indexers: 'Check the indexer in Prowlarr; get_indexers shows its recent failures.',
+    library: 'Trigger a Jellyfin library scan. If it still does not appear, check the path is inside a Jellyfin library and readable by it.',
+    scan: 'Wait for the running scan, or start one from Jellyfin’s dashboard.'
+};
+
+export function buildChain(query: string, ev: Evidence): Diagnosis {
+    const steps: Step[] = [];
+
+    if (ev.item === undefined) {
+        steps.push({ stage: 'resolve', status: 'blocked', detail: 'No configured service knows this title.' });
+        for (const stage of DISPLAY_ORDER.slice(1)) steps.push(SKIPPED(stage, 'Not reached — the item was never identified.'));
+
+        return {
+            query,
+            steps,
+            verdict: {
+                stage: 'resolve',
+                summary: `Nothing in your stack matches "${query}".`,
+                remedy: REMEDIES.resolve as string,
+                // Not knowing about it and not being able to look are different
+                // answers, and a degraded library service means the second.
+                certain: ev.degraded.length === 0
+            },
+            degraded: ev.degraded
+        };
+    }
+
+    const item = ev.item;
+    const acquisition = item.acquisition;
+
+    steps.push({ stage: 'resolve', status: 'ok', detail: `Identified as ${item.title}.` });
+    steps.push(requestStep(ev));
+
+    if (acquisition === undefined) {
+        steps.push({ stage: 'managed', status: 'blocked', detail: 'Neither Radarr nor Sonarr is managing it.' });
+        steps.push(SKIPPED('file', 'Not reached — nothing is managing it.'));
+    } else if (!acquisition.monitored) {
+        steps.push({
+            stage: 'managed',
+            service: acquisition.service,
+            status: 'blocked',
+            detail: `${acquisition.service} has it, but it is not monitored.`
+        });
+        steps.push(SKIPPED('file', 'Not reached — it is not monitored.'));
+    } else {
+        steps.push({ stage: 'managed', service: acquisition.service, status: 'ok', detail: `Monitored in ${acquisition.service}.` });
+        steps.push(
+            acquisition.hasFile
+                ? { stage: 'file', service: acquisition.service, status: 'ok', detail: 'A file is on disk.' }
+                : { stage: 'file', service: acquisition.service, status: 'blocked', detail: 'No file on disk yet.' }
+        );
+    }
+
+    steps.push(queueStep(ev, item));
+    steps.push(indexerStep(ev, item));
+    steps.push(libraryStep(ev, item));
+    steps.push(scanStep(ev));
+
+    const byStage = new Map(steps.map(s => [s.stage, s]));
+    const verdictStage = VERDICT_ORDER.find(s => byStage.get(s)?.status === 'blocked');
+    const blocking = verdictStage === undefined ? undefined : (byStage.get(verdictStage) as Step);
+
+    // Any stage that could not be checked *before* the verdict leaves a hole
+    // the verdict reads across. Stages after it cannot change the answer.
+    const cutoff = verdictStage === undefined ? DISPLAY_ORDER.length : VERDICT_ORDER.indexOf(verdictStage);
+    const unchecked = VERDICT_ORDER.slice(0, cutoff).filter(s => byStage.get(s)?.status === 'unknown');
+    const certain = unchecked.length === 0;
+
+    const caveat = certain
+        ? ''
+        : ` Could not check: ${[...new Set(unchecked.map(s => byStage.get(s)?.service ?? s))].join(', ')}.`;
+
+    if (blocking === undefined) {
+        return {
+            query,
+            resolved: resolvedOf(item),
+            steps,
+            verdict: {
+                stage: 'playable',
+                summary: ev.jellyfinConfigured
+                    ? `${item.title} is available in Jellyfin and playable.${caveat}`
+                    : `${item.title} is on disk. Nothing else to check — Jellyfin is not configured.${caveat}`,
+                certain
+            },
+            degraded: ev.degraded
+        };
+    }
+
+    const remedy = REMEDIES[blocking.stage];
+    // A download in progress is not a fault, so there is nothing to suggest.
+    const suggest = blocking.stage === 'queue' && !/stall|fail|error|paused/i.test(blocking.detail) ? undefined : remedy;
+
+    return {
+        query,
+        resolved: resolvedOf(item),
+        steps,
+        verdict: {
+            stage: blocking.stage,
+            summary: `${blocking.detail}${caveat}`,
+            ...(suggest === undefined ? {} : { remedy: suggest }),
+            certain
+        },
+        degraded: ev.degraded
+    };
+}
+
+const resolvedOf = (item: MergedItem): NonNullable<Diagnosis['resolved']> => ({
+    title: item.title,
+    ...(item.year === undefined ? {} : { year: item.year }),
+    kind: item.kind,
+    ids: item.ids
+});

--- a/src/tools/diagnose/chain.ts
+++ b/src/tools/diagnose/chain.ts
@@ -1,5 +1,5 @@
 import type { ServiceId } from '../../config/schema.ts';
-import { normaliseTitle } from '../../core/titleMatch.ts';
+import { unfenced } from '../../core/titleMatch.ts';
 import type { MergedItem } from '../../core/resolver.ts';
 import type { IndexerRejection, QueueItem, RequestStatus, ScanState } from '../../services/types.ts';
 
@@ -63,38 +63,61 @@ const DISPLAY_ORDER: readonly Stage[] = [
 
 const SKIPPED = (stage: Stage, detail: string): Step => ({ stage, status: 'skipped', detail });
 
-/**
- * Whether a release name (a queue row's title, a rejection's query) plausibly
- * refers to `item`. Built on the shared `normaliseTitle` — the fence-stripping,
- * lowercasing, leading-article rules `search_media` and the resolver already
- * use — rather than a second, divergent copy of it.
- *
- * Two failure modes this specifically guards against:
- * - **Substring matching.** "Alien" is a substring of "Aliens", and "Dune" of
- *   "Dune.Part.Two" — different films. Matching whole, normalised words
- *   closes the first; a differing year in the haystack closes the second
- *   (title match without a contradicting year is still allowed — an ambiguous
- *   release name is more useful reported than silently dropped).
- * - **A length filter that starves short titles.** "Up", "Se7en" and "Top
- *   Gun" have no word over three characters, so filtering them out (the
- *   previous approach) leaves nothing to match *anything* — every one of
- *   those titles matched no queue row or rejection, ever. All words count.
- */
-const mentions = (haystack: string, item: MergedItem): boolean => {
-    const words = normaliseTitle(item.title)
-        .split(' ')
-        .filter(w => w.length > 0);
-    if (words.length === 0) return false;
-
-    const hayWords = haystack
+/** Splits on runs of non-alphanumerics, exactly the way a release name's dots/dashes/spaces are treated — both sides of `mentions()` must tokenise identically, or a title survives round-tripping through `normaliseTitle`'s punctuation-*deletion* differently than a haystack split on the same punctuation (N3). */
+const tokenize = (value: string): string[] =>
+    value
         .toLowerCase()
         .split(/[^\p{L}\p{N}]+/u)
         .filter(w => w.length > 0);
+
+const LEADING_ARTICLE = new Set(['the', 'a', 'an']);
+
+/** Item-title tokens only: a release name legitimately keeping "The" as a word must still be able to satisfy a title that dropped it (`words` is checked as a subset of the haystack, so extra haystack tokens are harmless either way). */
+const titleWords = (item: MergedItem): string[] => {
+    const words = tokenize(unfenced(item.title));
+    return words.length > 1 && LEADING_ARTICLE.has(words[0] as string) ? words.slice(1) : words;
+};
+
+/**
+ * Whether a release name (a queue row's title, a rejection's query) plausibly
+ * refers to `item`.
+ *
+ * Three failure modes this specifically guards against:
+ * - **Substring matching.** "Alien" is a substring of "Aliens", and "Dune" of
+ *   "Dune.Part.Two" — different films. Matching whole, tokenised words closes
+ *   the first; a differing year in the haystack closes the second (title
+ *   match without a contradicting year is still allowed — an ambiguous
+ *   release name is more useful reported than silently dropped).
+ * - **A length filter that starves short titles.** "Up", "Se7en" and "Top
+ *   Gun" have no word over three characters; a filter that drops short words
+ *   (the original approach) leaves nothing to match *anything*. All words
+ *   count, however short.
+ * - **Punctuation deletion vs. punctuation splitting (N3, a round-1
+ *   regression).** `normaliseTitle` *deletes* intra-word punctuation
+ *   ("Spider-Man" → "spiderman"), while a release name is naturally *split*
+ *   on the same characters ("Spider.Man.2002" → "spider", "man", "2002").
+ *   Deleting on one side and splitting on the other means neither ever
+ *   produces the same tokens: `tokenize` splits both sides identically.
+ */
+const mentions = (haystack: string, item: MergedItem): boolean => {
+    const words = titleWords(item);
+    if (words.length === 0) return false;
+
+    const hayWords = tokenize(haystack);
     const haySet = new Set(hayWords);
     if (!words.every(w => haySet.has(w))) return false;
 
-    if (item.year !== undefined) {
-        const yearInHay = hayWords.find(w => /^(19|20)\d{2}$/.test(w));
+    // A series release's year is an episode's air year/date, not the series'
+    // start year — "The.Simpsons.S32E01.2020" is not a mismatch just because
+    // the show started in 1989 (N4). Skip the guard entirely for series.
+    if (item.kind !== 'series' && item.year !== undefined) {
+        // A token that is itself part of the title ("2049" in "Blade Runner
+        // 2049", "1917" as a whole title, "2001" in "2001: A Space Odyssey")
+        // must not be read as *the release's* year — it is already accounted
+        // for by the word match above. Only a year-shaped token that is not
+        // one of the title's own words is a candidate (N4).
+        const wordSet = new Set(words);
+        const yearInHay = hayWords.find(w => /^(19|20)\d{2}$/.test(w) && !wordSet.has(w));
         if (yearInHay !== undefined && Number(yearInHay) !== item.year) return false;
     }
 
@@ -136,37 +159,75 @@ function requestStep(ev: Evidence): Step {
  * emit: Radarr/Sonarr's queue (`queued`, `paused`, `downloading`, `completed`,
  * `failed`, `warning`, `delay`, `downloadClientUnavailable`), Transmission's
  * RPC spec, and SABnzbd's slot status, all lowercased before matching here.
+ *
+ * `seeding` / `queued to seed` (Transmission) mean the torrent itself
+ * finished — the file is fully on disk, same as Radarr/Sonarr's `completed`
+ * — so they classify as import-pending, not active (N5). `propagating`
+ * (SABnzbd, the file is being finalised/verified post-download — healthy)
+ * stays active (N6).
  */
 const QUEUE_ACTIVE = new Set([
     'downloading',
     'queued',
     'queued to verify',
     'verifying',
-    'queued to seed',
-    'seeding',
     'fetching',
     'checking',
     'extracting',
     'repairing',
     'moving',
-    'grabbing'
+    'grabbing',
+    'propagating'
 ]);
 
-type QueueClass = 'active' | 'importPending' | 'fault';
+const QUEUE_IMPORT_PENDING = new Set(['completed', 'seeding', 'queued to seed']);
 
-/** Anything not explicitly recognised as active or import-pending is a fault: that includes real faults like `failed`/`paused`/`stalled`/`warning`, and anything this module has never seen before — silence is not evidence of health. */
+type QueueClass = 'active' | 'importPending' | 'fault' | 'indeterminate';
+
+/**
+ * Anything not explicitly recognised as active or import-pending is a fault
+ * — that includes real faults like `failed`/`paused`/`stalled`/`warning`,
+ * and anything this module has never seen before — silence is not evidence
+ * of health.
+ *
+ * One exception (N6, by I5's own reasoning): the literal string `"unknown"`
+ * is not a status a download client actually reports — it is *this repo's
+ * own adapters'* fallback (`SabnzbdAdapter`'s `s.status ?? 'unknown'`,
+ * `TransmissionAdapter`'s `TORRENT_STATUS[...] ?? 'unknown'`) for a status
+ * code they could not map. That is the service answering with something
+ * this module cannot classify — `indeterminate`, not a fault, exactly as an
+ * indeterminate Seerr request status is `unknown`, not silently `ok` (I5).
+ */
 function classifyQueueStatus(item: QueueItem): QueueClass {
     if (item.errorMessage !== undefined) return 'fault';
     const status = item.status.toLowerCase();
-    if (status === 'completed') return 'importPending';
+    if (QUEUE_IMPORT_PENDING.has(status)) return 'importPending';
     if (QUEUE_ACTIVE.has(status)) return 'active';
+    if (status === 'unknown') return 'indeterminate';
     return 'fault';
+}
+
+/** Priority order when more than one row in the same queue matches the item: a fault outranks everything (something is actively broken), then an unimported completion, then genuine progress, then a row this module cannot even classify. */
+const QUEUE_CLASS_PRIORITY: readonly QueueClass[] = ['fault', 'importPending', 'active', 'indeterminate'];
+
+function pickQueueRow(mine: readonly QueueItem[]): { row: QueueItem; cls: QueueClass } {
+    for (const cls of QUEUE_CLASS_PRIORITY) {
+        const row = mine.find(q => classifyQueueStatus(q) === cls);
+        if (row !== undefined) return { row, cls };
+    }
+    // Unreachable: classifyQueueStatus always returns one of the classes
+    // above, and every call site already checked `mine.length > 0`.
+    const row = mine[0] as QueueItem;
+    return { row, cls: classifyQueueStatus(row) };
 }
 
 const QUEUE_FAULT_REMEDY =
     'Check the download client for the failed grab — retry it, remove it, or fix what it reports (e.g. connectivity to the indexer or news server), then let Radarr/Sonarr search again.';
 const QUEUE_IMPORT_REMEDY =
     'The download finished but has not been imported yet — check Radarr/Sonarr’s activity/history for why, then trigger the import manually if it did not run on its own.';
+
+/** The download-client services `queue` evidence can come from — used to fold `degraded` into "could not fully look" the same way `library`/`scan` already do (N8). */
+const QUEUE_SERVICES: readonly ServiceId[] = ['radarr', 'sonarr', 'sabnzbd', 'transmission'];
 
 type QueueResult = { step: Step; remedy?: string };
 
@@ -175,10 +236,14 @@ function queueStep(ev: Evidence, item: MergedItem): QueueResult {
     if (ev.queue === undefined) return { step: { stage: 'queue', status: 'unknown', detail: 'No download client could be reached.' } };
 
     const { items, partial } = ev.queue;
+    // A service already named in `degraded` is unreachable even if the
+    // collector's per-stage `partial` list did not separately say so (N8) —
+    // the same reachability signal `libraryStep`/`scanStep` read for Jellyfin.
+    const effectivePartial = [...new Set([...partial, ...ev.degraded.filter(s => QUEUE_SERVICES.includes(s))])];
     const mine = items.filter(q => mentions(q.title, item));
 
     if (mine.length === 0) {
-        if (partial.length > 0) {
+        if (effectivePartial.length > 0) {
             // A row for this item could be sitting on the client that failed
             // to answer — a partial read cannot rule that out, so this is
             // "could not fully look", not "looked and found nothing".
@@ -186,48 +251,63 @@ function queueStep(ev: Evidence, item: MergedItem): QueueResult {
                 step: {
                     stage: 'queue',
                     status: 'unknown',
-                    detail: `${partial.join(', ')} could not be reached, so the queue is only partially known.`
+                    detail: `${effectivePartial.join(', ')} could not be reached, so the queue is only partially known.`
                 }
             };
         }
         return { step: SKIPPED('queue', 'Nothing matching it is in any download queue.') };
     }
 
-    const fault = mine.find(q => classifyQueueStatus(q) === 'fault');
-    if (fault !== undefined) {
+    const { row, cls } = pickQueueRow(mine);
+
+    if (cls === 'fault') {
         return {
             step: {
                 stage: 'queue',
-                service: fault.service,
+                service: row.service,
                 status: 'blocked',
-                detail: `Download ${fault.status}${fault.errorMessage === undefined ? '' : `: ${fault.errorMessage}`}.`
+                detail: `Download ${row.status}${row.errorMessage === undefined ? '' : `: ${row.errorMessage}`}.`
             },
             remedy: QUEUE_FAULT_REMEDY
         };
     }
 
-    const importPending = mine.find(q => classifyQueueStatus(q) === 'importPending');
-    if (importPending !== undefined) {
+    if (cls === 'importPending') {
         return {
-            step: {
-                stage: 'queue',
-                service: importPending.service,
-                status: 'blocked',
-                detail: `Downloaded, but not yet imported by ${importPending.service}.`
-            },
+            step: { stage: 'queue', service: row.service, status: 'blocked', detail: `Downloaded, but not yet imported by ${row.service}.` },
             remedy: QUEUE_IMPORT_REMEDY
         };
     }
 
-    const active = mine[0] as QueueItem;
-    const eta = active.etaSeconds === undefined ? '' : ` — about ${Math.round(active.etaSeconds / 60)} minute(s) left`;
+    if (cls === 'indeterminate') {
+        // The row exists and mentions the item, but neither this module nor
+        // the adapter that read it knows what its status means — reported
+        // as could-not-fully-classify, not silently folded into "active"
+        // (which would claim progress this module has no basis for) or
+        // "fault" (which would claim a problem it cannot name) (N6).
+        return {
+            step: {
+                stage: 'queue',
+                service: row.service,
+                status: 'unknown',
+                detail: `${row.service} reports a status ("${row.status}") this module does not recognise.`
+            }
+        };
+    }
+
+    const eta = row.etaSeconds === undefined ? '' : ` — about ${Math.round(row.etaSeconds / 60)} minute(s) left`;
     // A download genuinely in progress is not a fault: there is nothing to
     // fix, so no remedy — see QueueResult's optional `remedy`.
-    return { step: { stage: 'queue', service: active.service, status: 'blocked', detail: `Still downloading${eta}.` } };
+    return { step: { stage: 'queue', service: row.service, status: 'blocked', detail: `Still downloading${eta}.` } };
 }
 
 function indexerStep(ev: Evidence, item: MergedItem): Step {
     if (!ev.prowlarrConfigured) return SKIPPED('indexers', 'No indexer manager is configured.');
+    if (ev.degraded.includes('prowlarr')) {
+        // Same reachability signal `libraryStep` reads for Jellyfin — closes
+        // the gap where only library/scan consulted `degraded` (N8).
+        return { stage: 'indexers', service: 'prowlarr', status: 'unknown', detail: 'Prowlarr could not be reached.' };
+    }
     if (ev.rejections === undefined) return { stage: 'indexers', service: 'prowlarr', status: 'unknown', detail: 'Prowlarr could not be reached.' };
 
     const mine = ev.rejections.filter(r => (r.query === undefined ? false : mentions(r.query, item)));
@@ -284,26 +364,49 @@ const REMEDIES: Partial<Record<Stage, string>> = {
     library: 'Trigger a Jellyfin library scan. If it still does not appear, check the path is inside a Jellyfin library and readable by it.',
     scan: 'Wait for the running scan, or start one from Jellyfin’s dashboard.'
     // `queue` is evidence-dependent (see queueStep's QueueResult) and `file`
-    // is configuration-dependent (see fileRemedy) — neither belongs in a
+    // is step-status-dependent (see fileRemedy) — neither belongs in a
     // static per-stage map.
 };
 
 /**
  * `file`'s remedy used to assert "no indexer reported a failure" and "nothing
  * is downloading" unconditionally — a claim about Prowlarr or a download
- * client even when the stack runs neither. Exactly the failure
- * `jellyfinConfigured` exists to prevent for Jellyfin, extended here.
+ * client even when the stack runs neither, *or* when it runs both but
+ * neither answered (N2: the summary's own caveat says "Could not check:
+ * queue, prowlarr" right next to a remedy asserting they were checked).
+ *
+ * `StepStatus: 'skipped'` alone cannot tell "not configured" apart from
+ * "configured, reachable, and genuinely found nothing" — `queueStep`/
+ * `indexerStep` return the same status for both, with only their `detail`
+ * text differing. So the *configured* flags decide "not configured", and
+ * `status === 'unknown'` (only reachable when configured) decides
+ * "unreachable"; only when neither applies does a service get credit for
+ * having actually been checked.
  */
-function fileRemedy(ev: Evidence): string {
+function fileRemedy(ev: Evidence, queueStatus: StepStatus, indexerStatus: StepStatus): string {
     const uncheckable: string[] = [];
     if (!ev.queueConfigured) uncheckable.push('no download client is configured');
+    else if (queueStatus === 'unknown') uncheckable.push('the download client(s) could not be fully checked');
     if (!ev.prowlarrConfigured) uncheckable.push('no indexer manager is configured');
+    else if (indexerStatus === 'unknown') uncheckable.push('Prowlarr could not be reached');
 
     if (uncheckable.length === 0) {
         return 'Trigger a search in Radarr or Sonarr — nothing is downloading and no indexer reported a failure.';
     }
     return `Trigger a search in Radarr or Sonarr (${uncheckable.join(' and ')}, so that could not be ruled out).`;
 }
+
+/**
+ * A queue row can be genuinely blocked (a fault, or a completed-but-unimported
+ * download) while `file` is still `ok` — an upgrade grab failing, say. C1
+ * correctly stops that from outranking a green chain, but going silent about
+ * a real, active failure is over-correction in the other direction (N7): it
+ * is worth a mention, just not the verdict.
+ */
+const queueAside = (queueResult: QueueResult): string =>
+    queueResult.remedy === undefined || queueResult.step.status !== 'blocked'
+        ? ''
+        : ` (Also: ${queueResult.step.detail} This does not block the file already on disk, but may be worth checking.)`;
 
 export function buildChain(query: string, ev: Evidence): Diagnosis {
     const steps: Step[] = [];
@@ -333,19 +436,25 @@ export function buildChain(query: string, ev: Evidence): Diagnosis {
     steps.push({ stage: 'resolve', status: 'ok', detail: `Identified as ${item.title}.` });
     steps.push(requestStep(ev));
 
+    // `file` is now computed whenever Radarr/Sonarr knows about the item at
+    // all, regardless of `monitored` — a file can exist on disk even when
+    // monitoring is off, and residual-C1 needs that real signal (below) to
+    // tell "not monitored, and also no file" apart from "not monitored, but
+    // it is sitting right there".
     if (acquisition === undefined) {
         steps.push({ stage: 'managed', status: 'blocked', detail: 'Neither Radarr nor Sonarr is managing it.' });
         steps.push(SKIPPED('file', 'Not reached — nothing is managing it.'));
-    } else if (!acquisition.monitored) {
-        steps.push({
-            stage: 'managed',
-            service: acquisition.service,
-            status: 'blocked',
-            detail: `${acquisition.service} has it, but it is not monitored.`
-        });
-        steps.push(SKIPPED('file', 'Not reached — it is not monitored.'));
     } else {
-        steps.push({ stage: 'managed', service: acquisition.service, status: 'ok', detail: `Monitored in ${acquisition.service}.` });
+        steps.push(
+            acquisition.monitored
+                ? { stage: 'managed', service: acquisition.service, status: 'ok', detail: `Monitored in ${acquisition.service}.` }
+                : {
+                      stage: 'managed',
+                      service: acquisition.service,
+                      status: 'blocked',
+                      detail: `${acquisition.service} has it, but it is not monitored.`
+                  }
+        );
         steps.push(
             acquisition.hasFile
                 ? { stage: 'file', service: acquisition.service, status: 'ok', detail: 'A file is on disk.' }
@@ -361,36 +470,35 @@ export function buildChain(query: string, ev: Evidence): Diagnosis {
 
     const byStage = new Map(steps.map(s => [s.stage, s]));
     const isBlocked = (s: Stage): boolean => byStage.get(s)?.status === 'blocked';
+    // A file already confirmed on disk is proof that whatever request/managed
+    // history led here already worked well enough to produce it — residual
+    // C1: an old declined/pending request, or `monitored: false`, cannot be
+    // why playback fails when the file is sitting right there. From this
+    // point on only Jellyfin's visibility of that file matters.
+    const fileIsOk = byStage.get('file')?.status === 'ok';
 
-    // The verdict walks a *tree*, not a flat list: a missing file is a
-    // symptom, and a stalled download or a dead indexer is its cause, but
-    // that reordering only applies once the file really is missing (C1 — a
-    // queue row or a rejection that merely mentions the title, while the
-    // file already sits `ok`, is context, not a verdict: a 4K upgrade
-    // in flight, or a rejection from before the film ever landed, must not
-    // outrank a green chain). Symmetrically, once the library actually is
-    // missing it, a scan already running is why, and outranks blaming the
-    // library itself (I6). `certaintyPath` mirrors exactly the stages that
-    // fed into whichever branch was taken — the ones a hole in would have
-    // been able to change this specific answer.
     let verdictStage: Stage | undefined;
     let certaintyPath: Stage[];
 
-    if (isBlocked('request')) {
+    if (!fileIsOk && isBlocked('request')) {
         verdictStage = 'request';
         certaintyPath = ['request'];
-    } else if (isBlocked('managed')) {
+    } else if (!fileIsOk && isBlocked('managed')) {
         verdictStage = 'managed';
         certaintyPath = ['request', 'managed'];
     } else if (isBlocked('file')) {
+        // A missing file is a symptom, not the cause: a stalled download or
+        // a dead indexer is (C1) — but only reached here because `file` is
+        // genuinely `blocked`, not merely mentioned by an unrelated row.
         if (isBlocked('queue')) {
+            // Checked first: a queue row is live, current evidence about an
+            // attempt happening right now, while an indexer rejection is
+            // drawn from a rolling history that can predate the grab
+            // actually stuck. When both are present, the live signal wins
+            // over the historical one.
             verdictStage = 'queue';
             certaintyPath = ['request', 'managed', 'queue'];
         } else if (isBlocked('indexers')) {
-            // queue before indexers: a queue row is live, current evidence
-            // about an attempt happening right now; an indexer rejection is
-            // drawn from a rolling history that can predate the grab that is
-            // actually stuck. When both are present, the live signal wins.
             verdictStage = 'indexers';
             certaintyPath = ['request', 'managed', 'queue', 'indexers'];
         } else {
@@ -398,17 +506,17 @@ export function buildChain(query: string, ev: Evidence): Diagnosis {
             certaintyPath = ['request', 'managed', 'queue', 'indexers', 'file'];
         }
     } else if (isBlocked('library')) {
+        // Only reachable with `fileIsOk` true — `libraryStep` can only
+        // report `blocked` when `acquisition.hasFile === true`, which is
+        // exactly `file`'s own `ok` condition. request/managed are excluded
+        // above, and correctly so: I6 (scan explains a blocked library) and
+        // N1 (an unknown scan costs certainty even when library alone would
+        // have been enough to verdict on) both apply here.
         verdictStage = isBlocked('scan') ? 'scan' : 'library';
-        certaintyPath = isBlocked('scan') ? ['request', 'managed', 'file', 'library', 'scan'] : ['request', 'managed', 'file', 'library'];
+        certaintyPath = ['file', 'library', 'scan'];
     } else {
-        // Nothing blocked: the candidate verdict is "playable". `library` is
-        // still on the path — an unreachable Jellyfin is exactly what must
-        // not be papered over by a confident "it is available in Jellyfin"
-        // (C2) — but `queue`/`indexers` are not: the file is already `ok`,
-        // so whatever is or is not reachable about the download side cannot
-        // change that.
-        verdictStage = undefined;
-        certaintyPath = ['request', 'managed', 'file', 'library'];
+        verdictStage = undefined; // playable
+        certaintyPath = fileIsOk ? ['file', 'library'] : ['request', 'managed', 'file', 'library'];
     }
 
     const unchecked = certaintyPath.filter(s => byStage.get(s)?.status === 'unknown');
@@ -417,6 +525,7 @@ export function buildChain(query: string, ev: Evidence): Diagnosis {
     const caveat = certain
         ? ''
         : ` Could not check: ${[...new Set(unchecked.map(s => byStage.get(s)?.service ?? s))].join(', ')}.`;
+    const aside = queueAside(queueResult);
 
     if (verdictStage === undefined) {
         const libStep = byStage.get('library');
@@ -426,10 +535,10 @@ export function buildChain(query: string, ev: Evidence): Diagnosis {
         // not retract an unqualified sentence sitting right next to it.
         const summary =
             libStep?.status === 'ok'
-                ? `${item.title} is available in Jellyfin and playable.${caveat}`
+                ? `${item.title} is available in Jellyfin and playable.${caveat}${aside}`
                 : libStep?.status === 'unknown'
-                  ? `${item.title} has a file, but Jellyfin could not be reached to confirm it is visible there.${caveat}`
-                  : `${item.title} is on disk. Nothing else to check — Jellyfin is not configured.${caveat}`;
+                  ? `${item.title} has a file, but Jellyfin could not be reached to confirm it is visible there.${caveat}${aside}`
+                  : `${item.title} is on disk. Nothing else to check — Jellyfin is not configured.${caveat}${aside}`;
 
         return {
             query,
@@ -441,7 +550,16 @@ export function buildChain(query: string, ev: Evidence): Diagnosis {
     }
 
     const blocking = byStage.get(verdictStage) as Step;
-    const remedy = blocking.stage === 'queue' ? queueResult.remedy : blocking.stage === 'file' ? fileRemedy(ev) : REMEDIES[blocking.stage];
+    const remedy =
+        blocking.stage === 'queue'
+            ? queueResult.remedy
+            : blocking.stage === 'file'
+              ? fileRemedy(ev, byStage.get('queue')?.status ?? 'unknown', byStage.get('indexers')?.status ?? 'unknown')
+              : REMEDIES[blocking.stage];
+    // The verdict's own stage is never also the aside (it is already the
+    // headline), so `aside` only ever adds information here for a
+    // non-queue verdict — same guard as the playable branch above.
+    const summaryAside = blocking.stage === 'queue' ? '' : aside;
 
     return {
         query,
@@ -449,7 +567,7 @@ export function buildChain(query: string, ev: Evidence): Diagnosis {
         steps,
         verdict: {
             stage: blocking.stage,
-            summary: `${blocking.detail}${caveat}`,
+            summary: `${blocking.detail}${caveat}${summaryAside}`,
             ...(remedy === undefined ? {} : { remedy }),
             certain
         },

--- a/src/tools/diagnose/chain.ts
+++ b/src/tools/diagnose/chain.ts
@@ -1,4 +1,5 @@
 import type { ServiceId } from '../../config/schema.ts';
+import { normaliseTitle } from '../../core/titleMatch.ts';
 import type { MergedItem } from '../../core/resolver.ts';
 import type { IndexerRejection, QueueItem, RequestStatus, ScanState } from '../../services/types.ts';
 
@@ -16,8 +17,20 @@ export type Step = { stage: Stage; service?: ServiceId; status: StepStatus; deta
 export type Evidence = {
     item: MergedItem | undefined;
     request: { status: RequestStatus | 'unknown' } | null | undefined;
-    queue: QueueItem[] | undefined;
+    /**
+     * A multi-service stage: `items` is whatever the collector actually read
+     * (from however many of Radarr/Sonarr/SABnzbd/Transmission answered),
+     * `partial` names the ones that didn't. A single unreachable client used
+     * to erase the whole stage to `undefined`, discarding rows another
+     * client *did* return — including the stalled row that was the actual
+     * cause. `undefined` still means every configured client failed.
+     */
+    queue: { items: QueueItem[]; partial: ServiceId[] } | undefined;
+    /** Analogue of `jellyfinConfigured`, below: no download client at all, not merely unreachable. */
+    queueConfigured: boolean;
     rejections: IndexerRejection[] | undefined;
+    /** Analogue of `jellyfinConfigured`: no Prowlarr configured, not merely unreachable. */
+    prowlarrConfigured: boolean;
     scan: ScanState | undefined;
     /**
      * A third state beyond looked/could-not-look: **never configured**. Without
@@ -48,38 +61,44 @@ const DISPLAY_ORDER: readonly Stage[] = [
     'scan'
 ];
 
-/**
- * The verdict is chosen in a *different* order, and the difference is the one
- * judgement call in this module: **a missing file is a symptom, and a stalled
- * download or a dead indexer is its cause**. Answering "it has no file" when
- * the real answer is "your news server is refusing connections" is technically
- * true and useless.
- */
-const VERDICT_ORDER: readonly Stage[] = [
-    'resolve',
-    'request',
-    'managed',
-    'queue',
-    'indexers',
-    'file',
-    'library',
-    'scan'
-];
-
 const SKIPPED = (stage: Stage, detail: string): Step => ({ stage, status: 'skipped', detail });
 
-/** Words a title and a release name are likely to share, after normalisation. */
+/**
+ * Whether a release name (a queue row's title, a rejection's query) plausibly
+ * refers to `item`. Built on the shared `normaliseTitle` — the fence-stripping,
+ * lowercasing, leading-article rules `search_media` and the resolver already
+ * use — rather than a second, divergent copy of it.
+ *
+ * Two failure modes this specifically guards against:
+ * - **Substring matching.** "Alien" is a substring of "Aliens", and "Dune" of
+ *   "Dune.Part.Two" — different films. Matching whole, normalised words
+ *   closes the first; a differing year in the haystack closes the second
+ *   (title match without a contradicting year is still allowed — an ambiguous
+ *   release name is more useful reported than silently dropped).
+ * - **A length filter that starves short titles.** "Up", "Se7en" and "Top
+ *   Gun" have no word over three characters, so filtering them out (the
+ *   previous approach) leaves nothing to match *anything* — every one of
+ *   those titles matched no queue row or rejection, ever. All words count.
+ */
 const mentions = (haystack: string, item: MergedItem): boolean => {
-    const words = item.title
-        .replace(/^<<untrusted:[^>]*>>/, '')
-        .replace(/<<\/untrusted>>$/, '')
-        .toLowerCase()
-        .split(/[^\p{L}\p{N}]+/u)
-        .filter(w => w.length > 3);
+    const words = normaliseTitle(item.title)
+        .split(' ')
+        .filter(w => w.length > 0);
     if (words.length === 0) return false;
 
-    const hay = haystack.toLowerCase();
-    return words.every(w => hay.includes(w));
+    const hayWords = haystack
+        .toLowerCase()
+        .split(/[^\p{L}\p{N}]+/u)
+        .filter(w => w.length > 0);
+    const haySet = new Set(hayWords);
+    if (!words.every(w => haySet.has(w))) return false;
+
+    if (item.year !== undefined) {
+        const yearInHay = hayWords.find(w => /^(19|20)\d{2}$/.test(w));
+        if (yearInHay !== undefined && Number(yearInHay) !== item.year) return false;
+    }
+
+    return true;
 };
 
 function requestStep(ev: Evidence): Step {
@@ -92,31 +111,123 @@ function requestStep(ev: Evidence): Step {
     if (ev.request.status === 'pending') {
         return { stage: 'request', service: 'seerr', status: 'blocked', detail: 'The request is still awaiting approval.' };
     }
+    if (ev.request.status === 'unknown') {
+        // Seerr answered, but not with a status this module recognises as a
+        // success — e.g. Overseerr's own FAILED. Reporting that as `ok`
+        // ("The request is unknown.") would be green on a request that never
+        // went anywhere.
+        return {
+            stage: 'request',
+            service: 'seerr',
+            status: 'blocked',
+            detail: 'Seerr reports the request in an indeterminate state — it may have failed to submit.'
+        };
+    }
     return { stage: 'request', service: 'seerr', status: 'ok', detail: `The request is ${ev.request.status}.` };
 }
 
-function queueStep(ev: Evidence, item: MergedItem): Step {
-    if (ev.queue === undefined) return { stage: 'queue', status: 'unknown', detail: 'No download client could be reached.' };
+/**
+ * Explicit, not a regex over free text: `/stall|fail|error|paused/i` reads
+ * `completed` — a download waiting on Radarr/Sonarr to import it, which *is*
+ * the broken import this phase exists to surface — as "still downloading",
+ * because the word "complete" contains none of those substrings. It misreads
+ * `downloadClientUnavailable`, and Radarr/Sonarr's own `warning`/`delay`, the
+ * same way. Status vocabulary is collected from what the adapters actually
+ * emit: Radarr/Sonarr's queue (`queued`, `paused`, `downloading`, `completed`,
+ * `failed`, `warning`, `delay`, `downloadClientUnavailable`), Transmission's
+ * RPC spec, and SABnzbd's slot status, all lowercased before matching here.
+ */
+const QUEUE_ACTIVE = new Set([
+    'downloading',
+    'queued',
+    'queued to verify',
+    'verifying',
+    'queued to seed',
+    'seeding',
+    'fetching',
+    'checking',
+    'extracting',
+    'repairing',
+    'moving',
+    'grabbing'
+]);
 
-    const mine = ev.queue.filter(q => mentions(q.title, item));
-    if (mine.length === 0) return SKIPPED('queue', 'Nothing matching it is in any download queue.');
+type QueueClass = 'active' | 'importPending' | 'fault';
 
-    const failed = mine.find(q => q.errorMessage !== undefined || /stall|fail|error|paused/i.test(q.status));
-    if (failed !== undefined) {
+/** Anything not explicitly recognised as active or import-pending is a fault: that includes real faults like `failed`/`paused`/`stalled`/`warning`, and anything this module has never seen before — silence is not evidence of health. */
+function classifyQueueStatus(item: QueueItem): QueueClass {
+    if (item.errorMessage !== undefined) return 'fault';
+    const status = item.status.toLowerCase();
+    if (status === 'completed') return 'importPending';
+    if (QUEUE_ACTIVE.has(status)) return 'active';
+    return 'fault';
+}
+
+const QUEUE_FAULT_REMEDY =
+    'Check the download client for the failed grab — retry it, remove it, or fix what it reports (e.g. connectivity to the indexer or news server), then let Radarr/Sonarr search again.';
+const QUEUE_IMPORT_REMEDY =
+    'The download finished but has not been imported yet — check Radarr/Sonarr’s activity/history for why, then trigger the import manually if it did not run on its own.';
+
+type QueueResult = { step: Step; remedy?: string };
+
+function queueStep(ev: Evidence, item: MergedItem): QueueResult {
+    if (!ev.queueConfigured) return { step: SKIPPED('queue', 'No download client is configured.') };
+    if (ev.queue === undefined) return { step: { stage: 'queue', status: 'unknown', detail: 'No download client could be reached.' } };
+
+    const { items, partial } = ev.queue;
+    const mine = items.filter(q => mentions(q.title, item));
+
+    if (mine.length === 0) {
+        if (partial.length > 0) {
+            // A row for this item could be sitting on the client that failed
+            // to answer — a partial read cannot rule that out, so this is
+            // "could not fully look", not "looked and found nothing".
+            return {
+                step: {
+                    stage: 'queue',
+                    status: 'unknown',
+                    detail: `${partial.join(', ')} could not be reached, so the queue is only partially known.`
+                }
+            };
+        }
+        return { step: SKIPPED('queue', 'Nothing matching it is in any download queue.') };
+    }
+
+    const fault = mine.find(q => classifyQueueStatus(q) === 'fault');
+    if (fault !== undefined) {
         return {
-            stage: 'queue',
-            service: failed.service,
-            status: 'blocked',
-            detail: `Download ${failed.status}${failed.errorMessage === undefined ? '' : `: ${failed.errorMessage}`}.`
+            step: {
+                stage: 'queue',
+                service: fault.service,
+                status: 'blocked',
+                detail: `Download ${fault.status}${fault.errorMessage === undefined ? '' : `: ${fault.errorMessage}`}.`
+            },
+            remedy: QUEUE_FAULT_REMEDY
+        };
+    }
+
+    const importPending = mine.find(q => classifyQueueStatus(q) === 'importPending');
+    if (importPending !== undefined) {
+        return {
+            step: {
+                stage: 'queue',
+                service: importPending.service,
+                status: 'blocked',
+                detail: `Downloaded, but not yet imported by ${importPending.service}.`
+            },
+            remedy: QUEUE_IMPORT_REMEDY
         };
     }
 
     const active = mine[0] as QueueItem;
     const eta = active.etaSeconds === undefined ? '' : ` — about ${Math.round(active.etaSeconds / 60)} minute(s) left`;
-    return { stage: 'queue', service: active.service, status: 'blocked', detail: `Still downloading${eta}.` };
+    // A download genuinely in progress is not a fault: there is nothing to
+    // fix, so no remedy — see QueueResult's optional `remedy`.
+    return { step: { stage: 'queue', service: active.service, status: 'blocked', detail: `Still downloading${eta}.` } };
 }
 
 function indexerStep(ev: Evidence, item: MergedItem): Step {
+    if (!ev.prowlarrConfigured) return SKIPPED('indexers', 'No indexer manager is configured.');
     if (ev.rejections === undefined) return { stage: 'indexers', service: 'prowlarr', status: 'unknown', detail: 'Prowlarr could not be reached.' };
 
     const mine = ev.rejections.filter(r => (r.query === undefined ? false : mentions(r.query, item)));
@@ -153,6 +264,12 @@ function libraryStep(ev: Evidence, item: MergedItem): Step {
 
 function scanStep(ev: Evidence): Step {
     if (!ev.jellyfinConfigured) return SKIPPED('scan', 'Jellyfin is not configured.');
+    if (ev.degraded.includes('jellyfin')) {
+        // Same reachability signal `libraryStep` reads — a Jellyfin that could
+        // not be asked about its library could not be asked about its scan
+        // state either, and the two should not be able to disagree about that.
+        return { stage: 'scan', service: 'jellyfin', status: 'unknown', detail: 'Jellyfin could not be reached, so its scan state was not checked.' };
+    }
     if (ev.scan === undefined) return { stage: 'scan', service: 'jellyfin', status: 'unknown', detail: 'Jellyfin’s scan state could not be read.' };
     if (ev.scan.running === true) return { stage: 'scan', service: 'jellyfin', status: 'blocked', detail: 'A library scan is running now — check again once it finishes.' };
     if (ev.scan.lastCompleted === undefined) return { stage: 'scan', service: 'jellyfin', status: 'unknown', detail: 'Jellyfin reports no completed library scan.' };
@@ -163,11 +280,30 @@ const REMEDIES: Partial<Record<Stage, string>> = {
     resolve: 'Try search_media — it also looks at what you do not have yet — or request it through Seerr.',
     request: 'Approve or re-submit the request in Seerr.',
     managed: 'Add it to Radarr or Sonarr, or turn monitoring on for it.',
-    file: 'Trigger a search in Radarr or Sonarr — nothing is downloading and no indexer reported a failure.',
     indexers: 'Check the indexer in Prowlarr; get_indexers shows its recent failures.',
     library: 'Trigger a Jellyfin library scan. If it still does not appear, check the path is inside a Jellyfin library and readable by it.',
     scan: 'Wait for the running scan, or start one from Jellyfin’s dashboard.'
+    // `queue` is evidence-dependent (see queueStep's QueueResult) and `file`
+    // is configuration-dependent (see fileRemedy) — neither belongs in a
+    // static per-stage map.
 };
+
+/**
+ * `file`'s remedy used to assert "no indexer reported a failure" and "nothing
+ * is downloading" unconditionally — a claim about Prowlarr or a download
+ * client even when the stack runs neither. Exactly the failure
+ * `jellyfinConfigured` exists to prevent for Jellyfin, extended here.
+ */
+function fileRemedy(ev: Evidence): string {
+    const uncheckable: string[] = [];
+    if (!ev.queueConfigured) uncheckable.push('no download client is configured');
+    if (!ev.prowlarrConfigured) uncheckable.push('no indexer manager is configured');
+
+    if (uncheckable.length === 0) {
+        return 'Trigger a search in Radarr or Sonarr — nothing is downloading and no indexer reported a failure.';
+    }
+    return `Trigger a search in Radarr or Sonarr (${uncheckable.join(' and ')}, so that could not be ruled out).`;
+}
 
 export function buildChain(query: string, ev: Evidence): Diagnosis {
     const steps: Step[] = [];
@@ -217,44 +353,95 @@ export function buildChain(query: string, ev: Evidence): Diagnosis {
         );
     }
 
-    steps.push(queueStep(ev, item));
+    const queueResult = queueStep(ev, item);
+    steps.push(queueResult.step);
     steps.push(indexerStep(ev, item));
     steps.push(libraryStep(ev, item));
     steps.push(scanStep(ev));
 
     const byStage = new Map(steps.map(s => [s.stage, s]));
-    const verdictStage = VERDICT_ORDER.find(s => byStage.get(s)?.status === 'blocked');
-    const blocking = verdictStage === undefined ? undefined : (byStage.get(verdictStage) as Step);
+    const isBlocked = (s: Stage): boolean => byStage.get(s)?.status === 'blocked';
 
-    // Any stage that could not be checked *before* the verdict leaves a hole
-    // the verdict reads across. Stages after it cannot change the answer.
-    const cutoff = verdictStage === undefined ? DISPLAY_ORDER.length : VERDICT_ORDER.indexOf(verdictStage);
-    const unchecked = VERDICT_ORDER.slice(0, cutoff).filter(s => byStage.get(s)?.status === 'unknown');
+    // The verdict walks a *tree*, not a flat list: a missing file is a
+    // symptom, and a stalled download or a dead indexer is its cause, but
+    // that reordering only applies once the file really is missing (C1 — a
+    // queue row or a rejection that merely mentions the title, while the
+    // file already sits `ok`, is context, not a verdict: a 4K upgrade
+    // in flight, or a rejection from before the film ever landed, must not
+    // outrank a green chain). Symmetrically, once the library actually is
+    // missing it, a scan already running is why, and outranks blaming the
+    // library itself (I6). `certaintyPath` mirrors exactly the stages that
+    // fed into whichever branch was taken — the ones a hole in would have
+    // been able to change this specific answer.
+    let verdictStage: Stage | undefined;
+    let certaintyPath: Stage[];
+
+    if (isBlocked('request')) {
+        verdictStage = 'request';
+        certaintyPath = ['request'];
+    } else if (isBlocked('managed')) {
+        verdictStage = 'managed';
+        certaintyPath = ['request', 'managed'];
+    } else if (isBlocked('file')) {
+        if (isBlocked('queue')) {
+            verdictStage = 'queue';
+            certaintyPath = ['request', 'managed', 'queue'];
+        } else if (isBlocked('indexers')) {
+            // queue before indexers: a queue row is live, current evidence
+            // about an attempt happening right now; an indexer rejection is
+            // drawn from a rolling history that can predate the grab that is
+            // actually stuck. When both are present, the live signal wins.
+            verdictStage = 'indexers';
+            certaintyPath = ['request', 'managed', 'queue', 'indexers'];
+        } else {
+            verdictStage = 'file';
+            certaintyPath = ['request', 'managed', 'queue', 'indexers', 'file'];
+        }
+    } else if (isBlocked('library')) {
+        verdictStage = isBlocked('scan') ? 'scan' : 'library';
+        certaintyPath = isBlocked('scan') ? ['request', 'managed', 'file', 'library', 'scan'] : ['request', 'managed', 'file', 'library'];
+    } else {
+        // Nothing blocked: the candidate verdict is "playable". `library` is
+        // still on the path — an unreachable Jellyfin is exactly what must
+        // not be papered over by a confident "it is available in Jellyfin"
+        // (C2) — but `queue`/`indexers` are not: the file is already `ok`,
+        // so whatever is or is not reachable about the download side cannot
+        // change that.
+        verdictStage = undefined;
+        certaintyPath = ['request', 'managed', 'file', 'library'];
+    }
+
+    const unchecked = certaintyPath.filter(s => byStage.get(s)?.status === 'unknown');
     const certain = unchecked.length === 0;
 
     const caveat = certain
         ? ''
         : ` Could not check: ${[...new Set(unchecked.map(s => byStage.get(s)?.service ?? s))].join(', ')}.`;
 
-    if (blocking === undefined) {
+    if (verdictStage === undefined) {
+        const libStep = byStage.get('library');
+        // The positive claim "is available in Jellyfin and playable" is only
+        // honest when `library` itself said `ok` — read the step, not just
+        // whether Jellyfin is configured (C2): `certain: false` alone does
+        // not retract an unqualified sentence sitting right next to it.
+        const summary =
+            libStep?.status === 'ok'
+                ? `${item.title} is available in Jellyfin and playable.${caveat}`
+                : libStep?.status === 'unknown'
+                  ? `${item.title} has a file, but Jellyfin could not be reached to confirm it is visible there.${caveat}`
+                  : `${item.title} is on disk. Nothing else to check — Jellyfin is not configured.${caveat}`;
+
         return {
             query,
             resolved: resolvedOf(item),
             steps,
-            verdict: {
-                stage: 'playable',
-                summary: ev.jellyfinConfigured
-                    ? `${item.title} is available in Jellyfin and playable.${caveat}`
-                    : `${item.title} is on disk. Nothing else to check — Jellyfin is not configured.${caveat}`,
-                certain
-            },
+            verdict: { stage: 'playable', summary, certain },
             degraded: ev.degraded
         };
     }
 
-    const remedy = REMEDIES[blocking.stage];
-    // A download in progress is not a fault, so there is nothing to suggest.
-    const suggest = blocking.stage === 'queue' && !/stall|fail|error|paused/i.test(blocking.detail) ? undefined : remedy;
+    const blocking = byStage.get(verdictStage) as Step;
+    const remedy = blocking.stage === 'queue' ? queueResult.remedy : blocking.stage === 'file' ? fileRemedy(ev) : REMEDIES[blocking.stage];
 
     return {
         query,
@@ -263,7 +450,7 @@ export function buildChain(query: string, ev: Evidence): Diagnosis {
         verdict: {
             stage: blocking.stage,
             summary: `${blocking.detail}${caveat}`,
-            ...(suggest === undefined ? {} : { remedy: suggest }),
+            ...(remedy === undefined ? {} : { remedy }),
             certain
         },
         degraded: ev.degraded

--- a/test/diagnoseChain.test.ts
+++ b/test/diagnoseChain.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { fenceText } from '../src/core/fence.ts';
 import type { MergedItem } from '../src/core/resolver.ts';
 import { buildChain, type Evidence } from '../src/tools/diagnose/chain.ts';
 
@@ -11,10 +12,12 @@ import { buildChain, type Evidence } from '../src/tools/diagnose/chain.ts';
  */
 type ItemOverride = { [K in keyof MergedItem]?: MergedItem[K] | undefined };
 
+const fence = (title: string): string => fenceText(title, { service: 'radarr', field: 'title' });
+
 const item = (over: ItemOverride = {}): MergedItem => {
     const merged: Record<string, unknown> = {
         kind: 'movie',
-        title: '<<untrusted:radarr.title>>Some Film<</untrusted>>',
+        title: fence('Some Film'),
         year: 2026,
         ids: { tmdb: 550 },
         acquisition: { service: 'radarr', monitored: true, hasFile: true },
@@ -35,8 +38,10 @@ const item = (over: ItemOverride = {}): MergedItem => {
 const healthy = (over: Partial<Evidence> = {}): Evidence => ({
     item: item(),
     request: null,
-    queue: [],
+    queue: { items: [], partial: [] },
+    queueConfigured: true,
     rejections: [],
+    prowlarrConfigured: true,
     scan: { service: 'jellyfin', lastCompleted: '2026-08-05T02:00:00Z' },
     jellyfinConfigured: true,
     degraded: [],
@@ -104,6 +109,19 @@ describe('buildChain — each stage blocking in isolation', () => {
         expect(d.verdict.remedy).toMatch(/approve/i);
     });
 
+    it('reports an indeterminate Seerr status as blocking, never as ok', () => {
+        // I5: Overseerr's own FAILED (and anything else the adapter cannot
+        // map to pending/approved/declined) comes through as 'unknown'. That
+        // must not fall through to "The request is unknown." reported `ok`.
+        const d = buildChain('some film', {
+            ...healthy(),
+            item: item({ acquisition: undefined, presence: 'jellyfin_only' }),
+            request: { status: 'unknown' }
+        });
+        expect(d.verdict.stage).toBe('request');
+        expect(stepFor(d, 'request')?.status).toBe('blocked');
+    });
+
     it('stops at managed when nothing is managing it', () => {
         const d = buildChain('some film', {
             ...healthy(),
@@ -140,13 +158,18 @@ describe('buildChain — each stage blocking in isolation', () => {
         expect(d.verdict.summary).toMatch(/Jellyfin/);
     });
 
-    it('blames the scan when the library is missing it and no scan has run since', () => {
+    it('blames the scan, not the library, when a scan is running and the library is missing it', () => {
+        // I6: the same symptom-vs-cause argument applied to queue/file below
+        // applies here — a scan already running *is why* the library does not
+        // show it yet, and outranks blaming the library stage itself.
         const d = buildChain('some film', {
             ...healthy(),
             item: item({ presence: 'arr_only', playback: undefined }),
             scan: { service: 'jellyfin', running: true }
         });
-        expect(stepFor(d, 'scan')?.detail).toMatch(/running/i);
+        expect(d.verdict.stage).toBe('scan');
+        expect(d.verdict.summary).toMatch(/running/i);
+        expect(stepFor(d, 'library')?.status).toBe('blocked');
     });
 });
 
@@ -157,31 +180,69 @@ describe('buildChain — a symptom never outranks its cause', () => {
         const d = buildChain('some film', {
             ...healthy(),
             item: noFile,
-            queue: [
-                {
-                    service: 'sabnzbd',
-                    id: '1',
-                    title: 'Some.Film.2026',
-                    status: 'stalled',
-                    errorMessage: 'no connection to news server'
-                }
-            ]
+            queue: {
+                items: [
+                    {
+                        service: 'sabnzbd',
+                        id: '1',
+                        title: 'Some.Film.2026',
+                        status: 'stalled',
+                        errorMessage: 'no connection to news server'
+                    }
+                ],
+                partial: []
+            }
         });
         expect(d.verdict.stage).toBe('queue');
         expect(d.verdict.summary).toMatch(/stalled|news server/i);
+        // I1: a stalled download is the single most actionable failure in the
+        // whole chain — it must never be the one case with no remedy.
+        expect(d.verdict.remedy).toMatch(/download client|retry|remove/i);
     });
 
     it('reports an active download as the explanation, with what it is waiting on', () => {
         const d = buildChain('some film', {
             ...healthy(),
             item: noFile,
-            queue: [{ service: 'radarr', id: '1', title: 'Some.Film.2026', status: 'downloading', etaSeconds: 600 }]
+            queue: { items: [{ service: 'radarr', id: '1', title: 'Some.Film.2026', status: 'downloading', etaSeconds: 600 }], partial: [] }
         });
         expect(d.verdict.stage).toBe('queue');
         expect(d.verdict.summary).toMatch(/downloading/i);
         // Downloading is not a fault: nothing to fix, so nothing to suggest.
+        // (I1: this must fail if the "no remedy for downloading" rule is
+        // deleted — it does, because REMEDIES no longer has a static `queue`
+        // entry for `remedy` to fall back to.)
         expect(d.verdict.remedy).toBeUndefined();
     });
+
+    it('treats a completed-but-unimported download as its own kind of block, not "still downloading"', () => {
+        // I2: `completed` is Radarr/Sonarr's status for a download waiting on
+        // import — the broken import itself, most of the time. A regex over
+        // stall/fail/error/paused reads "complete" as none of those and
+        // reports "Still downloading.", which is actively misleading.
+        const d = buildChain('some film', {
+            ...healthy(),
+            item: noFile,
+            queue: { items: [{ service: 'radarr', id: '1', title: 'Some.Film.2026', status: 'completed' }], partial: [] }
+        });
+        expect(d.verdict.stage).toBe('queue');
+        expect(d.verdict.summary).not.toMatch(/still downloading/i);
+        expect(d.verdict.summary).toMatch(/import/i);
+        expect(d.verdict.remedy).toMatch(/import/i);
+    });
+
+    it.each(['downloadClientUnavailable', 'warning', 'delay'])(
+        'classifies Radarr/Sonarr queue status %s as a fault, not "still downloading"',
+        status => {
+            const d = buildChain('some film', {
+                ...healthy(),
+                item: noFile,
+                queue: { items: [{ service: 'radarr', id: '1', title: 'Some.Film.2026', status }], partial: [] }
+            });
+            expect(d.verdict.stage).toBe('queue');
+            expect(d.verdict.summary).not.toMatch(/still downloading/i);
+        }
+    );
 
     it('blames a failing indexer when nothing is downloading', () => {
         const d = buildChain('some film', {
@@ -196,28 +257,122 @@ describe('buildChain — a symptom never outranks its cause', () => {
         const d = buildChain('some film', {
             ...healthy(),
             item: noFile,
-            queue: [{ service: 'radarr', id: '1', title: 'Some.Film.2026', status: 'downloading' }]
+            queue: { items: [{ service: 'radarr', id: '1', title: 'Some.Film.2026', status: 'downloading' }], partial: [] }
         });
         expect(stepFor(d, 'file')?.status).toBe('blocked');
     });
 });
 
+describe('buildChain — a symptom does not outrank a chain that is not actually broken (C1)', () => {
+    it('does not let an unrelated queue row (a quality upgrade in flight) outrank a file already on disk', () => {
+        const d = buildChain('some film', {
+            ...healthy(),
+            // item() defaults to hasFile: true.
+            queue: { items: [{ service: 'radarr', id: '1', title: 'Some.Film.2026', status: 'downloading', etaSeconds: 600 }], partial: [] }
+        });
+        expect(d.verdict).toMatchObject({ stage: 'playable', certain: true });
+    });
+
+    it('does not let a stale indexer rejection outrank a file already on disk', () => {
+        const d = buildChain('some film', {
+            ...healthy(),
+            rejections: [{ indexer: 'Indexer 1', at: '2020-01-01T00:00:00Z', reason: 'query failed', query: 'Some Film' }]
+        });
+        expect(d.verdict).toMatchObject({ stage: 'playable', certain: true });
+    });
+
+    it('does not let a running scan outrank a library that already has it', () => {
+        const d = buildChain('some film', { ...healthy(), scan: { service: 'jellyfin', running: true } });
+        expect(d.verdict).toMatchObject({ stage: 'playable', certain: true });
+    });
+});
+
+describe('buildChain — title matching (I3)', () => {
+    const noFileFor = (title: string, year: number): MergedItem =>
+        item({ title: fence(title), year, acquisition: { service: 'radarr', monitored: true, hasFile: false } });
+
+    const shortTitleCases: Array<[title: string, year: number, release: string]> = [
+        ['Up', 2009, 'Up.2009.1080p.BluRay'],
+        ['Top Gun', 1986, 'Top.Gun.1986.720p'],
+        ['Se7en', 1995, 'Se7en.1995.1080p']
+    ];
+
+    it.each(shortTitleCases)('matches a short title (%s) that a >3-character word filter would starve', (title, year, release) => {
+        const d = buildChain(title, {
+            ...healthy(),
+            item: noFileFor(title, year),
+            queue: { items: [{ service: 'radarr', id: '1', title: release, status: 'downloading' }], partial: [] }
+        });
+        expect(d.verdict.stage).toBe('queue');
+    });
+
+    it('does not match a different film in the same franchise when the years disagree', () => {
+        const d = buildChain('dune', {
+            ...healthy(),
+            item: noFileFor('Dune', 2021),
+            queue: { items: [{ service: 'radarr', id: '1', title: 'Dune.Part.Two.2024.1080p', status: 'downloading' }], partial: [] }
+        });
+        // The queue row is correctly ignored as unrelated, so nothing
+        // explains the missing file, and the verdict falls through to it.
+        expect(d.verdict.stage).toBe('file');
+    });
+
+    it('does not match a pluralised sibling title', () => {
+        const d = buildChain('alien', {
+            ...healthy(),
+            item: noFileFor('Alien', 1979),
+            queue: { items: [{ service: 'radarr', id: '1', title: 'Aliens.1986.1080p', status: 'downloading' }], partial: [] }
+        });
+        expect(d.verdict.stage).toBe('file');
+    });
+
+    it('does not match an unrelated title sharing only a common word', () => {
+        const d = buildChain('toy story', {
+            ...healthy(),
+            item: noFileFor('Toy Story', 1995),
+            queue: { items: [{ service: 'radarr', id: '1', title: 'American.Horror.Story.S01E01', status: 'downloading' }], partial: [] }
+        });
+        expect(d.verdict.stage).toBe('file');
+    });
+});
+
 describe('buildChain — certainty', () => {
     it('is uncertain when a stage before the verdict could not be checked', () => {
-        // §6.1: with Jellyfin unreachable, diagnose must not report "it is not
-        // in Jellyfin". It reports that it could not look.
+        // A real, blocked verdict (library) with an earlier stage on its
+        // certainty path (request) unreachable — the mechanism this test
+        // name describes, exercised against an actual blocking stage rather
+        // than the no-verdict/playable path (see the dedicated test below).
         const d = buildChain('some film', {
             item: item({ presence: 'arr_only', playback: undefined }),
-            request: null,
-            queue: [],
-            rejections: undefined,
-            scan: undefined,
+            request: undefined,
+            queue: { items: [], partial: [] },
+            queueConfigured: true,
+            rejections: [],
+            prowlarrConfigured: true,
+            scan: { service: 'jellyfin', lastCompleted: '2026-08-05T02:00:00Z' },
             jellyfinConfigured: true,
-            degraded: ['jellyfin', 'prowlarr']
+            degraded: ['seerr']
         });
 
+        expect(d.verdict.stage).toBe('library');
         expect(d.verdict.certain).toBe(false);
-        expect(d.verdict.summary).toMatch(/could not check|prowlarr/i);
+        expect(d.verdict.summary).toMatch(/could not check|seerr/i);
+    });
+
+    it('is uncertain about a playable verdict, and hedges the claim rather than asserting Jellyfin availability (C2)', () => {
+        // §6.1 / C2: certain: false must not just ride along under an
+        // unqualified positive claim. Reproduced with the shape review found
+        // it with: library unreachable, presence arr_only.
+        const d = buildChain('some film', {
+            ...healthy(),
+            item: item({ presence: 'arr_only', playback: undefined }),
+            degraded: ['jellyfin']
+        });
+
+        expect(d.verdict.stage).toBe('playable');
+        expect(d.verdict.certain).toBe(false);
+        expect(d.verdict.summary).not.toMatch(/is available in jellyfin/i);
+        expect(d.verdict.summary).toMatch(/could not|jellyfin/i);
     });
 
     it('names the services it could not reach', () => {
@@ -238,6 +393,19 @@ describe('buildChain — certainty', () => {
         expect(d.verdict.certain).toBe(true);
     });
 
+    it('stays certain about a missing-file verdict when only the library side is unreachable', () => {
+        // Symmetric with the case above, one branch over: the verdict is
+        // "nothing downloading, no indexer failure" (file). Jellyfin being
+        // unreachable is downstream of that answer, not upstream of it.
+        const d = buildChain('some film', {
+            ...healthy(),
+            item: item({ acquisition: { service: 'radarr', monitored: true, hasFile: false } }),
+            degraded: ['jellyfin']
+        });
+        expect(d.verdict.stage).toBe('file');
+        expect(d.verdict.certain).toBe(true);
+    });
+
     it('never claims playable while a stage is unknown', () => {
         const d = buildChain('some film', { ...healthy(), scan: undefined, degraded: ['jellyfin'] });
         if (d.verdict.stage === 'playable') expect(d.verdict.certain).toBe(false);
@@ -248,13 +416,71 @@ describe('buildChain — certainty', () => {
         const d = buildChain('some film', {
             item: undefined,
             request: null,
-            queue: [],
+            queue: { items: [], partial: [] },
+            queueConfigured: true,
             rejections: [],
+            prowlarrConfigured: true,
             scan: undefined,
             jellyfinConfigured: true,
             degraded: ['radarr']
         });
         expect(d.verdict).toMatchObject({ stage: 'resolve', certain: false });
+    });
+});
+
+describe('buildChain — verdict order is pinned, not incidental (I7)', () => {
+    it('request outranks managed when both are blocked', () => {
+        const d = buildChain('some film', {
+            ...healthy(),
+            item: item({ acquisition: undefined, presence: 'jellyfin_only' }),
+            request: { status: 'declined' }
+        });
+        expect(d.verdict.stage).toBe('request');
+    });
+
+    it('managed outranks the queue/file group when both are blocked', () => {
+        const d = buildChain('some film', {
+            ...healthy(),
+            item: item({ acquisition: undefined, presence: 'jellyfin_only' }),
+            queue: { items: [{ service: 'sabnzbd', id: '1', title: 'Some.Film.2026', status: 'downloading' }], partial: [] }
+        });
+        expect(d.verdict.stage).toBe('managed');
+    });
+
+    it('queue outranks indexers when both are blocked: a live queue row is current, a rejection is historical', () => {
+        const d = buildChain('some film', {
+            ...healthy(),
+            item: item({ acquisition: { service: 'radarr', monitored: true, hasFile: false } }),
+            queue: { items: [{ service: 'sabnzbd', id: '1', title: 'Some.Film.2026', status: 'stalled', errorMessage: 'x' }], partial: [] },
+            rejections: [{ indexer: 'Indexer 1', at: '2026-08-05T09:00:00Z', reason: 'query failed', query: 'Some Film' }]
+        });
+        expect(d.verdict.stage).toBe('queue');
+    });
+
+    it('indexers outranks file when both are blocked', () => {
+        const d = buildChain('some film', {
+            ...healthy(),
+            item: item({ acquisition: { service: 'radarr', monitored: true, hasFile: false } }),
+            rejections: [{ indexer: 'Indexer 1', at: '2026-08-05T09:00:00Z', reason: 'query failed', query: 'Some Film' }]
+        });
+        expect(d.verdict.stage).toBe('indexers');
+    });
+
+    it('library outranks scan when only library is blocked (scan itself is fine)', () => {
+        const d = buildChain('some film', {
+            ...healthy(),
+            item: item({ presence: 'arr_only', playback: undefined })
+        });
+        expect(d.verdict.stage).toBe('library');
+    });
+
+    it('scan outranks library when both are blocked', () => {
+        const d = buildChain('some film', {
+            ...healthy(),
+            item: item({ presence: 'arr_only', playback: undefined }),
+            scan: { service: 'jellyfin', running: true }
+        });
+        expect(d.verdict.stage).toBe('scan');
     });
 });
 
@@ -276,6 +502,68 @@ describe('buildChain — a stack without Jellyfin', () => {
     });
 });
 
+describe('buildChain — a stack without a download client or Prowlarr', () => {
+    it('skips the queue stage rather than reporting it unknown', () => {
+        const d = buildChain('some film', {
+            ...healthy(),
+            item: item({ acquisition: { service: 'radarr', monitored: true, hasFile: false } }),
+            queue: undefined,
+            queueConfigured: false
+        });
+        expect(stepFor(d, 'queue')?.status).toBe('skipped');
+    });
+
+    it('skips the indexers stage rather than reporting it unknown', () => {
+        const d = buildChain('some film', {
+            ...healthy(),
+            item: item({ acquisition: { service: 'radarr', monitored: true, hasFile: false } }),
+            rejections: undefined,
+            prowlarrConfigured: false
+        });
+        expect(stepFor(d, 'indexers')?.status).toBe('skipped');
+    });
+
+    it('does not claim "no indexer reported a failure" about a service the user does not run', () => {
+        const d = buildChain('some film', {
+            ...healthy(),
+            item: item({ acquisition: { service: 'radarr', monitored: true, hasFile: false } }),
+            queue: undefined,
+            queueConfigured: false,
+            rejections: undefined,
+            prowlarrConfigured: false
+        });
+        expect(d.verdict.stage).toBe('file');
+        expect(d.verdict.remedy).not.toMatch(/no indexer reported a failure/i);
+        expect(d.verdict.remedy).not.toMatch(/nothing is downloading/i);
+    });
+
+    it('does not report a queue as merely empty when one of several clients could not be reached (partial read)', () => {
+        // The planned collector: one flaky torrent client must not erase rows
+        // a different, healthy client already returned.
+        const d = buildChain('some film', {
+            ...healthy(),
+            item: item({ acquisition: { service: 'radarr', monitored: true, hasFile: false } }),
+            queue: { items: [], partial: ['transmission'] }
+        });
+        expect(stepFor(d, 'queue')?.status).toBe('unknown');
+        expect(d.verdict.certain).toBe(false);
+    });
+
+    it('still reports a genuine blockage found on a client that did answer, even when another client in the same read failed', () => {
+        const d = buildChain('some film', {
+            ...healthy(),
+            item: item({ acquisition: { service: 'radarr', monitored: true, hasFile: false } }),
+            queue: {
+                items: [{ service: 'sabnzbd', id: '1', title: 'Some.Film.2026', status: 'stalled', errorMessage: 'x' }],
+                partial: ['transmission']
+            }
+        });
+        expect(d.verdict.stage).toBe('queue');
+        // A hole elsewhere in the same stage cannot undo evidence already in hand.
+        expect(d.verdict.certain).toBe(true);
+    });
+});
+
 describe('buildChain — fencing', () => {
     it('composes fenced titles without unwrapping them', () => {
         const d = buildChain('some film', healthy());
@@ -287,19 +575,22 @@ describe('buildChain — fencing', () => {
         const d = buildChain('some film', {
             ...healthy(),
             item: item({ acquisition: { service: 'radarr', monitored: true, hasFile: false } }),
-            queue: [
-                {
-                    service: 'sabnzbd',
-                    id: '1',
-                    // Must plausibly match the item's title — queueStep's
-                    // `mentions()` heuristic exists precisely to ignore
-                    // unrelated queue entries, so a title that could not
-                    // match anything would defeat the fencing check below.
-                    title: 'Some.Film.2026',
-                    status: 'failed',
-                    errorMessage: '<<untrusted:sabnzbd.fail_message>>unpack failed<</untrusted>>'
-                }
-            ]
+            queue: {
+                items: [
+                    {
+                        service: 'sabnzbd',
+                        id: '1',
+                        // Must plausibly match the item's title — queueStep's
+                        // `mentions()` heuristic exists precisely to ignore
+                        // unrelated queue entries, so a title that could not
+                        // match anything would defeat the fencing check below.
+                        title: 'Some.Film.2026',
+                        status: 'failed',
+                        errorMessage: '<<untrusted:sabnzbd.fail_message>>unpack failed<</untrusted>>'
+                    }
+                ],
+                partial: []
+            }
         });
         expect(d.verdict.summary).toContain('<<untrusted:sabnzbd.fail_message>>');
     });

--- a/test/diagnoseChain.test.ts
+++ b/test/diagnoseChain.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, it } from 'vitest';
+import type { MergedItem } from '../src/core/resolver.ts';
+import { buildChain, type Evidence } from '../src/tools/diagnose/chain.ts';
+
+/**
+ * Unlike `Partial<MergedItem>`, this lets a caller override a field to
+ * `undefined` explicitly — e.g. `item({ acquisition: undefined })` for
+ * "nothing manages it" — which `Partial<MergedItem>` cannot type under
+ * `exactOptionalPropertyTypes` (its optional fields accept omission, not an
+ * explicit `undefined` value).
+ */
+type ItemOverride = { [K in keyof MergedItem]?: MergedItem[K] | undefined };
+
+const item = (over: ItemOverride = {}): MergedItem => {
+    const merged: Record<string, unknown> = {
+        kind: 'movie',
+        title: '<<untrusted:radarr.title>>Some Film<</untrusted>>',
+        year: 2026,
+        ids: { tmdb: 550 },
+        acquisition: { service: 'radarr', monitored: true, hasFile: true },
+        playback: { user: 'Someone', watched: false },
+        presence: 'both',
+        ...over
+    };
+    // A field overridden to `undefined` should clear it back to "not
+    // present", not leave the key assigned to `undefined` — the latter is
+    // exactly what `exactOptionalPropertyTypes` exists to forbid.
+    for (const key of Object.keys(merged)) {
+        if (merged[key] === undefined) delete merged[key];
+    }
+    return merged as MergedItem;
+};
+
+/** Everything looked at, nothing wrong: the baseline every case perturbs. */
+const healthy = (over: Partial<Evidence> = {}): Evidence => ({
+    item: item(),
+    request: null,
+    queue: [],
+    rejections: [],
+    scan: { service: 'jellyfin', lastCompleted: '2026-08-05T02:00:00Z' },
+    jellyfinConfigured: true,
+    degraded: [],
+    ...over
+});
+
+const stepFor = (d: ReturnType<typeof buildChain>, stage: string) => d.steps.find(s => s.stage === stage);
+
+describe('buildChain — a healthy item', () => {
+    it('reports every stage ok or skipped', () => {
+        const d = buildChain('some film', healthy());
+        expect(d.steps.every(s => s.status === 'ok' || s.status === 'skipped')).toBe(true);
+    });
+
+    it('verdicts as playable, and is certain about it', () => {
+        const d = buildChain('some film', healthy());
+        expect(d.verdict).toMatchObject({ stage: 'playable', certain: true });
+    });
+
+    it('reports the resolved item so the caller can check it matched the right thing', () => {
+        const d = buildChain('some film', healthy());
+        expect(d.resolved).toMatchObject({ title: item().title, year: 2026, ids: { tmdb: 550 } });
+    });
+
+    it('walks the stages in pipeline order', () => {
+        expect(buildChain('some film', healthy()).steps.map(s => s.stage)).toEqual([
+            'resolve',
+            'request',
+            'managed',
+            'file',
+            'queue',
+            'indexers',
+            'library',
+            'scan'
+        ]);
+    });
+});
+
+describe('buildChain — each stage blocking in isolation', () => {
+    it('stops at resolve when nothing knows the item', () => {
+        const d = buildChain('nonexistent', { ...healthy(), item: undefined });
+        expect(d.verdict.stage).toBe('resolve');
+        expect(d.verdict.remedy).toMatch(/search_media|request/i);
+        // No point reporting on stages that could not even be attempted.
+        expect(stepFor(d, 'managed')?.status).toBe('skipped');
+    });
+
+    it('stops at request when it was declined', () => {
+        const d = buildChain('some film', {
+            ...healthy(),
+            item: item({ acquisition: undefined, presence: 'jellyfin_only' }),
+            request: { status: 'declined' }
+        });
+        expect(d.verdict.stage).toBe('request');
+        expect(d.verdict.summary).toMatch(/declined/i);
+    });
+
+    it('reports a pending request as the blockage, not the missing file', () => {
+        const d = buildChain('some film', {
+            ...healthy(),
+            item: item({ acquisition: undefined, presence: 'jellyfin_only' }),
+            request: { status: 'pending' }
+        });
+        expect(d.verdict.stage).toBe('request');
+        expect(d.verdict.remedy).toMatch(/approve/i);
+    });
+
+    it('stops at managed when nothing is managing it', () => {
+        const d = buildChain('some film', {
+            ...healthy(),
+            item: item({ acquisition: undefined, presence: 'jellyfin_only' })
+        });
+        expect(d.verdict.stage).toBe('managed');
+        expect(d.verdict.summary).toMatch(/not managed|Radarr|Sonarr/i);
+    });
+
+    it('stops at managed when it is present but unmonitored', () => {
+        const d = buildChain('some film', {
+            ...healthy(),
+            item: item({ acquisition: { service: 'radarr', monitored: false, hasFile: false } })
+        });
+        expect(d.verdict.stage).toBe('managed');
+        expect(d.verdict.remedy).toMatch(/monitor/i);
+    });
+
+    it('stops at file when nothing explains the absence', () => {
+        const d = buildChain('some film', {
+            ...healthy(),
+            item: item({ acquisition: { service: 'radarr', monitored: true, hasFile: false } })
+        });
+        expect(d.verdict.stage).toBe('file');
+    });
+
+    it('stops at library when the *arr has a file Jellyfin cannot see', () => {
+        // §4.2: this is the broken import, and the reason the phase exists.
+        const d = buildChain('some film', {
+            ...healthy(),
+            item: item({ presence: 'arr_only', playback: undefined })
+        });
+        expect(d.verdict.stage).toBe('library');
+        expect(d.verdict.summary).toMatch(/Jellyfin/);
+    });
+
+    it('blames the scan when the library is missing it and no scan has run since', () => {
+        const d = buildChain('some film', {
+            ...healthy(),
+            item: item({ presence: 'arr_only', playback: undefined }),
+            scan: { service: 'jellyfin', running: true }
+        });
+        expect(stepFor(d, 'scan')?.detail).toMatch(/running/i);
+    });
+});
+
+describe('buildChain — a symptom never outranks its cause', () => {
+    const noFile = item({ acquisition: { service: 'radarr', monitored: true, hasFile: false } });
+
+    it('blames the stalled download rather than the missing file', () => {
+        const d = buildChain('some film', {
+            ...healthy(),
+            item: noFile,
+            queue: [
+                {
+                    service: 'sabnzbd',
+                    id: '1',
+                    title: 'Some.Film.2026',
+                    status: 'stalled',
+                    errorMessage: 'no connection to news server'
+                }
+            ]
+        });
+        expect(d.verdict.stage).toBe('queue');
+        expect(d.verdict.summary).toMatch(/stalled|news server/i);
+    });
+
+    it('reports an active download as the explanation, with what it is waiting on', () => {
+        const d = buildChain('some film', {
+            ...healthy(),
+            item: noFile,
+            queue: [{ service: 'radarr', id: '1', title: 'Some.Film.2026', status: 'downloading', etaSeconds: 600 }]
+        });
+        expect(d.verdict.stage).toBe('queue');
+        expect(d.verdict.summary).toMatch(/downloading/i);
+        // Downloading is not a fault: nothing to fix, so nothing to suggest.
+        expect(d.verdict.remedy).toBeUndefined();
+    });
+
+    it('blames a failing indexer when nothing is downloading', () => {
+        const d = buildChain('some film', {
+            ...healthy(),
+            item: noFile,
+            rejections: [{ indexer: 'Indexer 1', at: '2026-08-05T09:00:00Z', reason: 'query failed', query: 'Some Film' }]
+        });
+        expect(d.verdict.stage).toBe('indexers');
+    });
+
+    it('still reports the file step as blocked, because it is true', () => {
+        const d = buildChain('some film', {
+            ...healthy(),
+            item: noFile,
+            queue: [{ service: 'radarr', id: '1', title: 'Some.Film.2026', status: 'downloading' }]
+        });
+        expect(stepFor(d, 'file')?.status).toBe('blocked');
+    });
+});
+
+describe('buildChain — certainty', () => {
+    it('is uncertain when a stage before the verdict could not be checked', () => {
+        // §6.1: with Jellyfin unreachable, diagnose must not report "it is not
+        // in Jellyfin". It reports that it could not look.
+        const d = buildChain('some film', {
+            item: item({ presence: 'arr_only', playback: undefined }),
+            request: null,
+            queue: [],
+            rejections: undefined,
+            scan: undefined,
+            jellyfinConfigured: true,
+            degraded: ['jellyfin', 'prowlarr']
+        });
+
+        expect(d.verdict.certain).toBe(false);
+        expect(d.verdict.summary).toMatch(/could not check|prowlarr/i);
+    });
+
+    it('names the services it could not reach', () => {
+        const d = buildChain('some film', { ...healthy(), scan: undefined, degraded: ['jellyfin'] });
+        expect(d.degraded).toEqual(['jellyfin']);
+    });
+
+    it('stays certain when the unknown stage comes after the verdict', () => {
+        // The verdict is "nothing is managing it". Whether a scan has run since
+        // cannot change that, so an unreachable Jellyfin costs no confidence.
+        const d = buildChain('some film', {
+            ...healthy(),
+            item: item({ acquisition: undefined, presence: 'jellyfin_only' }),
+            scan: undefined,
+            degraded: ['jellyfin']
+        });
+        expect(d.verdict.stage).toBe('managed');
+        expect(d.verdict.certain).toBe(true);
+    });
+
+    it('never claims playable while a stage is unknown', () => {
+        const d = buildChain('some film', { ...healthy(), scan: undefined, degraded: ['jellyfin'] });
+        if (d.verdict.stage === 'playable') expect(d.verdict.certain).toBe(false);
+    });
+
+    it('is uncertain about a resolve failure when a library service was down', () => {
+        // "We do not have it" and "we could not look" are different answers.
+        const d = buildChain('some film', {
+            item: undefined,
+            request: null,
+            queue: [],
+            rejections: [],
+            scan: undefined,
+            jellyfinConfigured: true,
+            degraded: ['radarr']
+        });
+        expect(d.verdict).toMatchObject({ stage: 'resolve', certain: false });
+    });
+});
+
+describe('buildChain — a stack without Jellyfin', () => {
+    const noJellyfin = (over: Partial<Evidence> = {}): Evidence =>
+        healthy({ jellyfinConfigured: false, scan: undefined, ...over });
+
+    it('skips the library stage rather than reporting it unknown', () => {
+        // "Jellyfin cannot see it" would be a lie about a service the user
+        // never configured, and `unknown` would cost confidence for no reason.
+        const d = buildChain('some film', noJellyfin({ item: item({ presence: 'arr_only', playback: undefined }) }));
+        expect(stepFor(d, 'library')?.status).toBe('skipped');
+        expect(stepFor(d, 'scan')?.status).toBe('skipped');
+    });
+
+    it('stays certain, and verdicts on the file being present', () => {
+        const d = buildChain('some film', noJellyfin({ item: item({ presence: 'arr_only', playback: undefined }) }));
+        expect(d.verdict).toMatchObject({ stage: 'playable', certain: true });
+    });
+});
+
+describe('buildChain — fencing', () => {
+    it('composes fenced titles without unwrapping them', () => {
+        const d = buildChain('some film', healthy());
+        expect(d.resolved?.title).toContain('<<untrusted:radarr.title>>');
+        expect(JSON.stringify(d).match(/<<\/untrusted>>/g)?.length).toBeGreaterThan(0);
+    });
+
+    it('carries a queue error message through fenced', () => {
+        const d = buildChain('some film', {
+            ...healthy(),
+            item: item({ acquisition: { service: 'radarr', monitored: true, hasFile: false } }),
+            queue: [
+                {
+                    service: 'sabnzbd',
+                    id: '1',
+                    // Must plausibly match the item's title — queueStep's
+                    // `mentions()` heuristic exists precisely to ignore
+                    // unrelated queue entries, so a title that could not
+                    // match anything would defeat the fencing check below.
+                    title: 'Some.Film.2026',
+                    status: 'failed',
+                    errorMessage: '<<untrusted:sabnzbd.fail_message>>unpack failed<</untrusted>>'
+                }
+            ]
+        });
+        expect(d.verdict.summary).toContain('<<untrusted:sabnzbd.fail_message>>');
+    });
+});

--- a/test/diagnoseChain.test.ts
+++ b/test/diagnoseChain.test.ts
@@ -777,6 +777,130 @@ describe('buildChain — request/managed do not outrank a file already confirmed
     });
 });
 
+describe('buildChain — a series file signal is ambiguous, so request/managed still compete there (round 3)', () => {
+    // Sonarr's own `hasFile` (`src/services/sonarr.ts`: `episodeFileCount >
+    // 0`) means "any episode has a file", not "the thing being asked about
+    // is on disk" — unlike a movie, where `hasFile` is unambiguous. A show
+    // sitting on seasons 1-4 satisfies `fileIsOk` while season 5, the actual
+    // question, has never arrived. Excluding request/managed there the same
+    // way movies do would silently drop the single most common series
+    // diagnosis — "my show stopped getting new episodes because monitoring
+    // got turned off" — under a confident "is available in Jellyfin and
+    // playable", with no remedy and no mention: the exact failure the aside
+    // (N7) exists to prevent, in a stage the aside does not cover.
+    const seriesOnDisk = (over: ItemOverride = {}): MergedItem =>
+        item({
+            kind: 'series',
+            title: fence('Some Show'),
+            year: 2020,
+            ids: { tvdb: 71663 },
+            acquisition: { service: 'sonarr', monitored: true, hasFile: true },
+            presence: 'both',
+            ...over
+        });
+
+    it('blames monitoring being off — not "playable" — when seasons 1-4 are on disk and monitoring stopped', () => {
+        const d = buildChain('some show', {
+            ...healthy(),
+            item: seriesOnDisk({ acquisition: { service: 'sonarr', monitored: false, hasFile: true } })
+        });
+        expect(d.verdict.stage).toBe('managed');
+        expect(d.verdict.remedy).toMatch(/monitor/i);
+    });
+
+    it('blames the pending request — not "playable" — when seasons 1-4 are on disk and the season 5 request is pending', () => {
+        const d = buildChain('some show', {
+            ...healthy(),
+            item: seriesOnDisk(),
+            request: { status: 'pending' }
+        });
+        expect(d.verdict.stage).toBe('request');
+        expect(d.verdict.remedy).toMatch(/approve/i);
+    });
+
+    it('leaves a movie in the identical shape verdicting playable — the exclusion is series-specific, not a general regression', () => {
+        const d = buildChain('some film', {
+            ...healthy(),
+            item: item({ acquisition: { service: 'radarr', monitored: false, hasFile: true } }),
+            request: { status: 'pending' }
+        });
+        expect(d.verdict).toMatchObject({ stage: 'playable', certain: true });
+    });
+
+    it('still mentions, but does not verdict on, a genuinely faulted queue row for a healthy series (N7 continues to apply)', () => {
+        const d = buildChain('some show', {
+            ...healthy(),
+            item: seriesOnDisk(),
+            queue: {
+                items: [
+                    {
+                        service: 'sabnzbd',
+                        id: '1',
+                        title: queueTitle('sabnzbd', 'Some.Show.S05E01.2026'),
+                        status: 'stalled',
+                        errorMessage: 'x'
+                    }
+                ],
+                partial: []
+            }
+        });
+        expect(d.verdict.stage).toBe('playable');
+        expect(d.verdict.summary).toMatch(/stalled/i);
+    });
+});
+
+describe('buildChain — the queue aside only appears once a file is actually confirmed (round 3)', () => {
+    it('does not claim a file already exists in the aside when managed is blocked and there genuinely is no file yet', () => {
+        // Round 2's aside was gated on `blocking.stage !== 'queue'` alone,
+        // not on whether a file had been confirmed at all — so a `managed`
+        // (or `request`) verdict with no file, alongside an unrelated queue
+        // row that happens to fault, produced: "radarr has it, but it is
+        // not monitored. (Also: Download failed: unpack failed. This does
+        // not block the file already on disk…)" — asserting a file that was
+        // never confirmed to exist.
+        const d = buildChain('some film', {
+            ...healthy(),
+            item: item({ acquisition: { service: 'radarr', monitored: false, hasFile: false } }),
+            queue: {
+                items: [
+                    {
+                        service: 'sabnzbd',
+                        id: '1',
+                        title: queueTitle('sabnzbd', 'Some.Film.2026'),
+                        status: 'failed',
+                        errorMessage: 'unpack failed'
+                    }
+                ],
+                partial: []
+            }
+        });
+        expect(d.verdict.stage).toBe('managed');
+        expect(d.verdict.summary).not.toMatch(/already on disk/i);
+    });
+});
+
+describe('buildChain — the haystack is unfenced before tokenising (round 3)', () => {
+    it('does not let the fence markup itself — "untrusted", the service id, the field name — become a spurious matching token', () => {
+        const d = buildChain('untrusted', {
+            ...healthy(),
+            item: item({ title: fence('Untrusted'), acquisition: { service: 'radarr', monitored: true, hasFile: false } }),
+            queue: {
+                // No year-shaped token in this release name: the point is to
+                // isolate the fence-vocabulary bug from N4's year guard,
+                // which would otherwise reject the match anyway (on a real
+                // year mismatch) and mask whether *this* fix did anything.
+                items: [{ service: 'sabnzbd', id: '1', title: queueTitle('sabnzbd', 'Completely.Unrelated.Movie.BluRay'), status: 'downloading' }],
+                partial: []
+            }
+        });
+        // Genuinely unrelated apart from the fence's own vocabulary, which
+        // must not count as a match — before this fix, the needle was
+        // unfenced but the haystack was not, so "untrusted" (present in
+        // every fenced string) matched every fenced queue row.
+        expect(d.verdict.stage).toBe('file');
+    });
+});
+
 describe('buildChain — queue status classification (N5, N6)', () => {
     const noFile = item({ acquisition: { service: 'radarr', monitored: true, hasFile: false } });
 

--- a/test/diagnoseChain.test.ts
+++ b/test/diagnoseChain.test.ts
@@ -14,6 +14,18 @@ type ItemOverride = { [K in keyof MergedItem]?: MergedItem[K] | undefined };
 
 const fence = (title: string): string => fenceText(title, { service: 'radarr', field: 'title' });
 
+/**
+ * Every queue fixture used to pass an unfenced release title, while all
+ * three adapters actually fence it (`arrQueue.ts`'s `title`, SABnzbd's
+ * `filename`, Transmission's `name`). Matching still worked either way — the
+ * fence markers are outside the word tokens `mentions()` compares — but an
+ * unfenced fixture is not production shape. This fences per-service the same
+ * way the real adapter does.
+ */
+const QUEUE_TITLE_FIELD: Record<string, string> = { radarr: 'title', sonarr: 'title', sabnzbd: 'filename', transmission: 'name' };
+const queueTitle = (service: string, title: string): string =>
+    fenceText(title, { service: service as Parameters<typeof fenceText>[1]['service'], field: QUEUE_TITLE_FIELD[service] ?? 'title' });
+
 const item = (over: ItemOverride = {}): MergedItem => {
     const merged: Record<string, unknown> = {
         kind: 'movie',
@@ -185,7 +197,7 @@ describe('buildChain — a symptom never outranks its cause', () => {
                     {
                         service: 'sabnzbd',
                         id: '1',
-                        title: 'Some.Film.2026',
+                        title: queueTitle('sabnzbd', 'Some.Film.2026'),
                         status: 'stalled',
                         errorMessage: 'no connection to news server'
                     }
@@ -204,7 +216,7 @@ describe('buildChain — a symptom never outranks its cause', () => {
         const d = buildChain('some film', {
             ...healthy(),
             item: noFile,
-            queue: { items: [{ service: 'radarr', id: '1', title: 'Some.Film.2026', status: 'downloading', etaSeconds: 600 }], partial: [] }
+            queue: { items: [{ service: 'radarr', id: '1', title: queueTitle('radarr', 'Some.Film.2026'), status: 'downloading', etaSeconds: 600 }], partial: [] }
         });
         expect(d.verdict.stage).toBe('queue');
         expect(d.verdict.summary).toMatch(/downloading/i);
@@ -223,7 +235,7 @@ describe('buildChain — a symptom never outranks its cause', () => {
         const d = buildChain('some film', {
             ...healthy(),
             item: noFile,
-            queue: { items: [{ service: 'radarr', id: '1', title: 'Some.Film.2026', status: 'completed' }], partial: [] }
+            queue: { items: [{ service: 'radarr', id: '1', title: queueTitle('radarr', 'Some.Film.2026'), status: 'completed' }], partial: [] }
         });
         expect(d.verdict.stage).toBe('queue');
         expect(d.verdict.summary).not.toMatch(/still downloading/i);
@@ -237,7 +249,7 @@ describe('buildChain — a symptom never outranks its cause', () => {
             const d = buildChain('some film', {
                 ...healthy(),
                 item: noFile,
-                queue: { items: [{ service: 'radarr', id: '1', title: 'Some.Film.2026', status }], partial: [] }
+                queue: { items: [{ service: 'radarr', id: '1', title: queueTitle('radarr', 'Some.Film.2026'), status }], partial: [] }
             });
             expect(d.verdict.stage).toBe('queue');
             expect(d.verdict.summary).not.toMatch(/still downloading/i);
@@ -257,7 +269,7 @@ describe('buildChain — a symptom never outranks its cause', () => {
         const d = buildChain('some film', {
             ...healthy(),
             item: noFile,
-            queue: { items: [{ service: 'radarr', id: '1', title: 'Some.Film.2026', status: 'downloading' }], partial: [] }
+            queue: { items: [{ service: 'radarr', id: '1', title: queueTitle('radarr', 'Some.Film.2026'), status: 'downloading' }], partial: [] }
         });
         expect(stepFor(d, 'file')?.status).toBe('blocked');
     });
@@ -268,7 +280,7 @@ describe('buildChain — a symptom does not outrank a chain that is not actually
         const d = buildChain('some film', {
             ...healthy(),
             // item() defaults to hasFile: true.
-            queue: { items: [{ service: 'radarr', id: '1', title: 'Some.Film.2026', status: 'downloading', etaSeconds: 600 }], partial: [] }
+            queue: { items: [{ service: 'radarr', id: '1', title: queueTitle('radarr', 'Some.Film.2026'), status: 'downloading', etaSeconds: 600 }], partial: [] }
         });
         expect(d.verdict).toMatchObject({ stage: 'playable', certain: true });
     });
@@ -301,7 +313,7 @@ describe('buildChain — title matching (I3)', () => {
         const d = buildChain(title, {
             ...healthy(),
             item: noFileFor(title, year),
-            queue: { items: [{ service: 'radarr', id: '1', title: release, status: 'downloading' }], partial: [] }
+            queue: { items: [{ service: 'radarr', id: '1', title: queueTitle('radarr', release), status: 'downloading' }], partial: [] }
         });
         expect(d.verdict.stage).toBe('queue');
     });
@@ -310,7 +322,7 @@ describe('buildChain — title matching (I3)', () => {
         const d = buildChain('dune', {
             ...healthy(),
             item: noFileFor('Dune', 2021),
-            queue: { items: [{ service: 'radarr', id: '1', title: 'Dune.Part.Two.2024.1080p', status: 'downloading' }], partial: [] }
+            queue: { items: [{ service: 'radarr', id: '1', title: queueTitle('radarr', 'Dune.Part.Two.2024.1080p'), status: 'downloading' }], partial: [] }
         });
         // The queue row is correctly ignored as unrelated, so nothing
         // explains the missing file, and the verdict falls through to it.
@@ -321,7 +333,7 @@ describe('buildChain — title matching (I3)', () => {
         const d = buildChain('alien', {
             ...healthy(),
             item: noFileFor('Alien', 1979),
-            queue: { items: [{ service: 'radarr', id: '1', title: 'Aliens.1986.1080p', status: 'downloading' }], partial: [] }
+            queue: { items: [{ service: 'radarr', id: '1', title: queueTitle('radarr', 'Aliens.1986.1080p'), status: 'downloading' }], partial: [] }
         });
         expect(d.verdict.stage).toBe('file');
     });
@@ -330,7 +342,7 @@ describe('buildChain — title matching (I3)', () => {
         const d = buildChain('toy story', {
             ...healthy(),
             item: noFileFor('Toy Story', 1995),
-            queue: { items: [{ service: 'radarr', id: '1', title: 'American.Horror.Story.S01E01', status: 'downloading' }], partial: [] }
+            queue: { items: [{ service: 'radarr', id: '1', title: queueTitle('radarr', 'American.Horror.Story.S01E01'), status: 'downloading' }], partial: [] }
         });
         expect(d.verdict.stage).toBe('file');
     });
@@ -338,12 +350,19 @@ describe('buildChain — title matching (I3)', () => {
 
 describe('buildChain — certainty', () => {
     it('is uncertain when a stage before the verdict could not be checked', () => {
-        // A real, blocked verdict (library) with an earlier stage on its
+        // A real, blocked verdict (file — genuinely missing, nothing
+        // downloading, no indexer failure) with an earlier stage on its
         // certainty path (request) unreachable — the mechanism this test
         // name describes, exercised against an actual blocking stage rather
         // than the no-verdict/playable path (see the dedicated test below).
+        //
+        // Deliberately *not* a `library` verdict: once `file` is confirmed
+        // `ok`, request/managed are excluded from the certainty path
+        // entirely (residual C1) — an unreachable Seerr has no bearing on
+        // whether Jellyfin can see a file already confirmed to exist, so it
+        // would not be a meaningful "stage before the verdict" example there.
         const d = buildChain('some film', {
-            item: item({ presence: 'arr_only', playback: undefined }),
+            item: item({ acquisition: { service: 'radarr', monitored: true, hasFile: false } }),
             request: undefined,
             queue: { items: [], partial: [] },
             queueConfigured: true,
@@ -354,7 +373,7 @@ describe('buildChain — certainty', () => {
             degraded: ['seerr']
         });
 
-        expect(d.verdict.stage).toBe('library');
+        expect(d.verdict.stage).toBe('file');
         expect(d.verdict.certain).toBe(false);
         expect(d.verdict.summary).toMatch(/could not check|seerr/i);
     });
@@ -438,12 +457,25 @@ describe('buildChain — verdict order is pinned, not incidental (I7)', () => {
         expect(d.verdict.stage).toBe('request');
     });
 
-    it('managed outranks the queue/file group when both are blocked', () => {
+    it('managed outranks the queue/file group when both are genuinely blocked', () => {
+        // Not vacuous: `acquisition: undefined` alone always skips `file`
+        // (there is no hasFile to read), so queue/indexers can never compete
+        // regardless of ordering — that would make this test pass whether or
+        // not "managed first" is actually implemented. `monitored: false`
+        // with `hasFile: false` is the fixture where `file` is genuinely
+        // `blocked` (not skipped) *and* `managed` is *also* blocked, so
+        // queue/indexers really are in contention and the ordering matters.
         const d = buildChain('some film', {
             ...healthy(),
-            item: item({ acquisition: undefined, presence: 'jellyfin_only' }),
-            queue: { items: [{ service: 'sabnzbd', id: '1', title: 'Some.Film.2026', status: 'downloading' }], partial: [] }
+            item: item({
+                acquisition: { service: 'radarr', monitored: false, hasFile: false },
+                presence: 'arr_only',
+                playback: undefined
+            }),
+            queue: { items: [{ service: 'sabnzbd', id: '1', title: queueTitle('sabnzbd', 'Some.Film.2026'), status: 'downloading' }], partial: [] }
         });
+        expect(stepFor(d, 'file')?.status).toBe('blocked');
+        expect(stepFor(d, 'queue')?.status).toBe('blocked');
         expect(d.verdict.stage).toBe('managed');
     });
 
@@ -451,7 +483,7 @@ describe('buildChain — verdict order is pinned, not incidental (I7)', () => {
         const d = buildChain('some film', {
             ...healthy(),
             item: item({ acquisition: { service: 'radarr', monitored: true, hasFile: false } }),
-            queue: { items: [{ service: 'sabnzbd', id: '1', title: 'Some.Film.2026', status: 'stalled', errorMessage: 'x' }], partial: [] },
+            queue: { items: [{ service: 'sabnzbd', id: '1', title: queueTitle('sabnzbd', 'Some.Film.2026'), status: 'stalled', errorMessage: 'x' }], partial: [] },
             rejections: [{ indexer: 'Indexer 1', at: '2026-08-05T09:00:00Z', reason: 'query failed', query: 'Some Film' }]
         });
         expect(d.verdict.stage).toBe('queue');
@@ -554,13 +586,302 @@ describe('buildChain — a stack without a download client or Prowlarr', () => {
             ...healthy(),
             item: item({ acquisition: { service: 'radarr', monitored: true, hasFile: false } }),
             queue: {
-                items: [{ service: 'sabnzbd', id: '1', title: 'Some.Film.2026', status: 'stalled', errorMessage: 'x' }],
+                items: [{ service: 'sabnzbd', id: '1', title: queueTitle('sabnzbd', 'Some.Film.2026'), status: 'stalled', errorMessage: 'x' }],
                 partial: ['transmission']
             }
         });
         expect(d.verdict.stage).toBe('queue');
         // A hole elsewhere in the same stage cannot undo evidence already in hand.
         expect(d.verdict.certain).toBe(true);
+    });
+});
+
+describe('buildChain — punctuated titles (N3 regression)', () => {
+    // Round 1's `mentions()` used `normaliseTitle`, which *deletes*
+    // intra-word punctuation ("Spider-Man" → "spiderman"), while a release
+    // name is naturally *split* on the same characters
+    // ("Spider.Man.2002" → "spider", "man", "2002"). Deleting on one side and
+    // splitting on the other means neither ever produces matching tokens —
+    // every hyphenated or apostrophed title matched nothing, and the queue
+    // and indexer stages went blind for them.
+    const noFileFor = (title: string, year: number): MergedItem =>
+        item({ title: fence(title), year, acquisition: { service: 'radarr', monitored: true, hasFile: false } });
+
+    const punctuatedCases: Array<[title: string, year: number, release: string]> = [
+        ['Spider-Man', 2002, 'Spider.Man.2002.1080p'],
+        ['Spider-Man', 2002, 'Spider-Man.2002.1080p'],
+        ['WALL-E', 2008, 'WALL.E.2008.1080p'],
+        ['Face/Off', 1997, 'Face.Off.1997.1080p'],
+        ["Ocean's Eleven", 2001, "Ocean's.Eleven.2001.1080p"]
+    ];
+
+    it.each(punctuatedCases)('matches %s against release name %s', (title, year, release) => {
+        const d = buildChain(title, {
+            ...healthy(),
+            item: noFileFor(title, year),
+            queue: { items: [{ service: 'radarr', id: '1', title: queueTitle('radarr', release), status: 'downloading' }], partial: [] }
+        });
+        expect(d.verdict.stage).toBe('queue');
+    });
+});
+
+describe("buildChain — the year guard ignores the title's own year words (N4)", () => {
+    const noFileFor = (title: string, year: number): MergedItem =>
+        item({ title: fence(title), year, acquisition: { service: 'radarr', monitored: true, hasFile: false } });
+
+    const titleYearCases: Array<[title: string, year: number, release: string]> = [
+        // A naive "first year-shaped token" guard picks 2049 here — the
+        // title's own year — and rejects the real release year (2017).
+        ['Blade Runner 2049', 2017, 'Blade.Runner.2049.2017.1080p'],
+        // Same failure mode with a whole title that is a year.
+        ['1917', 2019, '1917.2019.1080p'],
+        ['2001: A Space Odyssey', 1968, '2001.A.Space.Odyssey.1968.1080p']
+    ];
+
+    it.each(titleYearCases)('matches %s (%i) even though the title itself contains a year-shaped word', (title, year, release) => {
+        const d = buildChain(title, {
+            ...healthy(),
+            item: noFileFor(title, year),
+            queue: { items: [{ service: 'radarr', id: '1', title: queueTitle('radarr', release), status: 'downloading' }], partial: [] }
+        });
+        expect(d.verdict.stage).toBe('queue');
+    });
+
+    it('skips the year guard entirely for a series, where the release year is an episode air year', () => {
+        const d = buildChain('the simpsons', {
+            ...healthy(),
+            item: item({
+                kind: 'series',
+                title: fence('The Simpsons'),
+                year: 1989,
+                ids: { tvdb: 71663 },
+                acquisition: { service: 'sonarr', monitored: true, hasFile: false },
+                presence: 'arr_only',
+                playback: undefined
+            }),
+            queue: {
+                items: [{ service: 'sonarr', id: '1', title: queueTitle('sonarr', 'The.Simpsons.S32E01.2020'), status: 'downloading' }],
+                partial: []
+            }
+        });
+        expect(d.verdict.stage).toBe('queue');
+    });
+});
+
+describe('buildChain — certainty is not laundered across an unreachable scan (N1)', () => {
+    it('is uncertain about a library verdict when scan itself could not be checked, even though scan is not itself blocked', () => {
+        // Round 1 only put `scan` on the certainty path when `scan` was
+        // *already* `blocked` — the one state that cannot change the
+        // verdict. With `library` blocked and `scan` merely `unknown` (could
+        // not tell if a scan is running), the verdict stayed `library` with
+        // `certain: true` and a remedy to "trigger a scan" — silent about
+        // the possibility one is already running, which I6 established
+        // outranks it.
+        const d = buildChain('some film', {
+            ...healthy(),
+            item: item({ presence: 'arr_only', playback: undefined }),
+            scan: undefined
+        });
+        expect(d.verdict.stage).toBe('library');
+        expect(d.verdict.certain).toBe(false);
+        expect(d.verdict.summary).toMatch(/could not check/i);
+    });
+});
+
+describe('buildChain — the file remedy matches what was actually checked (N2)', () => {
+    it('hedges when queue and indexers are configured but unreachable, rather than asserting they were both checked', () => {
+        const d = buildChain('some film', {
+            ...healthy(),
+            item: item({ acquisition: { service: 'radarr', monitored: true, hasFile: false } }),
+            queue: undefined,
+            rejections: undefined,
+            degraded: ['sabnzbd', 'prowlarr']
+        });
+        expect(d.verdict.stage).toBe('file');
+        expect(d.verdict.certain).toBe(false);
+        // The old wording asserted both were checked; the caveat right next
+        // to it says neither could be. The remedy must not contradict it.
+        expect(d.verdict.remedy).not.toMatch(/nothing is downloading and no indexer reported a failure/i);
+        expect(d.verdict.remedy).toMatch(/could not/i);
+    });
+
+    it('hedges specifically about the download client on a partial queue read, crediting indexers for genuinely being checked', () => {
+        const d = buildChain('some film', {
+            ...healthy(),
+            item: item({ acquisition: { service: 'radarr', monitored: true, hasFile: false } }),
+            queue: { items: [], partial: ['transmission'] }
+        });
+        expect(d.verdict.stage).toBe('file');
+        expect(d.verdict.remedy).not.toMatch(/nothing is downloading and no indexer reported a failure/i);
+        expect(d.verdict.remedy).toMatch(/download client/i);
+        // Prowlarr genuinely was reachable and found nothing here — it must
+        // not be named alongside the download client as also uncheckable.
+        expect(d.verdict.remedy).not.toMatch(/indexer manager is configured|prowlarr could not/i);
+    });
+
+    it('does not confuse "not configured" with "checked and found nothing" — the original wording still applies when both genuinely were checked', () => {
+        const d = buildChain('some film', {
+            ...healthy(),
+            item: item({ acquisition: { service: 'radarr', monitored: true, hasFile: false } })
+        });
+        expect(d.verdict.stage).toBe('file');
+        expect(d.verdict.certain).toBe(true);
+        expect(d.verdict.remedy).toMatch(/nothing is downloading and no indexer reported a failure/i);
+    });
+});
+
+describe('buildChain — request/managed do not outrank a file already confirmed on disk (residual C1)', () => {
+    it('does not blame an old declined request when the item is already on disk and visible in Jellyfin', () => {
+        const d = buildChain('some film', {
+            ...healthy(),
+            // item() defaults to hasFile: true, presence: 'both'.
+            request: { status: 'declined' }
+        });
+        expect(d.verdict).toMatchObject({ stage: 'playable', certain: true });
+    });
+
+    it('does not blame a pending request (the normal state of a second/4K request) when the item is already playable', () => {
+        const d = buildChain('some film', {
+            ...healthy(),
+            request: { status: 'pending' }
+        });
+        expect(d.verdict).toMatchObject({ stage: 'playable', certain: true });
+    });
+
+    it('does not blame monitoring being off when the item is already on disk and visible in Jellyfin', () => {
+        // "every hand-added Jellyfin item diagnoses as blocked" was the
+        // failure mode: `monitored: false` alone used to always win.
+        const d = buildChain('some film', {
+            ...healthy(),
+            item: item({ acquisition: { service: 'radarr', monitored: false, hasFile: true } })
+        });
+        expect(d.verdict).toMatchObject({ stage: 'playable', certain: true });
+    });
+
+    it('blames the actual cause (library) rather than monitoring, when the file exists but Jellyfin cannot see it', () => {
+        // The worst case: monitored: false + hasFile: true + arr_only used to
+        // verdict `managed` with remedy "turn monitoring on" — a wrong
+        // remedy, not just a wrong label, while `library` was genuinely
+        // blocked and was the real cause.
+        const d = buildChain('some film', {
+            ...healthy(),
+            item: item({
+                acquisition: { service: 'radarr', monitored: false, hasFile: true },
+                presence: 'arr_only',
+                playback: undefined
+            })
+        });
+        expect(d.verdict.stage).toBe('library');
+        expect(d.verdict.remedy).not.toMatch(/monitor/i);
+        expect(d.verdict.remedy).toMatch(/scan/i);
+    });
+});
+
+describe('buildChain — queue status classification (N5, N6)', () => {
+    const noFile = item({ acquisition: { service: 'radarr', monitored: true, hasFile: false } });
+
+    it.each(['seeding', 'queued to seed'])(
+        'classifies Transmission status %s as import-pending (the torrent itself finished), not "still downloading"',
+        status => {
+            const d = buildChain('some film', {
+                ...healthy(),
+                item: noFile,
+                queue: { items: [{ service: 'transmission', id: '1', title: queueTitle('transmission', 'Some.Film.2026'), status }], partial: [] }
+            });
+            expect(d.verdict.stage).toBe('queue');
+            expect(d.verdict.summary).not.toMatch(/still downloading/i);
+            expect(d.verdict.summary).toMatch(/import/i);
+            expect(d.verdict.remedy).toMatch(/import/i);
+        }
+    );
+
+    it('classifies SABnzbd status "propagating" as active (healthy), not a fault', () => {
+        const d = buildChain('some film', {
+            ...healthy(),
+            item: noFile,
+            queue: { items: [{ service: 'sabnzbd', id: '1', title: queueTitle('sabnzbd', 'Some.Film.2026'), status: 'propagating' }], partial: [] }
+        });
+        expect(d.verdict.stage).toBe('queue');
+        // "Active" is exactly what "propagating" is: no fault, no remedy —
+        // "Still downloading" is the correct, healthy description of it.
+        expect(d.verdict.remedy).toBeUndefined();
+        expect(d.verdict.summary).toMatch(/still downloading/i);
+    });
+
+    it('reports an adapter\'s own "unknown" status sentinel as indeterminate, not a fault (I5\'s reasoning, applied to a queue row)', () => {
+        // SABnzbd's `(s.status ?? 'unknown').toLowerCase()` and
+        // Transmission's `TORRENT_STATUS[...] ?? 'unknown'` fall back to the
+        // literal string "unknown" for a status code they cannot map. That
+        // is the service answering with something this module cannot
+        // classify — the same situation I5 fixed for a Seerr request status.
+        const d = buildChain('some film', {
+            ...healthy(),
+            item: noFile,
+            queue: { items: [{ service: 'transmission', id: '1', title: queueTitle('transmission', 'Some.Film.2026'), status: 'unknown' }], partial: [] }
+        });
+        expect(stepFor(d, 'queue')?.status).toBe('unknown');
+        expect(d.verdict.certain).toBe(false);
+    });
+});
+
+describe('buildChain — a queue fault does not outrank an already-playable file, but is not swallowed either (N7)', () => {
+    it('mentions a failing upgrade grab in the playable summary without changing the verdict', () => {
+        const d = buildChain('some film', {
+            ...healthy(),
+            // item() defaults to hasFile: true — a working file already exists.
+            queue: {
+                items: [
+                    {
+                        service: 'sabnzbd',
+                        id: '1',
+                        title: queueTitle('sabnzbd', 'Some.Film.2026'),
+                        status: 'failed',
+                        errorMessage: 'unpack failed'
+                    }
+                ],
+                partial: []
+            }
+        });
+        expect(d.verdict.stage).toBe('playable');
+        expect(d.verdict.summary).toMatch(/unpack failed/i);
+    });
+
+    it('does not mention a merely active (non-fault) queue row — that would just be C1 undone', () => {
+        const d = buildChain('some film', {
+            ...healthy(),
+            queue: {
+                items: [{ service: 'radarr', id: '1', title: queueTitle('radarr', 'Some.Film.2026'), status: 'downloading', etaSeconds: 600 }],
+                partial: []
+            }
+        });
+        expect(d.verdict.stage).toBe('playable');
+        expect(d.verdict.summary).not.toMatch(/downloading/i);
+    });
+});
+
+describe('buildChain — degraded is read the same way for every stage (N8)', () => {
+    it('reports indexers as unreachable when Prowlarr is named in degraded, even if rejections happens to be present', () => {
+        // `libraryStep`/`scanStep` already treat `degraded` as authoritative
+        // over their own dedicated field; `indexerStep` used to only ever
+        // consult `ev.rejections === undefined`.
+        const d = buildChain('some film', {
+            ...healthy(),
+            item: item({ acquisition: { service: 'radarr', monitored: true, hasFile: false } }),
+            rejections: [],
+            degraded: ['prowlarr']
+        });
+        expect(stepFor(d, 'indexers')?.status).toBe('unknown');
+    });
+
+    it('treats a queue-capable service named in degraded as unreachable even when the collector did not also add it to partial', () => {
+        const d = buildChain('some film', {
+            ...healthy(),
+            item: item({ acquisition: { service: 'radarr', monitored: true, hasFile: false } }),
+            queue: { items: [], partial: [] },
+            degraded: ['sabnzbd']
+        });
+        expect(stepFor(d, 'queue')?.status).toBe('unknown');
+        expect(d.verdict.certain).toBe(false);
     });
 });
 
@@ -584,7 +905,7 @@ describe('buildChain — fencing', () => {
                         // `mentions()` heuristic exists precisely to ignore
                         // unrelated queue entries, so a title that could not
                         // match anything would defeat the fencing check below.
-                        title: 'Some.Film.2026',
+                        title: queueTitle('sabnzbd', 'Some.Film.2026'),
                         status: 'failed',
                         errorMessage: '<<untrusted:sabnzbd.fail_message>>unpack failed<</untrusted>>'
                     }


### PR DESCRIPTION
Phase 3b, Task 5 of 9 — the reasoning core of the tool this project exists for. Pure: evidence in, diagnosis out, no network. Task 6 builds the collector.

**Three review rounds, and each found real defects.** The first implementation passed all 25 of its tests while answering its own question wrong.

## What review caught

**A playable film diagnosed as broken.** The queue and indexer stages never checked whether the file existed, and outranked the stage that did — so a film sitting watchable in Jellyfin reported *"Still downloading — about 10 minutes left"* with `certain: true`, because a 4K upgrade was in flight. One stale indexer rejection did the same, permanently: the rejection window has no age bound.

**A confident claim across a hole.** The playable summary asserted *"available in Jellyfin"* without reading the library step — emitted even when Jellyfin was unreachable. A positive claim across a hole breaks the honesty rule as squarely as a negative one.

**A stalled download had no remedy at all** — the remedy table had no queue entry, so the single most actionable failure in the chain gave no advice, and its test passed for the wrong reason.

**`completed` reported as "still downloading"** — that status is the import-pending row, which *is* the broken import this phase exists to surface.

**Title matching failed in both directions:** `Up`, `Top Gun` and `Se7en` matched nothing; `Dune` matched `Dune Part Two`, `Toy Story` matched `American Horror Story`. Fixing it then regressed punctuated titles — `Spider-Man`, `WALL-E`, `Ocean's Eleven` — because normalisation *deletes* punctuation while release names are *split* on it. And the year guard took the title's own year out of `Blade.Runner.2049.2017`.

## The series case, and a deviation

For a series, `hasFile` means "any episode on disk". Gating on it silenced real blockage for the season actually being asked about: a show with seasons 1–4 downloaded and monitoring switched off reported *"available and playable"*.

I proposed footnoting it. The implementer argued for making it the verdict instead — the footnote mechanism carries no remedy, and *"my show stopped getting new episodes"* needs an answer, not a mention. That was the better call.

## What holds it together

`undefined` is "could not look", `null` is "looked and found nothing", and a third state is "never configured" — so a stack without Prowlarr is never told "no indexer reported a failure" about a service it does not run. The `Evidence` type gained a shape for *"some rows, plus a hole"*, because one flaky download client was erasing the whole stage and discarding the stalled row that was the actual cause.

The verdict is chosen in a different order than the steps are reported in: a missing file is a symptom, a stalled download is its cause.

**661 tests**, up from 578. The chain's own file went from 25 tests to 83.

🤖 Generated with [Claude Code](https://claude.com/claude-code)