### PR TITLE
feat: add diagnose, the tool the project exists for

### DIFF
--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -204,6 +204,13 @@ export type MediaRequest = {
     requestedAt?: string;
 };
 
+export interface RequestCapable {
+    getRequests(opts: { user?: ServiceUser; status?: RequestStatus }): Promise<MediaRequest[]>;
+}
+
+export const hasRequests = (a: ServiceAdapter): a is ServiceAdapter & RequestCapable =>
+    typeof (a as Partial<RequestCapable>).getRequests === 'function';
+
 export type EpisodeSummary = {
     id: number;
     season: number;

--- a/src/tools/diagnose/chain.ts
+++ b/src/tools/diagnose/chain.ts
@@ -128,7 +128,13 @@ const mentions = (haystack: string, item: MergedItem): boolean => {
 };
 
 function requestStep(ev: Evidence): Step {
-    if (ev.request === undefined) return { stage: 'request', service: 'seerr', status: 'unknown', detail: 'Seerr could not be reached.' };
+    // True both when Seerr itself could not be reached and when it answered
+    // but the item had no tmdb id to match against (evidence.ts) — the
+    // wording has to hold in both cases rather than asserting an outage that
+    // may not have happened.
+    if (ev.request === undefined) {
+        return { stage: 'request', service: 'seerr', status: 'unknown', detail: 'Could not determine whether this was requested.' };
+    }
     if (ev.request === null) return SKIPPED('request', 'No request recorded — not everything arrives through Seerr.');
 
     if (ev.request.status === 'declined') {

--- a/src/tools/diagnose/evidence.ts
+++ b/src/tools/diagnose/evidence.ts
@@ -1,4 +1,5 @@
 import type { ServiceId } from '../../config/schema.ts';
+import { ServiceError } from '../../core/errors.ts';
 import { gather, type Gathered } from '../../core/gather.ts';
 import { logger } from '../../core/logger.ts';
 import type { MergedItem } from '../../core/resolver.ts';
@@ -55,24 +56,48 @@ async function resolveItem(
     // The explicit id wins: it is unambiguous and a title is not.
     if (target.service !== undefined && target.id !== undefined) {
         const adapter = deps.adapters.find(a => a.id === target.service);
-        if (adapter === undefined || !hasMediaDetails(adapter)) return undefined;
+        // A `ServiceId` the schema accepts but that does not implement
+        // getMediaDetails (e.g. sabnzbd) is a configuration mistake, not a
+        // hole to degrade across — silently returning `undefined` here would
+        // make the caller's own named service read as "the item does not
+        // exist" (`certain: true`), which is worse than either a stale
+        // download-client outage or a real absence. Same error, same remedy,
+        // as get_media_details.
+        if (adapter === undefined || !hasMediaDetails(adapter)) {
+            throw new ServiceError('NotFound', target.service, `${target.service} is not configured`, {
+                remedy: `Add services.${target.service} to config.yaml, or name a configured service.`
+            });
+        }
 
         const details = await probe(adapter.id, degraded, () =>
             adapter.getMediaDetails(target.id as string, { includeEpisodes: false, episodeLimit: 1 })
         );
         if (details === undefined) return undefined;
 
-        // Looked up in its own service, then found in the index — which is what
-        // gives the diagnosis both halves of the join rather than one.
-        const joined = snapshot.index.find(details.ids, details.kind === 'series' ? 'series' : 'movie');
+        // Jellyfin's MediaDetails never says 'movie' or 'series' — it is the
+        // one adapter that reports `kind: 'item'` for everything. Passing a
+        // *wrong* kind to `find` is worse than passing none: it restricts the
+        // lookup to one keyspace and can silently miss a real hit sitting in
+        // the other (a series id would scan only movie keys and never find
+        // it). `undefined` here makes `find` scan both, exactly as it already
+        // does for every caller that does not know the kind in advance.
+        const searchKind = details.kind === 'item' ? undefined : details.kind;
+        const joined = snapshot.index.find(details.ids, searchKind);
         if (joined !== undefined) return joined;
 
         // The id was valid and the index does not contain it — a real state,
         // not an error: the service holding it may be the one that failed to
         // load. Diagnosing the half we have beats reporting the item unknown
         // when the caller just handed us its id.
+        //
+        // `searchKind` (not a fresh coercion) decides the synthesised kind
+        // too: for Radarr/Sonarr it is the kind they actually reported: for
+        // Jellyfin's ambiguous 'item' — reachable only when *no* index entry
+        // matched under either kind — there is no signal left to disambiguate,
+        // so 'movie' is the least-committal default already implied by
+        // `MergedItem.kind` having no third option.
         return {
-            kind: details.kind === 'series' ? 'series' : 'movie',
+            kind: searchKind ?? 'movie',
             title: details.title,
             ...(details.year === undefined ? {} : { year: details.year }),
             ids: details.ids,
@@ -116,7 +141,7 @@ export async function collectEvidence(deps: DiagnoseDeps, target: DiagnoseTarget
     // `null` here is a third state the chain needs: not configured, as
     // distinct from asked-and-empty (`[]`) or could-not-ask (`undefined`).
     const requestsP: Promise<MediaRequest[] | null | undefined> =
-        seerr === undefined ? Promise.resolve(null) : probe('seerr', degraded, () => seerr.getRequests({}));
+        seerr === undefined ? Promise.resolve(null) : probe(seerr.id, degraded, () => seerr.getRequests({}));
 
     // Multi-service: `gather` already distinguishes "some clients answered,
     // some didn't" from "all of them did" — exactly the queue shape §6.1 asks
@@ -151,8 +176,12 @@ export async function collectEvidence(deps: DiagnoseDeps, target: DiagnoseTarget
     }
 
     /**
-     * Matched on tmdbId, never on title: Seerr's request payload carries no
-     * title at all, so a title match would find nothing on real data.
+     * Matched on tmdbId, never on title. Title is only optionally present on
+     * a Seerr request (`MediaRequest['title']` is `?`), and even when it is,
+     * a fuzzy match is far more fragile than the strong, structured id
+     * already used for §8's whole join — so tmdbId is the right key
+     * regardless of whether this particular request happened to carry a
+     * title.
      *
      * The requester's name is deliberately not carried into the evidence. The
      * status answers the question, and naming who asked exposes another
@@ -161,8 +190,18 @@ export async function collectEvidence(deps: DiagnoseDeps, target: DiagnoseTarget
     let request: Evidence['request'];
     if (requests === undefined) {
         request = undefined; // could not ask
-    } else if (requests === null || item?.ids.tmdb === undefined) {
-        request = null; // no Seerr, or nothing to match on
+    } else if (requests === null) {
+        request = null; // no Seerr configured
+    } else if (item === undefined) {
+        request = null; // nothing resolved to match against
+    } else if (item.ids.tmdb === undefined) {
+        // Seerr answered, but this item carries no tmdb id to match on — e.g.
+        // a Sonarr series (`SonarrAdapter.listLibrary` never emits `tmdb`)
+        // whose Jellyfin counterpart is absent, unreachable, or was never
+        // mapped to TMDB. `undefined` means "could not determine", not
+        // "looked and found nothing" — a real pending request must not be
+        // reported as no request at all just because the join has a gap.
+        request = undefined;
     } else {
         const match = requests.find(r => r.tmdbId === item.ids.tmdb);
         request = match === undefined ? null : { status: match.status };

--- a/src/tools/diagnose/evidence.ts
+++ b/src/tools/diagnose/evidence.ts
@@ -1,0 +1,183 @@
+import type { ServiceId } from '../../config/schema.ts';
+import { gather, type Gathered } from '../../core/gather.ts';
+import { logger } from '../../core/logger.ts';
+import type { MergedItem } from '../../core/resolver.ts';
+import {
+    hasIndexers,
+    hasMediaDetails,
+    hasQueue,
+    hasRequests,
+    hasScanState,
+    type IndexerRejection,
+    type MediaRequest,
+    type QueueItem,
+    type ScanState,
+    type ServiceAdapter
+} from '../../services/types.ts';
+import type { LibraryLoader } from '../library.ts';
+import type { Evidence } from './chain.ts';
+
+export type DiagnoseTarget = { query?: string; service?: ServiceId; id?: string; user?: string };
+
+export type DiagnoseDeps = {
+    adapters: readonly ServiceAdapter[];
+    library: LibraryLoader;
+};
+
+const RECENT_REJECTION_LIMIT = 50;
+
+/**
+ * Every probe returns `undefined` on failure and records the service in
+ * `degraded`. That is the shape the chain reads: undefined is "could not
+ * look", and it is what stops a verdict being confident across a hole (§6.1).
+ */
+async function probe<T>(id: ServiceId, degraded: ServiceId[], fn: () => Promise<T>): Promise<T | undefined> {
+    try {
+        return await fn();
+    } catch (err) {
+        logger.warn({ service: id, err }, 'diagnose probe failed; the stage will report unknown');
+        if (!degraded.includes(id)) degraded.push(id);
+        return undefined;
+    }
+}
+
+async function resolveItem(
+    deps: DiagnoseDeps,
+    target: DiagnoseTarget,
+    degraded: ServiceId[]
+): Promise<MergedItem | undefined> {
+    // §9's gate lives in the loader's identity resolver, and a refusal
+    // propagates out of diagnose rather than becoming a degraded stage — this
+    // call is deliberately not wrapped in `probe`.
+    const snapshot = await deps.library.load(target.user);
+    for (const id of snapshot.degraded) if (!degraded.includes(id)) degraded.push(id);
+
+    // The explicit id wins: it is unambiguous and a title is not.
+    if (target.service !== undefined && target.id !== undefined) {
+        const adapter = deps.adapters.find(a => a.id === target.service);
+        if (adapter === undefined || !hasMediaDetails(adapter)) return undefined;
+
+        const details = await probe(adapter.id, degraded, () =>
+            adapter.getMediaDetails(target.id as string, { includeEpisodes: false, episodeLimit: 1 })
+        );
+        if (details === undefined) return undefined;
+
+        // Looked up in its own service, then found in the index — which is what
+        // gives the diagnosis both halves of the join rather than one.
+        const joined = snapshot.index.find(details.ids, details.kind === 'series' ? 'series' : 'movie');
+        if (joined !== undefined) return joined;
+
+        // The id was valid and the index does not contain it — a real state,
+        // not an error: the service holding it may be the one that failed to
+        // load. Diagnosing the half we have beats reporting the item unknown
+        // when the caller just handed us its id.
+        return {
+            kind: details.kind === 'series' ? 'series' : 'movie',
+            title: details.title,
+            ...(details.year === undefined ? {} : { year: details.year }),
+            ids: details.ids,
+            presence: adapter.id === 'jellyfin' ? 'jellyfin_only' : 'arr_only',
+            ...(adapter.id === 'jellyfin'
+                ? {}
+                : {
+                      acquisition: {
+                          service: adapter.id,
+                          monitored: details.monitored ?? false,
+                          hasFile: details.hasFile ?? false,
+                          ...(details.quality === undefined ? {} : { quality: details.quality }),
+                          ...(details.sizeBytes === undefined ? {} : { sizeBytes: details.sizeBytes })
+                      }
+                  })
+        };
+    }
+
+    return target.query === undefined ? undefined : snapshot.index.search(target.query)[0];
+}
+
+export async function collectEvidence(deps: DiagnoseDeps, target: DiagnoseTarget): Promise<Evidence> {
+    if (target.query === undefined && (target.service === undefined || target.id === undefined)) {
+        throw new Error('Name either a query (a title) or both service and id.');
+    }
+
+    const degraded: ServiceId[] = [];
+    const item = await resolveItem(deps, target, degraded);
+
+    // Structural, not `instanceof SeerrAdapter`: every other capability here
+    // (queue, indexers, scan, media details) is checked the same way, and
+    // duck-typing is what lets a test double stand in for the real adapter.
+    const seerr = deps.adapters.find(hasRequests);
+    const queueAdapters = deps.adapters.filter(hasQueue);
+    const queueConfigured = queueAdapters.length > 0;
+    const prowlarr = deps.adapters.find(hasIndexers);
+    const prowlarrConfigured = prowlarr !== undefined;
+    const jellyfin = deps.adapters.filter(hasScanState).find(a => a.id === 'jellyfin');
+    const jellyfinConfigured = jellyfin !== undefined;
+
+    // `null` here is a third state the chain needs: not configured, as
+    // distinct from asked-and-empty (`[]`) or could-not-ask (`undefined`).
+    const requestsP: Promise<MediaRequest[] | null | undefined> =
+        seerr === undefined ? Promise.resolve(null) : probe('seerr', degraded, () => seerr.getRequests({}));
+
+    // Multi-service: `gather` already distinguishes "some clients answered,
+    // some didn't" from "all of them did" — exactly the queue shape §6.1 asks
+    // for, folded into `queue`/`queueConfigured` below rather than collapsed
+    // to a single undefined the way one failing client used to erase the
+    // whole stage.
+    const queueP: Promise<Gathered<QueueItem> | undefined> = queueConfigured
+        ? gather(queueAdapters.map(a => ({ id: a.id, fetch: () => a.getQueue() })))
+        : Promise.resolve(undefined);
+
+    const rejectionsP: Promise<IndexerRejection[] | undefined> =
+        prowlarr === undefined
+            ? Promise.resolve(undefined)
+            : probe(prowlarr.id, degraded, () => prowlarr.getRecentRejections(RECENT_REJECTION_LIMIT));
+
+    const scanP: Promise<ScanState | undefined> =
+        jellyfin === undefined ? Promise.resolve(undefined) : probe(jellyfin.id, degraded, () => jellyfin.getScanState());
+
+    const [requests, queueGathered, rejections, scan] = await Promise.all([requestsP, queueP, rejectionsP, scanP]);
+
+    let queue: Evidence['queue'];
+    if (queueGathered === undefined) {
+        // Either no download client is configured (queueConfigured is what
+        // tells the chain which), or every configured one failed to answer.
+        queue = undefined;
+    } else {
+        for (const id of queueGathered.degraded) if (!degraded.includes(id)) degraded.push(id);
+        queue =
+            queueGathered.degraded.length === queueAdapters.length
+                ? undefined // nothing read at all
+                : { items: queueGathered.items, partial: queueGathered.degraded }; // some rows plus a hole
+    }
+
+    /**
+     * Matched on tmdbId, never on title: Seerr's request payload carries no
+     * title at all, so a title match would find nothing on real data.
+     *
+     * The requester's name is deliberately not carried into the evidence. The
+     * status answers the question, and naming who asked exposes another
+     * household member's activity to whoever ran the tool (§9).
+     */
+    let request: Evidence['request'];
+    if (requests === undefined) {
+        request = undefined; // could not ask
+    } else if (requests === null || item?.ids.tmdb === undefined) {
+        request = null; // no Seerr, or nothing to match on
+    } else {
+        const match = requests.find(r => r.tmdbId === item.ids.tmdb);
+        request = match === undefined ? null : { status: match.status };
+    }
+
+    degraded.sort();
+    return {
+        item,
+        request,
+        queue,
+        queueConfigured,
+        rejections,
+        prowlarrConfigured,
+        scan,
+        jellyfinConfigured,
+        degraded
+    };
+}

--- a/src/tools/diagnose/index.ts
+++ b/src/tools/diagnose/index.ts
@@ -1,0 +1,48 @@
+import type { McpServer } from '@modelcontextprotocol/server';
+import * as z from 'zod/v4';
+import { ServiceIdSchema } from '../../config/schema.ts';
+import { buildChain, type Diagnosis } from './chain.ts';
+import { collectEvidence, type DiagnoseDeps, type DiagnoseTarget } from './evidence.ts';
+
+export type { DiagnoseDeps } from './evidence.ts';
+
+export async function buildDiagnose(deps: DiagnoseDeps, target: DiagnoseTarget): Promise<Diagnosis> {
+    const evidence = await collectEvidence(deps, target);
+    const label = target.query ?? `${target.service ?? ''}:${target.id ?? ''}`;
+    return buildChain(label, evidence);
+}
+
+export function registerDiagnose(server: McpServer, deps: DiagnoseDeps): void {
+    server.registerTool(
+        'diagnose',
+        {
+            description:
+                'Why is this not playable? Walks the whole chain — requested, managed, monitored, downloaded, indexed, imported, scanned — and names the first thing that explains the absence, with what to do about it. Give a title as `query` for how a person actually asks; give `service` plus `id` only when you already have an exact item in hand (e.g. from get_media_details) — the explicit id wins if both are given. Works with services down: any step it could not check sets `certain: false` and the summary says what was missed, rather than guessing across the hole.',
+            inputSchema: z.object({
+                query: z.string().min(1).optional().describe('A title — how a person actually asks.'),
+                service: ServiceIdSchema.optional().describe('With `id`: an exact item, when one is already in hand.'),
+                id: z.string().min(1).optional(),
+                user: z
+                    .string()
+                    .min(1)
+                    .optional()
+                    .describe('Whose watch state to consider. Defaults to the configured default_user.')
+            })
+        },
+        async ({ query, service, id, user }) => {
+            const result = await buildDiagnose(deps, {
+                ...(query === undefined ? {} : { query }),
+                ...(service === undefined ? {} : { service }),
+                ...(id === undefined ? {} : { id }),
+                ...(user === undefined ? {} : { user })
+            });
+
+            const confidence = result.verdict.certain ? '' : ' (uncertain)';
+            const text = `${result.verdict.summary}${confidence}${
+                result.verdict.remedy === undefined ? '' : ` ${result.verdict.remedy}`
+            }`;
+
+            return { content: [{ type: 'text', text }], structuredContent: result };
+        }
+    );
+}

--- a/src/tools/diagnose/index.ts
+++ b/src/tools/diagnose/index.ts
@@ -26,7 +26,9 @@ export function registerDiagnose(server: McpServer, deps: DiagnoseDeps): void {
                     .string()
                     .min(1)
                     .optional()
-                    .describe('Whose watch state to consider. Defaults to the configured default_user.')
+                    .describe(
+                        'Whose watch state to consider. Defaults to the configured default_user; any other value requires allow_other_users.'
+                    )
             })
         },
         async ({ query, service, id, user }) => {

--- a/src/tools/register.ts
+++ b/src/tools/register.ts
@@ -4,6 +4,7 @@ import { IdentityResolver } from '../core/identity.ts';
 import { JellyfinAdapter } from '../services/jellyfin.ts';
 import { SeerrAdapter } from '../services/seerr.ts';
 import { hasIndexers, hasSubtitles, type ServiceAdapter } from '../services/types.ts';
+import { registerDiagnose } from './diagnose/index.ts';
 import { registerDiscoverMedia } from './discoverMedia.ts';
 import { registerGetCalendar } from './getCalendar.ts';
 import { registerGetIndexers } from './getIndexers.ts';
@@ -64,6 +65,7 @@ export function registerAllTools(server: McpServer, context: ToolContext): void 
     const jellyfin = adapters.find((a): a is JellyfinAdapter => a instanceof JellyfinAdapter);
     const seerr = adapters.find((a): a is SeerrAdapter => a instanceof SeerrAdapter);
 
+    registerDiagnose(server, { adapters, library });
     registerStackHealth(server, adapters);
     registerGetIndexers(server, adapters.find(hasIndexers));
     registerGetSubtitles(server, adapters.find(hasSubtitles));
@@ -80,6 +82,7 @@ export function registerAllTools(server: McpServer, context: ToolContext): void 
 
 /** The tool surface, frozen. §18: renaming one breaks users' saved prompts. */
 export const TOOL_NAMES = [
+    'diagnose',
     'stack_health',
     'get_indexers',
     'get_subtitles',

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -169,7 +169,7 @@ describe('the advertised tool surface', () => {
      * tool rather than raising an error. This asserts the exact set, so any
      * change to it has to be deliberate enough to edit a test.
      */
-    it('exposes exactly the twelve tools of the frozen surface', async () => {
+    it('exposes exactly the thirteen tools of the frozen surface', async () => {
         expect((await listTools()).map(t => t.name).sort()).toEqual([...TOOL_NAMES].sort());
     });
 

--- a/test/diagnose.test.ts
+++ b/test/diagnose.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import { ServiceError } from '../src/core/errors.ts';
+import { IdentityResolver } from '../src/core/identity.ts';
 import type { IndexInput } from '../src/core/resolver.ts';
+import { collectEvidence } from '../src/tools/diagnose/evidence.ts';
 import { buildDiagnose, type DiagnoseDeps } from '../src/tools/diagnose/index.ts';
 import { LibraryLoader } from '../src/tools/library.ts';
-import type { ServiceAdapter } from '../src/services/types.ts';
+import type { ServiceAdapter, UserDirectoryCapable } from '../src/services/types.ts';
 
 const stub = (id: string, extra: Record<string, unknown>): ServiceAdapter =>
     ({
@@ -158,5 +160,168 @@ describe('diagnose', () => {
     it('stays within budget — a diagnosis is prose, not a list', async () => {
         const d = await buildDiagnose(deps(), { query: 'some film' });
         expect(JSON.stringify(d).length).toBeLessThan(4_000);
+    });
+
+    // --- Fix round 1 ---
+
+    it('Finding F: diagnoses a Jellyfin item as the series Sonarr already manages, not a fabricated unmanaged movie', async () => {
+        // JellyfinAdapter.getMediaDetails reports kind: 'item' for everything.
+        // Coercing that to 'movie' before calling find() used to restrict the
+        // lookup to the movie keyspace and silently miss this series, which
+        // is genuinely sitting in the index under sonarr's acquisition.
+        const SERIES: IndexInput = {
+            kind: 'series',
+            title: '<<untrusted:sonarr.title>>A Series<</untrusted>>',
+            ids: { tvdb: 900 },
+            acquisition: { service: 'sonarr', monitored: true, hasFile: false }
+        };
+        const adapters = [
+            stub('sonarr', { listLibrary: async () => [SERIES] }),
+            stub('jellyfin', {
+                getMediaDetails: async () => ({
+                    service: 'jellyfin',
+                    kind: 'item',
+                    id: 'abc123',
+                    title: 'A Series',
+                    ids: { tvdb: 900 }
+                })
+            })
+        ];
+
+        const d = await buildDiagnose(
+            { adapters, library: new LibraryLoader(adapters, undefined) },
+            { service: 'jellyfin', id: 'abc123' }
+        );
+
+        expect(d.resolved?.kind).toBe('series');
+        // The bug fabricated a kind: 'movie' record with no acquisition at
+        // all, verdicting 'managed' ("Neither Radarr nor Sonarr is managing
+        // it") at certain: true. The real join has Sonarr monitoring it with
+        // no file yet, so the true verdict is 'file'.
+        expect(d.verdict.stage).toBe('file');
+    });
+
+    it('Finding A: throws, rather than reporting "nothing matches", for an explicit service that cannot answer media details', async () => {
+        // get_media_details' schema accepts every ServiceId, but only Radarr,
+        // Sonarr and Jellyfin implement getMediaDetails. Naming any other
+        // configured service (e.g. sabnzbd) used to resolve silently to
+        // `undefined`, which the chain then reports as a confident
+        // "Nothing in your stack matches" — a false negative about a real
+        // configuration mistake, not a real absence.
+        await expect(buildDiagnose(deps(), { service: 'sabnzbd', id: '1' })).rejects.toThrow(
+            /sabnzbd.*not configured/i
+        );
+    });
+
+    it('Finding B: a tmdb-less series with Seerr configured reports "could not determine", not "no request", and loses certainty', async () => {
+        // SonarrAdapter.listLibrary never emits a tmdb id — only tvdb/imdb.
+        // Without Jellyfin to supply one, every series diagnosis on a
+        // Sonarr+Seerr stack used to read the missing tmdb id as "looked and
+        // found nothing" (request: null), silently hiding a pending request
+        // and reporting a confident, wrong remedy ("Trigger a search…").
+        const SERIES_NO_TMDB: IndexInput = {
+            kind: 'series',
+            title: '<<untrusted:sonarr.title>>A Series<</untrusted>>',
+            ids: { tvdb: 700 },
+            acquisition: { service: 'sonarr', monitored: true, hasFile: false }
+        };
+        const adapters = [
+            stub('sonarr', { listLibrary: async () => [SERIES_NO_TMDB] }),
+            stub('seerr', { getRequests: async () => [] })
+        ];
+
+        const d = await buildDiagnose(
+            { adapters, library: new LibraryLoader(adapters, undefined) },
+            { query: 'a series' }
+        );
+
+        expect(d.steps.find(s => s.stage === 'request')).toMatchObject({
+            status: 'unknown',
+            detail: 'Could not determine whether this was requested.'
+        });
+        expect(d.verdict.certain).toBe(false);
+    });
+
+    it('collects a partially-read queue as {items, partial}, not undefined, when only some clients answer', async () => {
+        const adapters = [
+            stub('radarr', {
+                listLibrary: async () => [FILM],
+                getQueue: async () => [{ service: 'radarr', id: '1', title: 'Some.Film.2026.1080p', status: 'downloading' }]
+            }),
+            stub('sabnzbd', {
+                getQueue: async () => {
+                    throw new Error('down');
+                }
+            })
+        ];
+
+        const evidence = await collectEvidence(
+            { adapters, library: new LibraryLoader(adapters, undefined) },
+            { query: 'some film' }
+        );
+
+        expect(evidence.queue).toEqual({
+            items: [{ service: 'radarr', id: '1', title: 'Some.Film.2026.1080p', status: 'downloading' }],
+            partial: ['sabnzbd']
+        });
+        expect(evidence.degraded).toContain('sabnzbd');
+    });
+
+    it('collapses the queue to undefined only when every configured client fails, not when one of several does', async () => {
+        const adapters = [
+            stub('radarr', {
+                listLibrary: async () => [FILM],
+                getQueue: async () => {
+                    throw new Error('down');
+                }
+            }),
+            stub('sabnzbd', {
+                getQueue: async () => {
+                    throw new Error('down too');
+                }
+            })
+        ];
+
+        const evidence = await collectEvidence(
+            { adapters, library: new LibraryLoader(adapters, undefined) },
+            { query: 'some film' }
+        );
+
+        expect(evidence.queue).toBeUndefined();
+        expect(evidence.queueConfigured).toBe(true);
+        expect(evidence.degraded).toEqual(['radarr', 'sabnzbd']);
+    });
+
+    it('reports queueConfigured/prowlarrConfigured/jellyfinConfigured as false, not merely absent, when no such service exists', async () => {
+        const adapters = [stub('radarr', { listLibrary: async () => [FILM] })];
+
+        const evidence = await collectEvidence(
+            { adapters, library: new LibraryLoader(adapters, undefined) },
+            { query: 'some film' }
+        );
+
+        expect(evidence.queueConfigured).toBe(false);
+        expect(evidence.prowlarrConfigured).toBe(false);
+        expect(evidence.jellyfinConfigured).toBe(false);
+        expect(evidence.queue).toBeUndefined();
+        expect(evidence.rejections).toBeUndefined();
+        expect(evidence.scan).toBeUndefined();
+    });
+
+    it('propagates an identity refusal as a thrown error rather than a degraded stage', async () => {
+        // §9's gate: naming a user other than the configured default without
+        // allow_other_users must reach the caller as a refusal, not as "the
+        // library could not be read" — a model told the latter would retry
+        // forever instead of stopping.
+        const jellyfin = stub('jellyfin', {
+            listUsers: async () => [{ id: '1', name: 'alice' }]
+        }) as unknown as ServiceAdapter & UserDirectoryCapable;
+        const identity = new IdentityResolver(jellyfin, { default_user: 'alice', allow_other_users: false });
+        const adapters = [stub('radarr', { listLibrary: async () => [FILM] }), jellyfin];
+        const library = new LibraryLoader(adapters, identity);
+
+        await expect(buildDiagnose({ adapters, library }, { query: 'some film', user: 'bob' })).rejects.toThrow(
+            /not permitted/i
+        );
     });
 });

--- a/test/diagnose.test.ts
+++ b/test/diagnose.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest';
+import { ServiceError } from '../src/core/errors.ts';
+import type { IndexInput } from '../src/core/resolver.ts';
+import { buildDiagnose, type DiagnoseDeps } from '../src/tools/diagnose/index.ts';
+import { LibraryLoader } from '../src/tools/library.ts';
+import type { ServiceAdapter } from '../src/services/types.ts';
+
+const stub = (id: string, extra: Record<string, unknown>): ServiceAdapter =>
+    ({
+        id,
+        testConnection: async () => ({ ok: true, service: id, latency_ms: 1 }),
+        getVersion: async () => '1.0.0',
+        ...extra
+    }) as unknown as ServiceAdapter;
+
+const FILM: IndexInput = {
+    kind: 'movie',
+    title: '<<untrusted:radarr.title>>Some Film<</untrusted>>',
+    year: 2026,
+    ids: { tmdb: 550 },
+    acquisition: { service: 'radarr', monitored: true, hasFile: false }
+};
+
+const deps = (over: Partial<Record<string, unknown>> = {}): DiagnoseDeps => {
+    const adapters = [
+        stub('radarr', {
+            listLibrary: async () => [FILM],
+            getQueue: async () => over.queue ?? []
+        }),
+        stub('prowlarr', { getIndexers: async () => [], getRecentRejections: async () => over.rejections ?? [] }),
+        stub('jellyfin', { getScanState: async () => ({ service: 'jellyfin', lastCompleted: '2026-08-05T02:00:00Z' }) }),
+        stub('seerr', { getRequests: async () => over.requests ?? [] })
+    ];
+    return { adapters, library: new LibraryLoader(adapters, undefined) };
+};
+
+describe('diagnose', () => {
+    it('resolves a title and returns the chain', async () => {
+        const d = await buildDiagnose(deps(), { query: 'some film' });
+        expect(d.resolved?.ids).toEqual({ tmdb: 550 });
+        expect(d.steps).toHaveLength(8);
+    });
+
+    it('reports the missing file when nothing else explains it', async () => {
+        const d = await buildDiagnose(deps(), { query: 'some film' });
+        expect(d.verdict).toMatchObject({ stage: 'file', certain: true });
+    });
+
+    it('finds the item in the download queue and blames that instead', async () => {
+        const d = await buildDiagnose(
+            deps({ queue: [{ service: 'radarr', id: '1', title: 'Some.Film.2026.1080p', status: 'downloading' }] }),
+            { query: 'some film' }
+        );
+        expect(d.verdict.stage).toBe('queue');
+    });
+
+    it('matches a Seerr request by tmdb id rather than by title', async () => {
+        // Seerr's request payload carries no title at all, so a title match
+        // here would find nothing on real data.
+        const d = await buildDiagnose(
+            deps({ requests: [{ service: 'seerr', id: 1, status: 'pending', mediaType: 'movie', tmdbId: 550, requestedBy: 'Someone' }] }),
+            { query: 'some film' }
+        );
+        expect(d.verdict.stage).toBe('request');
+    });
+
+    it('does not report who requested it', async () => {
+        // §9: the request status answers the question; naming the requester
+        // exposes another household member's activity to whoever asked.
+        const d = await buildDiagnose(
+            deps({ requests: [{ service: 'seerr', id: 1, status: 'pending', mediaType: 'movie', tmdbId: 550, requestedBy: 'Someone Else' }] }),
+            { query: 'some film' }
+        );
+        expect(JSON.stringify(d)).not.toContain('Someone Else');
+    });
+
+    it('degrades a failing service into unknown rather than failing the call', async () => {
+        const adapters = [
+            stub('radarr', { listLibrary: async () => [FILM], getQueue: async () => [] }),
+            stub('prowlarr', {
+                getIndexers: async () => [],
+                getRecentRejections: async () => {
+                    throw new ServiceError('Unreachable', 'prowlarr', 'connection refused');
+                }
+            })
+        ];
+        const d = await buildDiagnose(
+            { adapters, library: new LibraryLoader(adapters, undefined) },
+            { query: 'some film' }
+        );
+
+        expect(d.degraded).toContain('prowlarr');
+        expect(d.steps.find(s => s.stage === 'indexers')?.status).toBe('unknown');
+    });
+
+    it('is uncertain when the unreachable service sits before the verdict', async () => {
+        const adapters = [
+            stub('radarr', { listLibrary: async () => [FILM] }),
+            stub('prowlarr', {
+                getIndexers: async () => [],
+                getRecentRejections: async () => {
+                    throw new Error('down');
+                }
+            })
+        ];
+        const d = await buildDiagnose(
+            { adapters, library: new LibraryLoader(adapters, undefined) },
+            { query: 'some film' }
+        );
+        expect(d.verdict.certain).toBe(false);
+    });
+
+    it('accepts an explicit service and id', async () => {
+        const withDetails = deps();
+        (withDetails.adapters[0] as unknown as Record<string, unknown>).getMediaDetails = async () => ({
+            service: 'radarr',
+            kind: 'movie',
+            id: '1',
+            title: 'Some Film',
+            ids: { tmdb: 550 }
+        });
+
+        const d = await buildDiagnose(withDetails, { service: 'radarr', id: '1' });
+        expect(d.resolved?.ids).toEqual({ tmdb: 550 });
+    });
+
+    it('diagnoses an explicit id the index does not contain', async () => {
+        // The service holding it may be the one that failed to load. Reporting
+        // the item unknown when the caller just handed us its id would be a
+        // worse answer than diagnosing the half we have.
+        const orphan = deps();
+        (orphan.adapters[0] as unknown as Record<string, unknown>).getMediaDetails = async () => ({
+            service: 'radarr',
+            kind: 'movie',
+            id: '99',
+            title: 'Another Film',
+            monitored: true,
+            hasFile: false,
+            ids: { tmdb: 999 }
+        });
+
+        const d = await buildDiagnose(orphan, { service: 'radarr', id: '99' });
+        expect(d.verdict.stage).not.toBe('resolve');
+        expect(d.resolved?.ids).toEqual({ tmdb: 999 });
+    });
+
+    it('names the parameters when given neither', async () => {
+        await expect(buildDiagnose(deps(), {})).rejects.toThrow(/query.*service.*id/i);
+    });
+
+    it('reports a title it cannot resolve rather than throwing', async () => {
+        // Unlike get_media_details: "we have never heard of this" is a
+        // diagnosis, and the most common one a user starts from.
+        const d = await buildDiagnose(deps(), { query: 'nothing like this' });
+        expect(d.verdict.stage).toBe('resolve');
+    });
+
+    it('stays within budget — a diagnosis is prose, not a list', async () => {
+        const d = await buildDiagnose(deps(), { query: 'some film' });
+        expect(JSON.stringify(d).length).toBeLessThan(4_000);
+    });
+});


### PR DESCRIPTION
Phase 3b, Task 6 of 9. The collector that gathers evidence from a live stack, plus the tool itself. **The surface goes from twelve tools to thirteen**, with `diagnose` first.

Task 5 built the pure reasoning half; this is the impure half. No chain logic is duplicated here — the only judgement the collector makes is which of the three states each probe landed in.

## Three states, everywhere

`undefined` means "could not look". An empty result means "looked and found nothing". A `configured` flag means "the user does not run this service". Collapsing any pair is how a diagnosis becomes confidently wrong, and the queue is the hard case: it spans up to four download clients, so one failing client reports a **partial read** rather than erasing the stage and discarding the stalled row that was the actual cause.

The `configured` flags come from adapter capability, never from whether a probe succeeded — an unreachable Prowlarr is still configured, so the chain refuses to claim "no indexer reported a failure".

A refusal is not a degradation: an authorization error propagates out rather than becoming a degraded stage, because a model told "the service is down" when it was actually refused will retry forever.

## Three confident wrong answers review caught

**A Jellyfin series id diagnosed as an unmanaged movie.** Jellyfin returns `kind: 'item'` for everything — the only adapter that does — and coercing that to `'movie'` made the lookup scan the wrong keyspace and miss a series sitting in the index. It then fabricated a movie with no acquisition half and reported *"Neither Radarr nor Sonarr is managing it"* about a series Sonarr actively manages. A wrong kind turned out to be worse than no kind.

**An explicit service that cannot answer read as "nothing matches".** Only three adapters implement item lookup while the schema accepts all eight, so `service: 'sabnzbd'` produced a confident false negative instead of an error. It now throws the same `NotFound` its sibling tool does.

**Every tmdb-less series silently lost its request stage.** Sonarr emits `{tvdb, imdb}` and never `tmdb`, so on a Sonarr+Seerr stack without Jellyfin *every* series diagnosis recorded "looked and found nothing" when the truth was "could not match" — making a pending, unapproved request invisible and advising "trigger a search", which is the wrong action for something awaiting approval. It now costs certainty and names Seerr as unchecked.

## Also

The requester's name never reaches the evidence or the output — the request *status* answers the question, and naming who asked would expose another household member's activity. Seerr requests match on `tmdbId`, never on title.

Seven tests were added for paths with **zero** coverage, including refusal propagation: every prior fixture built the loader without an identity resolver, so that binding constraint had never been exercised.

**680 tests**, up from 661.

🤖 Generated with [Claude Code](https://claude.com/claude-code)