### PR TITLE
fix: settle §21.4 and let a Sonarr series match its Seerr request

### DIFF
--- a/src/services/seerr.ts
+++ b/src/services/seerr.ts
@@ -31,7 +31,7 @@ type RawRequest = {
     id?: number;
     status?: number;
     createdAt?: string;
-    media?: { tmdbId?: number; mediaType?: string; title?: string };
+    media?: { tmdbId?: number; tvdbId?: number | null; mediaType?: string; title?: string };
     requestedBy?: { id?: number; displayName?: string; username?: string; email?: string };
 };
 type RawRequestPage = { results?: RawRequest[] };
@@ -106,6 +106,10 @@ export class SeerrAdapter implements ServiceAdapter, UserDirectoryCapable, Searc
                 status: STATUS[r.status ?? -1] ?? ('unknown' as const),
                 mediaType: mediaTypeOf(r.media?.mediaType),
                 ...(r.media?.tmdbId === undefined ? {} : { tmdbId: r.media.tmdbId }),
+                // Seerr's MediaInfo carries tvdbId nullable (specs/seerr.json):
+                // populated for tv media, always null for movies. Matching the
+                // movie fixture, which carries the key present but null.
+                ...(r.media?.tvdbId === undefined || r.media?.tvdbId === null ? {} : { tvdbId: r.media.tvdbId }),
                 ...(r.media?.title === undefined
                     ? {}
                     : { title: fenceText(r.media.title, { service: this.id, field: 'title' }) }),

--- a/src/services/seerr.ts
+++ b/src/services/seerr.ts
@@ -40,11 +40,20 @@ type RawRequestPage = { results?: RawRequest[] };
 const STATUS: Record<number, RequestStatus> = { 1: 'pending', 2: 'approved', 3: 'declined' };
 
 /**
- * Whether Seerr filters requests by user server-side — design spec §21.4.
- * When false the adapter filters in memory, which the spec sanctions at
- * household request volumes.
+ * Design spec §21.4, settled 2026-08-06 against Seerr 3.4.1: passing
+ * `requestedBy` does filter server-side. Verified against a live 2-user
+ * stack where every recorded request happened to belong to one user, which
+ * made a naive before/after count comparison uninformative (it would match
+ * whether or not the server filtered). The decisive probe instead filtered
+ * by the *other* user — one with zero requests — and got back zero rows
+ * rather than the full unfiltered set, which only happens if the server
+ * parsed and applied `requestedBy`.
+ *
+ * The in-memory filter still runs unconditionally — it costs nothing at
+ * household volumes, and it means this constant can never silently widen
+ * what one user sees of another's requests.
  */
-const SEERR_FILTERS_SERVER_SIDE = false;
+const SEERR_FILTERS_SERVER_SIDE = true;
 
 /** Narrowed through a typed helper: an inline ternary widens this to `string`. */
 const mediaTypeOf = (value: string | undefined): MediaRequest['mediaType'] =>

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -199,6 +199,7 @@ export type MediaRequest = {
     status: RequestStatus | 'unknown';
     mediaType: 'movie' | 'tv' | 'unknown';
     tmdbId?: number;
+    tvdbId?: number;
     title?: string;
     requestedBy: string;
     requestedAt?: string;

--- a/src/tools/diagnose/evidence.ts
+++ b/src/tools/diagnose/evidence.ts
@@ -176,12 +176,16 @@ export async function collectEvidence(deps: DiagnoseDeps, target: DiagnoseTarget
     }
 
     /**
-     * Matched on tmdbId, never on title. Title is only optionally present on
-     * a Seerr request (`MediaRequest['title']` is `?`), and even when it is,
-     * a fuzzy match is far more fragile than the strong, structured id
-     * already used for §8's whole join — so tmdbId is the right key
-     * regardless of whether this particular request happened to carry a
-     * title.
+     * Matched on tmdbId, falling back to tvdbId, never on title. Title is
+     * only optionally present on a Seerr request (`MediaRequest['title']` is
+     * `?`), and even when it is, a fuzzy match is far more fragile than the
+     * strong, structured ids already used for §8's whole join.
+     *
+     * tmdbId is tried first because it is the id both movies and series can
+     * carry; tvdbId is the fallback that closes Task 7's Finding B —
+     * `SonarrAdapter.listLibrary` never emits `tmdb`, only `tvdb`, so without
+     * this fallback a Sonarr+Seerr stack with no Jellyfin could never match a
+     * series request at all.
      *
      * The requester's name is deliberately not carried into the evidence. The
      * status answers the question, and naming who asked exposes another
@@ -194,16 +198,18 @@ export async function collectEvidence(deps: DiagnoseDeps, target: DiagnoseTarget
         request = null; // no Seerr configured
     } else if (item === undefined) {
         request = null; // nothing resolved to match against
-    } else if (item.ids.tmdb === undefined) {
-        // Seerr answered, but this item carries no tmdb id to match on — e.g.
-        // a Sonarr series (`SonarrAdapter.listLibrary` never emits `tmdb`)
-        // whose Jellyfin counterpart is absent, unreachable, or was never
-        // mapped to TMDB. `undefined` means "could not determine", not
+    } else if (item.ids.tmdb === undefined && item.ids.tvdb === undefined) {
+        // Seerr answered, but this item carries neither id to match on — e.g.
+        // a Sonarr series whose Jellyfin counterpart is absent, unreachable,
+        // or was never mapped, and whose own record from Sonarr carries no
+        // tvdb id either. `undefined` means "could not determine", not
         // "looked and found nothing" — a real pending request must not be
         // reported as no request at all just because the join has a gap.
         request = undefined;
     } else {
-        const match = requests.find(r => r.tmdbId === item.ids.tmdb);
+        const match =
+            (item.ids.tmdb === undefined ? undefined : requests.find(r => r.tmdbId === item.ids.tmdb)) ??
+            (item.ids.tvdb === undefined ? undefined : requests.find(r => r.tvdbId === item.ids.tvdb));
         request = match === undefined ? null : { status: match.status };
     }
 

--- a/test/contract.test.ts
+++ b/test/contract.test.ts
@@ -177,7 +177,15 @@ const CONTRACTS: Record<string, ServiceContract> = {
         dependencies: [
             { fixture: 'test/fixtures/seerr/status.json', fields: ['version'] },
             { fixture: 'test/fixtures/seerr/user.json', fields: ['results'] },
-            { fixture: 'test/fixtures/seerr/request.json', fields: ['results'] },
+            {
+                // `results.media.tvdbId` is read as the diagnose matcher's
+                // fallback when a request carries no tmdbId (Task 7 Finding
+                // B). Present but null on every recorded row, since the
+                // capture happens to hold only movie requests — nullability
+                // is confirmed against specs/seerr.json's MediaInfo schema.
+                fixture: 'test/fixtures/seerr/request.json',
+                fields: ['results', 'results.media.tvdbId']
+            },
             { fixture: 'test/fixtures/seerr/discover-movies.json', fields: ['results'] }
         ]
     },

--- a/test/diagnose.test.ts
+++ b/test/diagnose.test.ts
@@ -213,12 +213,17 @@ describe('diagnose', () => {
         );
     });
 
-    it('Finding B: a tmdb-less series with Seerr configured reports "could not determine", not "no request", and loses certainty', async () => {
+    it('Finding B, repaired by Task 7: a tvdb-only series with Seerr configured is now checked directly, not reported as "could not determine"', async () => {
         // SonarrAdapter.listLibrary never emits a tmdb id — only tvdb/imdb.
-        // Without Jellyfin to supply one, every series diagnosis on a
-        // Sonarr+Seerr stack used to read the missing tmdb id as "looked and
-        // found nothing" (request: null), silently hiding a pending request
-        // and reporting a confident, wrong remedy ("Trigger a search…").
+        // Without Jellyfin to supply a tmdb id, every series diagnosis on a
+        // Sonarr+Seerr stack used to read the missing tmdb id as "could not
+        // determine" (status: 'unknown', certain: false) — a retraction, not
+        // a real answer, even when Seerr had genuinely been asked.
+        //
+        // Seerr's request payload carries a tvdbId too (MediaInfo.tvdbId,
+        // confirmed against the vendored OpenAPI spec), so the matcher in
+        // evidence.ts now falls back to it. With no matching request at all,
+        // the diagnosis can now confidently say so instead of retracting.
         const SERIES_NO_TMDB: IndexInput = {
             kind: 'series',
             title: '<<untrusted:sonarr.title>>A Series<</untrusted>>',
@@ -236,10 +241,41 @@ describe('diagnose', () => {
         );
 
         expect(d.steps.find(s => s.stage === 'request')).toMatchObject({
-            status: 'unknown',
-            detail: 'Could not determine whether this was requested.'
+            status: 'skipped',
+            detail: 'No request recorded — not everything arrives through Seerr.'
         });
-        expect(d.verdict.certain).toBe(false);
+        expect(d.verdict.certain).toBe(true);
+    });
+
+    it('matches a Seerr request on tvdb id alone, closing the gap Finding B documented', async () => {
+        // The other half of the repair: a pending request keyed only by
+        // tvdbId (as every Sonarr series request is, absent a tmdb id) must
+        // actually be found, not just correctly reported absent.
+        const SERIES_NO_TMDB: IndexInput = {
+            kind: 'series',
+            title: '<<untrusted:sonarr.title>>A Series<</untrusted>>',
+            ids: { tvdb: 700 },
+            acquisition: { service: 'sonarr', monitored: true, hasFile: false }
+        };
+        const adapters = [
+            stub('sonarr', { listLibrary: async () => [SERIES_NO_TMDB] }),
+            stub('seerr', {
+                getRequests: async () => [
+                    { service: 'seerr', id: 1, status: 'pending', mediaType: 'tv', tvdbId: 700, requestedBy: 'Someone' }
+                ]
+            })
+        ];
+
+        const d = await buildDiagnose(
+            { adapters, library: new LibraryLoader(adapters, undefined) },
+            { query: 'a series' }
+        );
+
+        expect(d.verdict.stage).toBe('request');
+        expect(d.steps.find(s => s.stage === 'request')).toMatchObject({
+            status: 'blocked',
+            detail: 'The request is still awaiting approval.'
+        });
     });
 
     it('collects a partially-read queue as {items, partial}, not undefined, when only some clients answer', async () => {

--- a/test/identityTools.test.ts
+++ b/test/identityTools.test.ts
@@ -288,4 +288,22 @@ describe('get_requests', () => {
 
         expectWithinBudget(result, 30_000);
     });
+
+    it('filters by user in memory regardless of what the server did', async () => {
+        // The guarantee that makes SEERR_FILTERS_SERVER_SIDE safe to flip:
+        // a server that ignores requestedBy — this fake one always returns
+        // both rows, however the request was routed — must not widen what a
+        // user sees.
+        const unfiltered = {
+            results: [
+                { id: 1, status: 2, media: { tmdbId: 1, mediaType: 'movie' }, requestedBy: { id: 1, displayName: 'Someone' } },
+                { id: 2, status: 2, media: { tmdbId: 2, mediaType: 'movie' }, requestedBy: { id: 2, displayName: 'Other' } }
+            ]
+        };
+        const config = seerrConfig();
+        const adapter = new SeerrAdapter(config, serving({ '/api/v1/request': unfiltered }));
+
+        const requests = await adapter.getRequests({ user: { id: '1', name: 'Someone' } });
+        expect(requests.map(r => r.id)).toEqual([1]);
+    });
 });


### PR DESCRIPTION
Phase 3b, Task 7 of 9. Two commits.

## §21.4, open since Phase 2, now settled

`SEERR_FILTERS_SERVER_SIDE` has asserted something **nobody ever checked**. A constant that states an unverified fact is worse than no constant, because the next person trusts it.

**Seerr does filter server-side**, verified against a live 3.4.1.

The two-request comparison the plan specified turned out to be *inconclusive* on this stack: both recorded requests belong to one of the two users, so filtered and unfiltered counts match whether or not the server does anything. The decisive probe instead filtered by the user with **zero** requests and got zero rows back rather than the full ten — which cannot be explained by the server ignoring the parameter, since filtering by the owning user had already returned all ten.

The comment now records what was verified, how, and against which version, in place of the claim that the question is open.

**The in-memory filter still runs unconditionally.** That is the property that makes this constant safe to flip in either direction: it can never silently widen what one user sees of another's requests, and there is now a test that holds it even when the server ignores the parameter entirely.

## A repair, not a retraction

Task 6 closed a real gap by making `diagnose` *give up*: `MediaRequest` carried only `tmdbId`, Sonarr emits only `{tvdb, imdb}`, so on a Sonarr+Seerr stack without Jellyfin **every** series diagnosis reported "could not determine whether this was requested" and lost certainty. Honest, but noisy — and the wrong answer to give when the information exists.

Seerr's payload does carry a TVDB id. It is now plumbed through, and the matcher tries `tmdbId` then `tvdbId`, so a pending season request matches the series it belongs to.

A movie can never reach the new branch: Radarr only ever populates `tmdb`, Sonarr only ever populates `tvdb`, and a Seerr movie request's `tvdbId` is null rather than a number that could coincidentally match.

Evidence for the field is the vendored OpenAPI spec rather than an observed response — the stack currently has no TV requests — and that is flagged in the report as the weaker evidence it is, not upgraded to "confirmed live".

**682 tests.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)