### PR TITLE
chore: add the integration script, and fix what it found

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -70,7 +70,8 @@ A phase that ships without its README change is not finished.
 
 - [ ] `git log --oneline origin/main` contains everything you think the release does
 - [ ] `docker run` the published tag against a real stack, not just the build
-- [ ] An MCP client lists the expected tool count and **calls every one of them**
+- [ ] `npm run integration` — calls every tool against a real stack and fails
+      if any tool has no case at all
 - [ ] `/healthz` responds, and an unauthenticated `/mcp` request is rejected
 
 Calling every tool matters more than it sounds. Adapters are tested against
@@ -78,6 +79,11 @@ recorded fixtures, which prove the mapping and nothing else. Every defect that
 reached 0.3.0 — a null field crashing a tool, a query parameter that has to be
 asked for, an endpoint that answers 400 — was invisible to 396 passing tests
 and obvious within seconds of a real call.
+
+`npm run integration` is the mechanical form of "call every tool". It fails
+when `TOOL_NAMES` gains a tool no case covers, so a new tool cannot ship
+uncalled — which is exactly how 0.3.0 shipped a `get_subtitles` that crashed
+on the first real request.
 
 ## Recapture fixtures when an adapter starts reading a new endpoint
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test:watch": "vitest",
     "specs:fetch": "bash scripts/fetch-specs.sh",
     "codegen": "node scripts/codegen.mjs",
-    "capture": "node scripts/capture-fixtures.ts"
+    "capture": "node scripts/capture-fixtures.ts",
+    "integration": "node scripts/integration.ts"
   },
   "dependencies": {
     "@hono/node-server": "^2.1.0",

--- a/scripts/capture-fixtures.ts
+++ b/scripts/capture-fixtures.ts
@@ -15,6 +15,7 @@ import { loadConfig } from '../src/config/load.ts';
 import type { Config, ServiceId } from '../src/config/schema.ts';
 import { apiKeyHeader, embyToken, queryParamKey, transmissionRpc, type AuthStrategy } from '../src/core/auth.ts';
 import { ServiceHttp } from '../src/core/http.ts';
+import { hostsOf, redactHosts } from './lib/redact.ts';
 
 const REDACTED = '__REDACTED__';
 
@@ -310,29 +311,11 @@ function strategyFor(id: ServiceId, service: NonNullable<Config['services'][Serv
 
 const ANONYMOUS_HOST = 'service.example.test';
 
-/**
- * Every host the user configured — hostname and host:port both, longest first
- * so `10.0.0.1:7878` is replaced before the bare `10.0.0.1` inside it.
- *
- * Substituting the configured values exactly, rather than pattern-matching for
- * anything IP-shaped, means no false positives: an *arr version like
- * `6.3.0.10514` is four dot-separated numbers and would match a naive IPv4
- * regex.
- */
-function hostsOf(config: Config): string[] {
-    const out = new Set<string>();
-    for (const service of Object.values(config.services)) {
-        if (service === undefined) continue;
-        try {
-            const url = new URL((service as { url: string }).url);
-            out.add(url.host);
-            out.add(url.hostname);
-        } catch {
-            // A url that does not parse cannot appear in a response either.
-        }
-    }
-    return [...out].sort((a, b) => b.length - a.length);
-}
+// `hostsOf` is shared with `integration.ts` (`scripts/lib/redact.ts`) — both
+// scripts need the same "every host the user configured" list, one to
+// anonymise fixture files, the other to keep a live error message off the
+// terminal, and a second hand-written copy is exactly the kind of drift this
+// phase exists to eliminate.
 
 /** Every configured credential, so the post-write scan can look for them exactly. */
 function secretsOf(config: Config): string[] {
@@ -439,7 +422,13 @@ for (const [id, service] of Object.entries(config.services) as [ServiceId, Confi
         } catch (err) {
             // A missing endpoint is information, not a failure: it tells us the
             // service does not have that capability. Record and continue.
-            console.warn(`skipped  ${id}/${endpoint.name}: ${(err as Error).message}`);
+            //
+            // `classifyFetchError` (src/core/errors.ts) deliberately embeds the
+            // host in a Timeout/Unreachable ServiceError's own `.message` — the
+            // fixture-writing path below never sees that (it redacts hosts out
+            // of *captured response bodies*), but this line prints the error
+            // itself, straight to the terminal, unredacted otherwise.
+            console.warn(`skipped  ${id}/${endpoint.name}: ${redactHosts((err as Error).message, hosts)}`);
             skipped += 1;
         }
     }

--- a/scripts/integration.ts
+++ b/scripts/integration.ts
@@ -9,29 +9,49 @@
  *
  *     ARR_MCP_CONFIG_DIR=./config npm run integration
  *
- * Credential handling: this script reads a live config with real API keys.
- * It never prints a value out of that config — only tool names, counts,
- * latencies, and each tool's own summary line (titles, ids and pass/fail
- * text, never a key, token or service URL).
+ * Calls go through `buildApp` (`src/app.ts`) — the same `McpServer` and the
+ * same `tools/call` JSON-RPC dispatch a real MCP client hits — driven
+ * in-process via Hono's `app.request()`, exactly as `test/app.test.ts`
+ * already does. No listening port, but no hand-rolled reimplementation of
+ * the SDK's own argument parsing/defaulting and error-to-`isError` wrapping
+ * either: an earlier version of this script called each tool's handler
+ * directly against a stub `registerTool`, which meant every one of those
+ * behaviours had to be reproduced by hand to get a truthful result — and one
+ * (schema defaults) was missed on the first pass. Going through the real
+ * dispatch removes that whole class of drift.
+ *
+ * Credential handling: this script reads a live config with real API keys
+ * and sends the real bearer token as `Authorization` on every call. It never
+ * prints a header, a key, or a token. It does print each tool's own summary
+ * line, which normally contains only titles, ids and counts — except that a
+ * live connectivity failure's message deliberately embeds the failing
+ * service's *host* (`classifyFetchError` in `src/core/errors.ts`, by
+ * design — a model diagnosing a dead connection needs to know where it
+ * failed). That is fine for the tool's real caller, but not for this
+ * script's stricter promise never to print a service URL, so every printed
+ * line — pass or fail — is passed through `redactHosts` first.
  */
-import type { McpServer } from '@modelcontextprotocol/server';
-import * as z from 'zod/v4';
 import { loadConfig } from '../src/config/load.ts';
 import { buildAdapters } from '../src/services/registry.ts';
-import { buildToolContext, registerAllTools, TOOL_NAMES } from '../src/tools/register.ts';
+import { buildApp } from '../src/app.ts';
+import { TOOL_NAMES } from '../src/tools/register.ts';
+import { hostsOf, redactHosts } from './lib/redact.ts';
 
 type ToolName = (typeof TOOL_NAMES)[number];
 type Case = { tool: ToolName; args: Record<string, unknown> };
-type ToolResult = { content?: { text?: string }[]; structuredContent?: unknown };
+type ToolCallResult = { isError?: boolean; content?: { type: string; text?: string }[]; structuredContent?: unknown };
 
 /**
  * Arguments chosen to exercise the path a user actually takes, not the
  * cheapest one. `detail: 'full'` on at least one call per tool, because that
  * is the level whose extra fields are the ones adapters get wrong.
  *
- * get_library gets three calls — its documented filters (§5: presence,
+ * get_library gets several calls — its documented filters (§5: presence,
  * min_rating, kind) each take a different code path through the join, and a
- * fixture-only test would never exercise more than one of them for real.
+ * fixture-only test would never exercise more than one of them for real. The
+ * metacritic/rottenTomatoes pair is a standing regression case: those two
+ * sources arrive on a 0-100 scale while `min_rating` is documented 0-10, and
+ * before that was fixed they matched every rated film regardless of score.
  */
 const CASES: Case[] = [
     { tool: 'stack_health', args: { detail: 'full' } },
@@ -50,10 +70,6 @@ const CASES: Case[] = [
     { tool: 'get_library', args: { presence: 'arr_only', limit: 10 } },
     { tool: 'get_library', args: { min_rating: 8, limit: 5 } },
     { tool: 'get_library', args: { kind: 'movie', limit: 5 } },
-    // A regression guard for the cross-source rating scale defect: metacritic
-    // and rottenTomatoes arrive on a 0-100 scale, everything else on 0-10.
-    // Before the fix these two returned every rated film — "rated at all"
-    // silently read as "rated 8+".
     { tool: 'get_library', args: { min_rating: 8, rating_source: 'metacritic', limit: 5 } },
     { tool: 'get_library', args: { min_rating: 8, rating_source: 'rottenTomatoes', limit: 5 } },
     { tool: 'get_media_details', args: { query: 'the' } },
@@ -64,45 +80,18 @@ const CASES: Case[] = [
 ];
 
 // Same env var src/index.ts uses, so this reads the config the container
-// does. The default differs from src/index.ts's `/config`, though: that
-// default is right for the container, where the volume is always mounted
-// there, but wrong for a maintainer running this from a checkout — `/config`
-// resolves outside the repo entirely (on Windows, to a different drive root).
-// `./config` is the local-checkout default the capture script already
-// established under its own env var, so this follows that convention rather
-// than the container one.
+// does — but a different default. src/index.ts defaults to `/config`, which
+// is right for the container, where the volume is always mounted there; it
+// is wrong for a maintainer running this from a checkout, where `/config`
+// resolves outside the repo entirely (on Windows, to a different drive
+// root). `./config` matches capture-fixtures.ts's own local-checkout
+// default, under its own env var, for the same reason.
 const CONFIG_DIR = process.env.ARR_MCP_CONFIG_DIR ?? './config';
 const { config } = await loadConfig(CONFIG_DIR);
 
 const adapters = buildAdapters(config);
-const context = buildToolContext(adapters, config);
-
-/**
- * Registering against a recording stub is what lets this call the handlers
- * directly, without an MCP client or a listening port. The real server
- * parses every call's arguments through the tool's own `inputSchema` before
- * the handler ever sees them — that is where a `detail`/`limit` default
- * (`standard`/`50`) actually gets applied. Skipping that step here would
- * make every case that omits an optional field fail silently: `applyLimit`
- * fed a genuinely undefined limit returns zero items, which is precisely the
- * false "0 of N" this script exists to tell apart from a real one. So the
- * stub captures each tool's schema alongside its handler and parses through
- * it before every call, the same as a real client would.
- */
-type Registered = { schema: z.ZodTypeAny; handler: (args: Record<string, unknown>) => Promise<ToolResult> };
-const handlers = new Map<string, Registered>();
-const server = {
-    registerTool: (
-        name: string,
-        meta: { inputSchema?: z.ZodTypeAny },
-        handler: (a: Record<string, unknown>) => Promise<ToolResult>
-    ) => {
-        if (meta.inputSchema === undefined) throw new Error(`${name} registered with no inputSchema`);
-        handlers.set(name, { schema: meta.inputSchema, handler });
-    }
-};
-
-registerAllTools(server as unknown as McpServer, context);
+const app = buildApp({ config, adapters });
+const hosts = hostsOf(config);
 
 const missing = TOOL_NAMES.filter(name => !CASES.some(c => c.tool === name));
 if (missing.length > 0) {
@@ -112,36 +101,78 @@ if (missing.length > 0) {
     process.exitCode = 1;
 }
 
+let nextId = 1;
+
+/**
+ * One `tools/call` JSON-RPC request, in-process through Hono — no listening
+ * port. Throws on any transport- or protocol-level failure (a non-2xx HTTP
+ * status, an unparsable body, or a JSON-RPC `error`); a tool-level failure is
+ * not one of these — it comes back as a normal 200 with `isError: true`,
+ * which the caller inspects.
+ */
+async function callTool(name: string, args: Record<string, unknown>): Promise<ToolCallResult> {
+    const res = await app.request('http://localhost:6060/mcp', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json, text/event-stream',
+            Authorization: `Bearer ${config.auth.bearer_token}`
+        },
+        body: JSON.stringify({ jsonrpc: '2.0', id: nextId++, method: 'tools/call', params: { name, arguments: args } })
+    });
+
+    const text = await res.text();
+    if (!res.ok) throw new Error(`transport error: HTTP ${res.status}`);
+
+    // The SDK may frame the body as SSE rather than plain JSON; the payload
+    // is always the one top-level JSON object in it. Same approach
+    // test/app.test.ts's rpcPayload() uses.
+    const start = text.indexOf('{');
+    const end = text.lastIndexOf('}');
+    if (start === -1 || end === -1) throw new Error('transport error: no JSON-RPC payload in the response body');
+
+    const payload = JSON.parse(text.slice(start, end + 1)) as { result?: ToolCallResult; error?: { message?: string } };
+    if (payload.error !== undefined) throw new Error(`protocol error: ${payload.error.message ?? 'unnamed'}`);
+    if (payload.result === undefined) throw new Error('protocol error: no result in the response');
+    return payload.result;
+}
+
 let passes = 0;
 let failures = 0;
 
 /** Runs one case, printing PASS/FAIL with latency and the tool's own summary line. */
-async function run(tool: string, args: Record<string, unknown>, note?: string): Promise<ToolResult | undefined> {
+async function run(tool: string, args: Record<string, unknown>, note?: string): Promise<ToolCallResult | undefined> {
     const label = `${tool} ${JSON.stringify(args)}${note === undefined ? '' : ` — ${note}`}`;
-    const registered = handlers.get(tool);
-    if (registered === undefined) {
-        console.error(`FAIL ${label} — not registered`);
-        failures += 1;
-        return undefined;
-    }
-
     const started = performance.now();
+
     try {
-        const parsed = registered.schema.parse(args) as Record<string, unknown>;
-        const result = await registered.handler(parsed);
+        const result = await callTool(tool, args);
         const ms = Math.round(performance.now() - started);
-        console.log(`PASS ${label} (${ms}ms) — ${result.content?.[0]?.text ?? ''}`);
+        const text = redactHosts(result.content?.[0]?.text ?? '', hosts);
+
+        if (result.isError === true) {
+            console.error(`FAIL ${label} (${ms}ms) — ${text}`);
+            failures += 1;
+            return undefined;
+        }
+        console.log(`PASS ${label} (${ms}ms) — ${text}`);
         passes += 1;
         return result;
     } catch (err) {
-        console.error(`FAIL ${label} — ${(err as Error).message}`);
+        // Latency here is exactly as diagnostic as on a pass: it tells apart a
+        // fast validation error from a multi-second timeout. Hosts get
+        // redacted here too — this is where classifyFetchError's Timeout/
+        // Unreachable message (which embeds one by design) would otherwise
+        // reach the terminal unfiltered.
+        const ms = Math.round(performance.now() - started);
+        console.error(`FAIL ${label} (${ms}ms) — ${redactHosts((err as Error).message, hosts)}`);
         failures += 1;
         return undefined;
     }
 }
 
-let libraryResult: ToolResult | undefined;
-let searchResult: ToolResult | undefined;
+let libraryResult: ToolCallResult | undefined;
+let searchResult: ToolCallResult | undefined;
 
 for (const { tool, args } of CASES) {
     const result = await run(tool, args);
@@ -154,7 +185,7 @@ for (const { tool, args } of CASES) {
  * single generic query does not exercise the chain the way a maintainer
  * actually would: a title that resolves, one that plainly does not, an
  * explicit service+id (the form get_media_details hands back for a join that
- * looks wrong), and — when the library actually has one — an item Present on
+ * looks wrong), and — when the library actually has one — an item present on
  * one side and not the other, which is the case diagnose exists to explain.
  */
 type LibraryItemLike = { title?: unknown; presence?: unknown };
@@ -194,4 +225,10 @@ if (brokenTitle !== undefined) {
 }
 
 console.log(`\n${passes}/${passes + failures} calls succeeded.`);
+if (missing.length > 0) {
+    // Repeated here, not just at the top: a maintainer skimming only the last
+    // line — the one that matters most — must not be able to miss this even
+    // though the exit code (already set above) reflects it either way.
+    console.error(`No case covers: ${missing.join(', ')} — exit code reflects this even though every call above passed.`);
+}
 process.exitCode = failures > 0 ? 1 : process.exitCode;

--- a/scripts/integration.ts
+++ b/scripts/integration.ts
@@ -1,0 +1,191 @@
+/**
+ * Calls every tool against a live stack and reports pass or fail per tool.
+ * Maintainer-run, never CI — it needs real services and a real config.
+ *
+ * This is not busywork. Fixtures prove the mapping and nothing else: the
+ * defects that reached 0.3.0 were a null field crashing a tool outright, a
+ * query parameter that has to be asked for, and an endpoint that answers 400.
+ * All three were invisible to the unit suite and obvious within seconds here.
+ *
+ *     ARR_MCP_CONFIG_DIR=./config npm run integration
+ *
+ * Credential handling: this script reads a live config with real API keys.
+ * It never prints a value out of that config — only tool names, counts,
+ * latencies, and each tool's own summary line (titles, ids and pass/fail
+ * text, never a key, token or service URL).
+ */
+import type { McpServer } from '@modelcontextprotocol/server';
+import * as z from 'zod/v4';
+import { loadConfig } from '../src/config/load.ts';
+import { buildAdapters } from '../src/services/registry.ts';
+import { buildToolContext, registerAllTools, TOOL_NAMES } from '../src/tools/register.ts';
+
+type ToolName = (typeof TOOL_NAMES)[number];
+type Case = { tool: ToolName; args: Record<string, unknown> };
+type ToolResult = { content?: { text?: string }[]; structuredContent?: unknown };
+
+/**
+ * Arguments chosen to exercise the path a user actually takes, not the
+ * cheapest one. `detail: 'full'` on at least one call per tool, because that
+ * is the level whose extra fields are the ones adapters get wrong.
+ *
+ * get_library gets three calls — its documented filters (§5: presence,
+ * min_rating, kind) each take a different code path through the join, and a
+ * fixture-only test would never exercise more than one of them for real.
+ */
+const CASES: Case[] = [
+    { tool: 'stack_health', args: { detail: 'full' } },
+    { tool: 'get_indexers', args: { detail: 'full' } },
+    { tool: 'get_subtitles', args: { detail: 'full', limit: 100 } },
+    { tool: 'get_queue', args: { detail: 'full' } },
+    // The brief's case used `days: 14`, a field this schema does not have —
+    // get_calendar takes `days_back` and `days_ahead` separately. Using the
+    // brief's field name would silently no-op back to the defaults (7/14)
+    // rather than fail, which is exactly the kind of thing this script exists
+    // to catch, so it is fixed here rather than reproduced.
+    { tool: 'get_calendar', args: { detail: 'full', days_back: 14, days_ahead: 14 } },
+    { tool: 'get_playback', args: { detail: 'full' } },
+    { tool: 'get_requests', args: { detail: 'full' } },
+    { tool: 'get_library', args: { detail: 'standard', limit: 10 } },
+    { tool: 'get_library', args: { presence: 'arr_only', limit: 10 } },
+    { tool: 'get_library', args: { min_rating: 8, limit: 5 } },
+    { tool: 'get_library', args: { kind: 'movie', limit: 5 } },
+    { tool: 'get_media_details', args: { query: 'the' } },
+    { tool: 'search_media', args: { query: 'the', source: 'library', detail: 'full', limit: 10 } },
+    { tool: 'lookup_media', args: { query: 'matrix' } },
+    { tool: 'discover_media', args: { media_type: 'movie', detail: 'full' } },
+    { tool: 'diagnose', args: { query: 'the' } }
+];
+
+// Same env var src/index.ts uses, so this reads the config the container
+// does. The default differs from src/index.ts's `/config`, though: that
+// default is right for the container, where the volume is always mounted
+// there, but wrong for a maintainer running this from a checkout — `/config`
+// resolves outside the repo entirely (on Windows, to a different drive root).
+// `./config` is the local-checkout default the capture script already
+// established under its own env var, so this follows that convention rather
+// than the container one.
+const CONFIG_DIR = process.env.ARR_MCP_CONFIG_DIR ?? './config';
+const { config } = await loadConfig(CONFIG_DIR);
+
+const adapters = buildAdapters(config);
+const context = buildToolContext(adapters, config);
+
+/**
+ * Registering against a recording stub is what lets this call the handlers
+ * directly, without an MCP client or a listening port. The real server
+ * parses every call's arguments through the tool's own `inputSchema` before
+ * the handler ever sees them — that is where a `detail`/`limit` default
+ * (`standard`/`50`) actually gets applied. Skipping that step here would
+ * make every case that omits an optional field fail silently: `applyLimit`
+ * fed a genuinely undefined limit returns zero items, which is precisely the
+ * false "0 of N" this script exists to tell apart from a real one. So the
+ * stub captures each tool's schema alongside its handler and parses through
+ * it before every call, the same as a real client would.
+ */
+type Registered = { schema: z.ZodTypeAny; handler: (args: Record<string, unknown>) => Promise<ToolResult> };
+const handlers = new Map<string, Registered>();
+const server = {
+    registerTool: (
+        name: string,
+        meta: { inputSchema?: z.ZodTypeAny },
+        handler: (a: Record<string, unknown>) => Promise<ToolResult>
+    ) => {
+        if (meta.inputSchema === undefined) throw new Error(`${name} registered with no inputSchema`);
+        handlers.set(name, { schema: meta.inputSchema, handler });
+    }
+};
+
+registerAllTools(server as unknown as McpServer, context);
+
+const missing = TOOL_NAMES.filter(name => !CASES.some(c => c.tool === name));
+if (missing.length > 0) {
+    // Counting tools is not calling them — the check RELEASING.md added after
+    // 0.3.0, made mechanical.
+    console.error(`No case covers: ${missing.join(', ')}`);
+    process.exitCode = 1;
+}
+
+let passes = 0;
+let failures = 0;
+
+/** Runs one case, printing PASS/FAIL with latency and the tool's own summary line. */
+async function run(tool: string, args: Record<string, unknown>, note?: string): Promise<ToolResult | undefined> {
+    const label = `${tool} ${JSON.stringify(args)}${note === undefined ? '' : ` — ${note}`}`;
+    const registered = handlers.get(tool);
+    if (registered === undefined) {
+        console.error(`FAIL ${label} — not registered`);
+        failures += 1;
+        return undefined;
+    }
+
+    const started = performance.now();
+    try {
+        const parsed = registered.schema.parse(args) as Record<string, unknown>;
+        const result = await registered.handler(parsed);
+        const ms = Math.round(performance.now() - started);
+        console.log(`PASS ${label} (${ms}ms) — ${result.content?.[0]?.text ?? ''}`);
+        passes += 1;
+        return result;
+    } catch (err) {
+        console.error(`FAIL ${label} — ${(err as Error).message}`);
+        failures += 1;
+        return undefined;
+    }
+}
+
+let libraryResult: ToolResult | undefined;
+let searchResult: ToolResult | undefined;
+
+for (const { tool, args } of CASES) {
+    const result = await run(tool, args);
+    if (tool === 'get_library' && args.detail === 'standard') libraryResult = result;
+    if (tool === 'search_media') searchResult = result;
+}
+
+/**
+ * diagnose's verdict and remedy are the product this phase built, and a
+ * single generic query does not exercise the chain the way a maintainer
+ * actually would: a title that resolves, one that plainly does not, an
+ * explicit service+id (the form get_media_details hands back for a join that
+ * looks wrong), and — when the library actually has one — an item Present on
+ * one side and not the other, which is the case diagnose exists to explain.
+ */
+type LibraryItemLike = { title?: unknown; presence?: unknown };
+type SearchHitLike = { service?: unknown; id?: unknown };
+
+const libraryItems = ((libraryResult?.structuredContent as { items?: unknown[] } | undefined)?.items ??
+    []) as LibraryItemLike[];
+// Prefers an item present on both sides, so the "exists" case is a genuinely
+// different scenario from the "broken" one below rather than coincidentally
+// landing on the same item — get_library's own ordering put a presence:
+// arr_only item first often enough that picking items[0] unconditionally
+// tested the same title twice.
+const completeItem = libraryItems.find(i => i.presence === 'both') ?? libraryItems[0];
+const existingTitle = typeof completeItem?.title === 'string' ? completeItem.title : undefined;
+const brokenItem = libraryItems.find(i => i.presence === 'arr_only' || i.presence === 'jellyfin_only');
+const brokenTitle = typeof brokenItem?.title === 'string' ? brokenItem.title : undefined;
+
+const searchHit = (searchResult?.structuredContent as { items?: unknown[] } | undefined)?.items?.[0] as
+    | SearchHitLike
+    | undefined;
+
+if (existingTitle !== undefined) {
+    await run('diagnose', { query: existingTitle }, 'a title that exists');
+}
+await run('diagnose', { query: 'zzz-not-a-real-title-9f3k2q' }, 'a title that does not exist');
+
+if (typeof searchHit?.service === 'string' && searchHit.id !== undefined) {
+    await run('diagnose', { service: searchHit.service, id: String(searchHit.id) }, 'explicit service+id');
+} else {
+    console.log('SKIP diagnose explicit service+id — search_media returned no library hit to take one from.');
+}
+
+if (brokenTitle !== undefined) {
+    await run('diagnose', { query: brokenTitle }, 'presence disagrees between services — genuinely broken');
+} else {
+    console.log('SKIP diagnose "genuinely broken" case — no arr_only/jellyfin_only item in the sampled library.');
+}
+
+console.log(`\n${passes}/${passes + failures} calls succeeded.`);
+process.exitCode = failures > 0 ? 1 : process.exitCode;

--- a/scripts/integration.ts
+++ b/scripts/integration.ts
@@ -50,6 +50,12 @@ const CASES: Case[] = [
     { tool: 'get_library', args: { presence: 'arr_only', limit: 10 } },
     { tool: 'get_library', args: { min_rating: 8, limit: 5 } },
     { tool: 'get_library', args: { kind: 'movie', limit: 5 } },
+    // A regression guard for the cross-source rating scale defect: metacritic
+    // and rottenTomatoes arrive on a 0-100 scale, everything else on 0-10.
+    // Before the fix these two returned every rated film — "rated at all"
+    // silently read as "rated 8+".
+    { tool: 'get_library', args: { min_rating: 8, rating_source: 'metacritic', limit: 5 } },
+    { tool: 'get_library', args: { min_rating: 8, rating_source: 'rottenTomatoes', limit: 5 } },
     { tool: 'get_media_details', args: { query: 'the' } },
     { tool: 'search_media', args: { query: 'the', source: 'library', detail: 'full', limit: 10 } },
     { tool: 'lookup_media', args: { query: 'matrix' } },

--- a/scripts/lib/redact.ts
+++ b/scripts/lib/redact.ts
@@ -1,0 +1,39 @@
+/**
+ * Host redaction shared by the maintainer scripts that print a live error
+ * message to the terminal (`capture-fixtures.ts`, `integration.ts`).
+ *
+ * `classifyFetchError` (`src/core/errors.ts`) deliberately embeds the
+ * configured host in `ServiceError.message` for the Timeout/Unreachable
+ * cases — the right choice for a model reading a tool result, which needs to
+ * know *where* the connection failed. It is the wrong choice for these
+ * scripts' own, stricter promise never to print a service URL to a
+ * maintainer's terminal, so any raw error text they print is passed through
+ * `redactHosts` first.
+ */
+import type { Config } from '../../src/config/schema.ts';
+
+const PLACEHOLDER = '<configured-host>';
+
+/**
+ * Every host the user configured — hostname and host:port both, longest
+ * first so `10.0.0.1:7878` is replaced before the bare `10.0.0.1` inside it.
+ */
+export function hostsOf(config: Config): string[] {
+    const out = new Set<string>();
+    for (const service of Object.values(config.services)) {
+        if (service === undefined) continue;
+        try {
+            const url = new URL((service as { url: string }).url);
+            out.add(url.host);
+            out.add(url.hostname);
+        } catch {
+            // A url that does not parse cannot appear in a message either.
+        }
+    }
+    return [...out].sort((a, b) => b.length - a.length);
+}
+
+/** Replaces every configured host with a placeholder, wherever it appears in `text`. */
+export function redactHosts(text: string, hosts: readonly string[]): string {
+    return hosts.reduce((acc, host) => acc.split(host).join(PLACEHOLDER), text);
+}

--- a/src/tools/getLibrary.ts
+++ b/src/tools/getLibrary.ts
@@ -14,6 +14,38 @@ export type RatingSource = (typeof RATING_SOURCES)[number];
 /** Films only. `tvdb` is Sonarr's flat value and belongs to series alone (§21.2). */
 const FILM_SOURCES: readonly RatingSource[] = ['imdb', 'tmdb', 'trakt', 'metacritic', 'rottenTomatoes'];
 
+/**
+ * The scale each source's raw value arrives on. `min_rating` is documented as
+ * 0–10 for every source, but Radarr/Sonarr pass Metacritic and Rotten Tomatoes
+ * through on their own site's native 0–100 scale, and nothing upstream of
+ * this filter rescales them — `flattenRatings`/`toMergedRatings`
+ * (`src/services/arrRatings.ts`) store exactly what the *arr reported.
+ *
+ * Comparing a raw 64 or 82 against an 0–10 `min_rating` threshold makes
+ * "rated at all" read as "rated 8+" for those two sources: measured against a
+ * real library, an 8+ filter matched 136 of 136 metacritic-rated films and
+ * 121 of 121 rottenTomatoes-rated ones. The next source to add here needs to
+ * see this decision, which is why it is a named table rather than a `/ 10` at
+ * the comparison site below.
+ */
+const RATING_SCALE_MAX: Record<RatingSource, number> = {
+    imdb: 10,
+    tmdb: 10,
+    trakt: 10,
+    tvdb: 10,
+    metacritic: 100,
+    rottenTomatoes: 100
+};
+
+/**
+ * `value`, as reported on `source`'s native scale, rescaled to the 0–10 scale
+ * `min_rating` is documented in — for comparison only. The stored/returned
+ * rating keeps its native scale (a displayed `6.4` would read worse than `64`
+ * for a site whose own UI has always shown out of 100), so this is called at
+ * the filter comparison, never at the point a rating is read into a response.
+ */
+const toTenPointScale = (source: RatingSource, value: number): number => (value / RATING_SCALE_MAX[source]) * 10;
+
 export type LibraryQuery = {
     detail: DetailLevel;
     limit: number;
@@ -132,7 +164,9 @@ export async function buildGetLibrary(loader: LibraryLoader, opts: LibraryQuery)
     // unrated" answer the question the caller actually asked.
     const source = opts.rating_source ?? bestCoveredSource(filtered, opts.kind);
     const rated = filtered.filter(i => ratingOf(i, source) !== undefined);
-    const matching = rated.filter(i => (ratingOf(i, source) as number) >= (opts.min_rating as number));
+    const matching = rated.filter(
+        i => toTenPointScale(source, ratingOf(i, source) as number) >= (opts.min_rating as number)
+    );
 
     const shaped = applyLimit(matching, opts.limit);
     return {
@@ -158,7 +192,14 @@ export function registerGetLibrary(server: McpServer, loader: LibraryLoader): vo
                 watched: z.boolean().optional().describe('Jellyfin watch state. Items Jellyfin has never seen count as unwatched.'),
                 watched_by: UserSchema,
                 quality: z.string().min(1).optional().describe('Films only.'),
-                min_rating: z.number().min(0).max(10).optional(),
+                min_rating: z
+                    .number()
+                    .min(0)
+                    .max(10)
+                    .optional()
+                    .describe(
+                        'Always 0-10, regardless of source. Metacritic and Rotten Tomatoes are reported in the response on their native 0-100 scale, but rescaled to 0-10 for this comparison.'
+                    ),
                 rating_source: z
                     .enum(RATING_SOURCES)
                     .optional()

--- a/test/getLibrary.test.ts
+++ b/test/getLibrary.test.ts
@@ -173,6 +173,61 @@ describe('get_library rating filtering', () => {
     });
 });
 
+describe('get_library rating filtering — cross-source scale', () => {
+    // `min_rating` is documented 0-10 for every source, but Radarr/Sonarr pass
+    // Rotten Tomatoes and Metacritic through on their site's native 0-100
+    // scale — nothing upstream rescales them. A raw comparison against a 0-10
+    // threshold makes "rated at all" read as "rated 8+" for those two sources:
+    // a real library measured 136 of 136 metacritic-rated films and 121 of 121
+    // rottenTomatoes-rated films "passing" an 8+ filter.
+    it('fails a metacritic film below min_rating once rescaled off its 0-100 scale (64 -> 6.4)', async () => {
+        const items = [film({ ids: { tmdb: 1 }, ratings: { metacritic: 64 } })];
+        const result = await buildGetLibrary(loaderOf(items), { ...base, min_rating: 8, rating_source: 'metacritic' });
+        expect(result.total).toBe(0);
+    });
+
+    it('passes a metacritic film at/above min_rating once rescaled (95 -> 9.5)', async () => {
+        const items = [film({ ids: { tmdb: 1 }, ratings: { metacritic: 95 } })];
+        const result = await buildGetLibrary(loaderOf(items), { ...base, min_rating: 8, rating_source: 'metacritic' });
+        expect(result.total).toBe(1);
+    });
+
+    it('rescales rottenTomatoes the same way, and keeps the native-scale value in the response', async () => {
+        const items = [
+            film({ ids: { tmdb: 1 }, ratings: { rottenTomatoes: 82 } }), // 8.2, passes
+            film({ ids: { tmdb: 2 }, ratings: { rottenTomatoes: 64 } }) // 6.4, fails
+        ];
+        const result = await buildGetLibrary(loaderOf(items), {
+            ...base,
+            min_rating: 8,
+            rating_source: 'rottenTomatoes'
+        });
+        expect(result.total).toBe(1);
+        // The stored/returned value stays on Rotten Tomatoes' own 0-100 scale —
+        // rescaling is for the comparison only, not the reported number.
+        expect(result.items[0]?.ratings?.rottenTomatoes).toBe(82);
+    });
+
+    it('leaves an imdb comparison unchanged — it was already 0-10', async () => {
+        const items = [
+            film({ ids: { tmdb: 1 }, ratings: { imdb: 8.5 } }),
+            film({ ids: { tmdb: 2 }, ratings: { imdb: 7.9 } })
+        ];
+        const result = await buildGetLibrary(loaderOf(items), { ...base, min_rating: 8, rating_source: 'imdb' });
+        expect(result.total).toBe(1);
+    });
+
+    it('does not change rated/unrated coverage counts — coverage is presence, not magnitude', async () => {
+        const items = [
+            film({ ids: { tmdb: 1 }, ratings: { metacritic: 64 } }),
+            film({ ids: { tmdb: 2 }, ratings: { metacritic: 95 } }),
+            film({ ids: { tmdb: 3 } })
+        ];
+        const result = await buildGetLibrary(loaderOf(items), { ...base, min_rating: 8, rating_source: 'metacritic' });
+        expect(result.ratingCoverage).toEqual({ source: 'metacritic', rated: 2, unrated: 1 });
+    });
+});
+
 describe('get_library shaping', () => {
     it('truncates honestly', async () => {
         const many = repeat(film(), 120).map((f, i) => ({ ...f, ids: { tmdb: i + 1 } }));

--- a/test/scriptsRedact.test.ts
+++ b/test/scriptsRedact.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { ConfigSchema } from '../src/config/schema.ts';
+import { classifyFetchError } from '../src/core/errors.ts';
+import { hostsOf, redactHosts } from '../scripts/lib/redact.ts';
+
+const TOKEN = 'a'.repeat(64);
+
+const configWith = (url: string) =>
+    ConfigSchema.parse({
+        auth: { bearer_token: TOKEN },
+        services: { radarr: { url, api_key: 'k' } }
+    });
+
+describe('hostsOf', () => {
+    it('extracts both the host and the bare hostname of every configured service', () => {
+        const config = configWith('http://192.168.1.20:7878');
+        expect(hostsOf(config)).toEqual(expect.arrayContaining(['192.168.1.20:7878', '192.168.1.20']));
+    });
+
+    it('sorts longest first, so a host:port match wins before the bare hostname inside it', () => {
+        const hosts = hostsOf(configWith('http://192.168.1.20:7878'));
+        expect(hosts.indexOf('192.168.1.20:7878')).toBeLessThan(hosts.indexOf('192.168.1.20'));
+    });
+});
+
+describe('redactHosts', () => {
+    it('replaces every occurrence of a configured host', () => {
+        const hosts = ['192.168.1.20:7878', '192.168.1.20'];
+        expect(redactHosts('reached 192.168.1.20:7878 twice: 192.168.1.20:7878', hosts)).not.toContain('192.168.1.20');
+    });
+
+    it('leaves text with no configured host untouched', () => {
+        expect(redactHosts('5 of 5 indexer(s).', ['192.168.1.20:7878'])).toBe('5 of 5 indexer(s).');
+    });
+
+    /**
+     * The exact scenario the review flagged: `classifyFetchError` deliberately
+     * embeds the host in `ServiceError.message` for a live connectivity
+     * failure (`src/core/errors.ts`) — the case scripts/integration.ts never
+     * exercised in its first live run, because every configured service was
+     * reachable. Reproduced here with the same ECONNREFUSED shape
+     * `test/errors.test.ts` uses, so the host-in-message premise is not
+     * assumed — it is the same fixture the errors suite already trusts.
+     */
+    it('strips the host classifyFetchError deliberately embeds in a live connectivity failure', () => {
+        const config = configWith('http://192.168.1.20:7878');
+        const cause = Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' });
+        const err = classifyFetchError(cause, 'radarr', 'http://192.168.1.20:7878');
+
+        expect(err.message).toContain('192.168.1.20:7878'); // the premise: it really is embedded
+        expect(redactHosts(err.message, hostsOf(config))).not.toContain('192.168.1.20');
+    });
+});


### PR DESCRIPTION
Phase 3b, Task 8 of 9. The mechanical form of "call every tool before announcing" — and it earned its place immediately.

## What it is

Calls all thirteen tools against a live stack and **fails if `TOOL_NAMES` contains a tool no case covers**, so a new tool cannot ship uncalled. Maintainer-run, never CI.

It drives `buildApp`'s real `McpServer` and real `tools/call` JSON-RPC in-process through Hono — the same path a real client takes, the same pattern `test/app.test.ts` uses. The first version hand-rolled a dispatch stub and had already needed one hand-fix to match the SDK's schema defaulting; that drift is the exact class of bug this script exists to eliminate for adapters, so applying the lesson to the harness itself was the right trade.

**22/22 calls pass**, including four `diagnose` scenarios built from live data — a title that exists, one that does not, an explicit `service`+`id`, and a genuinely incomplete item — with correctly differentiated verdicts.

## The defect it found on its first real run

`min_rating` is documented as 0–10. Metacritic and Rotten Tomatoes come back on their native **0–100** scale.

| source | "rated 8+" before | after |
|---|---|---|
| metacritic | **136 of 136** | 19 of 136 |
| rottenTomatoes | **121 of 121** | 65 of 121 |

*"Films rated 8+ on Metacritic"* returned every film that had a score at all — a confidently wrong answer, which is the failure class this design keeps guarding against. It survived until now because fixtures prove the mapping and nothing else, and the one rating case in the first draft used the auto-selected source, which happened to be `tmdb`.

Rescaling happens **at the comparison only**. Stored values stay native, because `metacritic: 64` is the scale people recognise and a displayed `6.4` would be worse. The scale table is typed against the rating-source union, so adding a source without a scale is a compile error rather than a silent 0–10 assumption.

## Three gaps in the harness itself

- a tool returning `isError: true` was reported as **PASS** — now real SDK output, checked
- FAIL lines carried no latency, which is exactly when timing distinguishes a validation error from a timeout
- the header promised it never prints a service URL while the FAIL branch printed raw `ServiceError` messages, which **deliberately embed the configured host**. Now redacted in both scripts, verified by a unit test reproducing the real `classifyFetchError` path and by a live probe against an unreachable service.

That last one was the same defect shape as `toModelText()`: a comment asserting a guarantee nothing enforced.

**692 tests**, up from 682.

🤖 Generated with [Claude Code](https://claude.com/claude-code)