### PR TITLE
feat: add the write foundation and trigger_search

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,6 +118,42 @@ Three of the eight services publish no usable OpenAPI spec, so the adapter
 interface is defined by us and must stay hand-writable. Code generation is an
 implementation detail inside an adapter, never the shape of the contract.
 
+## Adding a write tool
+
+Write tools are **not** registered like read tools. Use `registerWriteTool`
+(`src/tools/write.ts`) and supply only two callbacks:
+
+- `plan(args)` — resolves the arguments into a `WritePlan`: the concrete
+  `target` id, a one-sentence `summary`, and an itemised `effects` list. It must
+  not mutate anything. Set `noop: true` when there is nothing to do, and the
+  harness skips the confirmation rather than asking the user to approve a
+  no-op.
+- `apply(plan, args)` — performs the write. It is reached only after the
+  permission tier passed, a valid single-use confirmation token was presented,
+  and an audit row was opened.
+
+The four §10 guarantees — the tier check, `dry_run`, the audit trail, the
+confirmation handshake — are properties of the harness, not of your tool. Do not
+reimplement any of them, and do not call an adapter's write method from `plan`:
+the preview phase must be incapable of mutating, and it is, because the harness
+simply does not invoke `apply`.
+
+`src/tools/triggerSearch.ts` is the worked example. Note two things it does that
+yours should:
+
+- **`service` is derived from the arguments**, not fixed, for a tool spanning
+  more than one service. A fixed id would check Sonarr writes against Radarr's
+  `permissions` block.
+- **It takes `service` + `id`, never a title.** Fuzzy title resolution is fine
+  when a wrong match costs a wrong answer; it is not fine when it costs an
+  action against the wrong item.
+
+Pick the tier by what an undo costs. `safe` is anything the service can reverse
+— monitor, unmonitor, trigger a search. `destructive` is anything that loses
+data: files on disk, a request's history, a blocklist entry. When unsure, it is
+`destructive`; the cost of over-classifying is one config flag, and the cost of
+under-classifying is someone's library.
+
 ## Vendored API specs
 
 `specs/*.json` are upstream OpenAPI documents, refreshed by `npm run specs:fetch`

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ Jellyfin. arr-mcp correlates them and gives you the causal chain.
 - **Tool output is treated as untrusted data, never instruction.** Release names
   from public indexers are attacker-controllable and flow straight into model
   context; arr-mcp fences them.
-- **Reads only.** Writes arrive in 0.5, behind per-service permission toggles
-  that default off, and per-call confirmation even then.
+- **Writes are opt-in, previewed, and recorded.** Every write is off until you
+  turn it on per service, shows you exactly what it would do before it does it,
+  and lands in an audit trail either way.
 
 > ### Status: 0.4 — correlation across the stack
 >
@@ -23,6 +24,11 @@ Jellyfin. arr-mcp correlates them and gives you the causal chain.
 > instead of service by service. `diagnose` walks the whole chain from request
 > to playable and names the first thing that explains a gap, even with
 > services down. See [the roadmap](#roadmap).
+>
+> **On `main`, ahead of the 0.4 tag:** the write foundation described under
+> [Writes](#writes) — permission tiers, `dry_run`, confirmation tokens, the
+> audit trail — plus the first write tool, `trigger_search`. Released images
+> tagged `0.4` are still read-only.
 
 ## Services
 
@@ -47,6 +53,7 @@ All eight are supported as of 0.3.
 | `get_requests` | What has been requested, and what is still pending |
 | `lookup_media` | Tell me about this, without adding it |
 | `discover_media` | What exists in this genre, year, or rating band |
+| `trigger_search` | Go look for this again — the one write in 0.5 so far |
 
 Every tool but `diagnose` takes `detail` (`minimal`/`standard`/`full`) and
 `limit`, and reports `{ total, returned, truncated }` — a truncated answer
@@ -61,8 +68,8 @@ only — a series has no series-level quality, and Sonarr carries one flat
 TVDB rating rather than per-source scores. Asking either of series returns a
 refusal explaining why, not an empty list.
 
-Reads only. Writes arrive in 0.5, behind per-service permission toggles and
-per-call confirmation.
+Every tool except `trigger_search` is a read. See [Writes](#writes) for how that
+one — and every write after it — is gated.
 
 ### Why is this not playable?
 
@@ -85,6 +92,60 @@ that actually tells you what to do next.
 It also works with services down. Any step it could not check sets
 `certain: false` and the summary names what was missed, because a confident
 verdict across a hole is worse than no verdict.
+
+## Writes
+
+Nothing writes to your stack until you say so, per service:
+
+```yaml
+services:
+  radarr:
+    url: http://192.168.1.20:7878
+    api_key: "…"
+    permissions:
+      safe_write: true       # monitor, trigger a search — reversible
+      destructive: false     # delete files, remove requests — not
+```
+
+Both default to **false**. A service you add by hand-editing YAML acquires no
+write access by doing so. The tiers are ordered: `destructive: true` implies
+`safe_write`, so you never have to reason about a config that permits deleting
+a film but refuses to re-monitor it.
+
+A write tool called without a confirmation token **does not write**. It resolves
+the target, reports exactly what it would do, and hands back a token:
+
+```
+trigger_search { service: "radarr", id: "5" }
+```
+
+> Not applied yet. Ask radarr to search for releases for Alien (1979).
+>
+> - Queues a movie search on radarr for Alien (1979).
+> - May grab and start downloading a release, which will appear in get_queue.
+>
+> To apply this, call trigger_search again with the same arguments plus
+> `confirm` set to the token in `confirm_token`.
+
+Tokens are single-use, expire after five minutes, and are cryptographically
+bound to the exact operation and arguments previewed — a token issued for one
+film cannot be replayed against another. Restarting arr-mcp invalidates any
+outstanding ones.
+
+`dry_run: true` is the separate, terminal form: it describes the effect and
+issues no token at all, so it can never turn into a write. It works even with
+the tier switched off, and tells you which key you would need to set — that is
+how you answer *"what would this do?"* without granting anything first.
+
+Every attempt — applied, previewed, refused, dry run, or failed mid-flight —
+is recorded in `config/audit.db` beside your `config.yaml`, with the resolved
+target and the arguments. If that file cannot be written, writes are refused
+rather than proceeding unrecorded; reads are unaffected.
+
+Write tools take `service` and `id`, never a title. Titles are resolved fuzzily,
+which is fine when the cost of being wrong is a wrong answer and not fine when
+it is an action against the wrong film — use `get_media_details` or
+`get_library` to get an id first.
 
 ## Quick start
 
@@ -123,6 +184,9 @@ services:
     password: "…"
 ```
 
+Each service also takes an optional `permissions` block — both flags default to
+false, so the config above is read-only. See [Writes](#writes).
+
 All eight are supported: `radarr`, `sonarr`, `prowlarr`, `bazarr`, `jellyfin`,
 `seerr`, `sabnzbd`, `transmission`. Configure only what you run — anything you
 leave out is simply absent, not broken.
@@ -148,7 +212,7 @@ container** to pick up changes.
 | 0.1 / 0.2 | Walking skeleton: stateless MCP transport, bearer auth, Radarr, `stack_health` |
 | 0.3 | The remaining seven service adapters and ten read tools |
 | 0.4 | Cross-service correlation: identity resolver, three-way library join, `diagnose` |
-| 0.5 | Writes: permission tiers, `dry_run`, write audit, per-call confirmation |
+| 0.5 | Writes: permission tiers, `dry_run`, write audit, per-call confirmation — foundation and `trigger_search` on `main` |
 | 0.6 | Web config page: dashboard, diagnosing connection tests, log streams |
 | 0.7 → 1.0 | Metadata providers, MCP resources and prompts |
 

--- a/scripts/integration.ts
+++ b/scripts/integration.ts
@@ -34,6 +34,7 @@
 import { loadConfig } from '../src/config/load.ts';
 import { buildAdapters } from '../src/services/registry.ts';
 import { buildApp } from '../src/app.ts';
+import { WriteAudit } from '../src/core/audit.ts';
 import { TOOL_NAMES } from '../src/tools/register.ts';
 import { hostsOf, redactHosts } from './lib/redact.ts';
 
@@ -90,10 +91,23 @@ const CONFIG_DIR = process.env.ARR_MCP_CONFIG_DIR ?? './config';
 const { config } = await loadConfig(CONFIG_DIR);
 
 const adapters = buildAdapters(config);
-const app = buildApp({ config, adapters });
+// Ephemeral on purpose: this script is a maintainer smoke run, and its dry-run
+// probes are not events the user's own audit trail should be cluttered with.
+const app = buildApp({ config, adapters, audit: WriteAudit.ephemeral() });
 const hosts = hostsOf(config);
 
-const missing = TOOL_NAMES.filter(name => !CASES.some(c => c.tool === name));
+/**
+ * Tools the dynamic section below drives rather than the static CASES table,
+ * because their arguments have to come from an earlier call's result. Listed
+ * here so the coverage check counts them — without this, adding a tool that
+ * needs a real id would either fail the check forever or, worse, be given a
+ * made-up id just to satisfy it.
+ */
+const DYNAMIC_TOOLS: ToolName[] = ['trigger_search'];
+
+const missing = TOOL_NAMES.filter(
+    name => !CASES.some(c => c.tool === name) && !DYNAMIC_TOOLS.includes(name)
+);
 if (missing.length > 0) {
     // Counting tools is not calling them — the check RELEASING.md added after
     // 0.3.0, made mechanical.
@@ -203,9 +217,18 @@ const existingTitle = typeof completeItem?.title === 'string' ? completeItem.tit
 const brokenItem = libraryItems.find(i => i.presence === 'arr_only' || i.presence === 'jellyfin_only');
 const brokenTitle = typeof brokenItem?.title === 'string' ? brokenItem.title : undefined;
 
-const searchHit = (searchResult?.structuredContent as { items?: unknown[] } | undefined)?.items?.[0] as
-    | SearchHitLike
-    | undefined;
+const searchHits = ((searchResult?.structuredContent as { items?: unknown[] } | undefined)?.items ??
+    []) as SearchHitLike[];
+const searchHit = searchHits[0];
+
+/**
+ * `diagnose` accepts a service+id from any of the eight, so it takes items[0]
+ * above. `trigger_search` reaches only Radarr and Sonarr, and the first library
+ * hit is routinely a Jellyfin one — taking items[0] for both made the run fail
+ * on a tool that was behaving correctly, which is a script bug that would
+ * otherwise recur on every stack whose search happens to rank Jellyfin first.
+ */
+const searchableHit = searchHits.find(h => h.service === 'radarr' || h.service === 'sonarr');
 
 if (existingTitle !== undefined) {
     await run('diagnose', { query: existingTitle }, 'a title that exists');
@@ -222,6 +245,27 @@ if (brokenTitle !== undefined) {
     await run('diagnose', { query: brokenTitle }, 'presence disagrees between services — genuinely broken');
 } else {
     console.log('SKIP diagnose "genuinely broken" case — no arr_only/jellyfin_only item in the sampled library.');
+}
+
+/**
+ * The one write tool, exercised **only as a dry run**. That is the whole reason
+ * a dry run is not permission-gated: this covers the real path — resolve the
+ * id, read the item back from the live service, describe the effect, report the
+ * permission verdict — against a maintainer's actual stack without needing
+ * write permission enabled and without touching anything.
+ *
+ * A live confirm/apply case is deliberately absent. It would queue a real
+ * search on a real Radarr on every run, and the failure mode of getting that
+ * wrong is a stack grabbing releases nobody asked for.
+ */
+if (typeof searchableHit?.service === 'string' && searchableHit.id !== undefined) {
+    await run(
+        'trigger_search',
+        { service: searchableHit.service, id: String(searchableHit.id), dry_run: true },
+        'dry run only — never applied from this script'
+    );
+} else {
+    console.log('SKIP trigger_search — search_media returned no Radarr or Sonarr hit to take a service+id from.');
 }
 
 console.log(`\n${passes}/${passes + failures} calls succeeded.`);

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,7 @@ import { McpServer, createMcpHandler } from '@modelcontextprotocol/server';
 import type { Context } from 'hono';
 import { timingSafeEqual } from 'node:crypto';
 import type { Config } from './config/schema.ts';
+import type { WriteAudit } from './core/audit.ts';
 import { logger } from './core/logger.ts';
 import type { ServiceAdapter } from './services/types.ts';
 import { buildToolContext, registerAllTools } from './tools/register.ts';
@@ -23,13 +24,15 @@ function tokenMatches(presented: string, expected: string): boolean {
     return timingSafeEqual(a, b);
 }
 
-export function buildApp(opts: { config: Config; adapters: readonly ServiceAdapter[] }) {
-    const { config, adapters } = opts;
+export function buildApp(opts: { config: Config; adapters: readonly ServiceAdapter[]; audit: WriteAudit }) {
+    const { config, adapters, audit } = opts;
 
     // Built once, outside the per-request factory: the identity resolvers cache
     // each service's user directory, and rebuilding them per request would
-    // refetch it on every tool call.
-    const toolContext = buildToolContext(adapters, config);
+    // refetch it on every tool call. The write context has a second, harder
+    // reason — its confirmation tokens must outlive a single request or the
+    // preview/confirm handshake could never complete.
+    const toolContext = buildToolContext(adapters, config, audit);
 
     // The factory runs once per request, so every call gets a fresh McpServer.
     // This is what keeps the transport stateless (design spec §5) — do not

--- a/src/core/audit.ts
+++ b/src/core/audit.ts
@@ -1,0 +1,186 @@
+import Database from 'better-sqlite3';
+import type { Database as Db } from 'better-sqlite3';
+import { join } from 'node:path';
+import type { ServiceId } from '../config/schema.ts';
+import type { WriteTier } from './permissions.ts';
+import { logger } from './logger.ts';
+
+/**
+ * Design spec §10's write audit: a durable answer to "what did this thing do
+ * to my library, and who asked it to".
+ *
+ * SQLite rather than a JSONL file because 0.6's config page has to *read* this
+ * back — filtered by service, by outcome, by date — and re-parsing an
+ * append-only text file to render a table is work we would only do once before
+ * regretting it. `better-sqlite3` is already a dependency (it is also the
+ * intended sink for 0.6's log ring buffer), so this costs no new supply chain.
+ *
+ * The file is the audit trail, so it lives beside `config.yaml` in the mounted
+ * config volume, not in the container's ephemeral filesystem. A trail that
+ * vanishes on `docker compose down` is not a trail.
+ */
+
+export const AUDIT_FILENAME = 'audit.db';
+
+/**
+ * `attempted` is written *before* the service is called; every other outcome
+ * replaces it once the call resolves. A row still reading `attempted` therefore
+ * means arr-mcp died mid-write — which is precisely the case an audit log
+ * exists to make visible, and the one an after-the-fact-only log cannot show.
+ */
+export type WriteOutcome =
+    | 'attempted'
+    | 'applied'
+    | 'dry_run'
+    /** Refused by the permission tier — the service was never called. */
+    | 'denied'
+    /** Previewed because no valid confirmation token was presented. */
+    | 'unconfirmed'
+    /** The service was called and said no. */
+    | 'failed';
+
+export type AuditRecord = {
+    tool: string;
+    service: ServiceId;
+    operation: string;
+    tier: WriteTier;
+    target: string;
+    args: Record<string, unknown>;
+};
+
+const SCHEMA = `
+CREATE TABLE IF NOT EXISTS write_audit (
+    id        INTEGER PRIMARY KEY AUTOINCREMENT,
+    at        TEXT    NOT NULL,
+    tool      TEXT    NOT NULL,
+    service   TEXT    NOT NULL,
+    operation TEXT    NOT NULL,
+    tier      TEXT    NOT NULL,
+    target    TEXT    NOT NULL,
+    args      TEXT    NOT NULL,
+    outcome   TEXT    NOT NULL,
+    detail    TEXT,
+    settled_at TEXT
+);
+CREATE INDEX IF NOT EXISTS write_audit_at ON write_audit (at DESC);
+CREATE INDEX IF NOT EXISTS write_audit_service ON write_audit (service, at DESC);
+`;
+
+/** Keys whose value never belongs in a durable log, however it got there. No
+ *  write tool takes one today; this is here so that stays true by construction
+ *  rather than by everyone remembering. */
+const SECRET_KEY = /(api[_-]?key|token|password|secret|authorization)/i;
+
+function safeArgs(args: Record<string, unknown>): string {
+    const clean: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(args)) {
+        clean[key] = SECRET_KEY.test(key) ? '__REDACTED__' : value;
+    }
+    return JSON.stringify(clean);
+}
+
+/**
+ * Thrown when the trail cannot be written. Writes are refused rather than
+ * proceeding unlogged: an unrecorded deletion is the exact outcome this module
+ * exists to prevent, and a read-only or full config volume is a real
+ * misconfiguration a user can fix once the error names the path.
+ */
+export class AuditUnavailableError extends Error {
+    constructor(path: string, cause: unknown) {
+        super(
+            `the write audit log at ${path} could not be opened, so writes are refused — ` +
+                `check the config volume is writable and not full. Reads are unaffected. ` +
+                `(${(cause as Error)?.message ?? 'unknown error'})`,
+            { cause }
+        );
+        this.name = 'AuditUnavailableError';
+    }
+}
+
+export class WriteAudit {
+    readonly #db: Db;
+    readonly #path: string;
+
+    private constructor(db: Db, path: string) {
+        this.#db = db;
+        this.#path = path;
+    }
+
+    /** Opens (creating if absent) the trail in the config directory. */
+    static open(configDir: string): WriteAudit {
+        const path = join(configDir, AUDIT_FILENAME);
+        try {
+            const db = new Database(path);
+            // WAL so a reader (0.6's config page) cannot block a write, and so
+            // an unclean shutdown replays rather than truncates.
+            db.pragma('journal_mode = WAL');
+            db.pragma('synchronous = FULL');
+            db.exec(SCHEMA);
+            return new WriteAudit(db, path);
+        } catch (err) {
+            throw new AuditUnavailableError(path, err);
+        }
+    }
+
+    /** In-memory trail for tests — same schema, same statements, no file. */
+    static ephemeral(): WriteAudit {
+        const db = new Database(':memory:');
+        db.exec(SCHEMA);
+        return new WriteAudit(db, ':memory:');
+    }
+
+    /**
+     * Records the intent and returns its row id. Called *before* the service
+     * is touched, so the trail cannot be missing an operation that happened.
+     */
+    begin(record: AuditRecord): number {
+        try {
+            const result = this.#db
+                .prepare(
+                    `INSERT INTO write_audit (at, tool, service, operation, tier, target, args, outcome)
+                     VALUES (?, ?, ?, ?, ?, ?, ?, 'attempted')`
+                )
+                .run(
+                    new Date().toISOString(),
+                    record.tool,
+                    record.service,
+                    record.operation,
+                    record.tier,
+                    record.target,
+                    safeArgs(record.args)
+                );
+            return Number(result.lastInsertRowid);
+        } catch (err) {
+            throw new AuditUnavailableError(this.#path, err);
+        }
+    }
+
+    /**
+     * The one legal mutation of an audit row: resolving `attempted` into what
+     * actually happened. Deliberately not an INSERT of a second row — an
+     * operator scanning the trail should see one line per operation, with a
+     * lingering `attempted` standing out as the anomaly it is.
+     *
+     * Failing to settle must not mask the write's own result, so unlike
+     * `begin` this logs rather than throws: by the time it runs, the service
+     * has already been called and the caller has a real outcome to report.
+     */
+    settle(id: number, outcome: Exclude<WriteOutcome, 'attempted'>, detail?: string): void {
+        try {
+            this.#db
+                .prepare(`UPDATE write_audit SET outcome = ?, detail = ?, settled_at = ? WHERE id = ?`)
+                .run(outcome, detail ?? null, new Date().toISOString(), id);
+        } catch (err) {
+            logger.error({ err, id, outcome, path: this.#path }, 'could not settle write audit row');
+        }
+    }
+
+    /** Newest first. The read side 0.6's config page will grow into. */
+    recent(limit = 50): unknown[] {
+        return this.#db.prepare(`SELECT * FROM write_audit ORDER BY id DESC LIMIT ?`).all(limit);
+    }
+
+    close(): void {
+        this.#db.close();
+    }
+}

--- a/src/core/confirm.ts
+++ b/src/core/confirm.ts
@@ -1,0 +1,196 @@
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+import type { ServiceId } from '../config/schema.ts';
+import type { Clock } from './cache.ts';
+import type { WriteTier } from './permissions.ts';
+
+/**
+ * Design spec §10's per-call confirmation, built to survive the stateless
+ * transport of §5.
+ *
+ * A write tool called without `confirm` performs nothing and hands back a
+ * preview plus a token. Calling again with that token performs the write. The
+ * point is not to stop a determined model — it holds the token and can always
+ * call twice — it is that the *first* call is the one that cannot mutate
+ * anything, so a mis-parsed instruction ("delete the Alien films") surfaces as
+ * a preview a human sees before it becomes a deletion.
+ *
+ * Two properties do the work:
+ *
+ *   1. The token is an HMAC over the exact operation, so a token issued for
+ *      "delete movie 5" cannot be replayed as "delete movie 9". Without this
+ *      binding a model could preview something harmless and then confirm
+ *      something else, which is strictly worse than no confirmation because it
+ *      looks like protection.
+ *   2. It is single-use, so "add movie" cannot be confirmed twice into a
+ *      duplicate.
+ *
+ * The signing key is fresh per process and never written down: a restart
+ * invalidating outstanding tokens is correct, not a limitation. The alternative
+ * — deriving it from the bearer token — would tie confirmation lifetime to
+ * credential rotation, which are unrelated concerns.
+ */
+
+/** Long enough for a model to read a preview and decide; short enough that a
+ *  token found in an old transcript is dead. */
+export const CONFIRM_TTL_MS = 300_000;
+
+/** Defensive bound on the consumed-token set, which is otherwise TTL-swept. */
+const MAX_CONSUMED = 10_000;
+
+/**
+ * Everything a token commits to. Any field that changes the effect of the
+ * write belongs here — that is what makes "the token matches this call" mean
+ * "this is the call you previewed".
+ */
+export type WriteIntent = {
+    tool: string;
+    service: ServiceId;
+    tier: WriteTier;
+    /** The adapter-level verb, e.g. `delete_movie`. Distinct from `tool` because
+     *  one tool may reach more than one operation. */
+    operation: string;
+    /** The resolved target — an id, not the phrase the user typed. Binding to a
+     *  title would let the same token hit a different film after a re-resolve. */
+    target: string;
+    /** Remaining arguments that alter the effect (e.g. `{ deleteFiles: true }`). */
+    args?: Record<string, unknown>;
+};
+
+export type ConfirmFailure = 'expired' | 'mismatch' | 'used' | 'malformed';
+
+export type ConfirmResult = { ok: true } | { ok: false; failure: ConfirmFailure; remedy: string };
+
+const REMEDY: Record<ConfirmFailure, string> = {
+    expired: `The confirmation token has expired (they last ${CONFIRM_TTL_MS / 1000}s). Call this tool again without \`confirm\` to preview the operation and get a fresh token.`,
+    mismatch:
+        'That confirmation token was issued for a different operation or different arguments. Call this tool again without `confirm` to preview *this* operation and use the token it returns — do not reuse a token from an earlier preview.',
+    used: 'That confirmation token has already been used. Tokens are single-use so a write cannot be applied twice; call this tool again without `confirm` if you genuinely intend to repeat the operation.',
+    malformed:
+        'That is not a confirmation token issued by this server. Call this tool again without `confirm` to preview the operation and use the token it returns verbatim.'
+};
+
+/**
+ * Stable serialisation, so `{a:1,b:2}` and `{b:2,a:1}` produce one signature.
+ * Plain `JSON.stringify` preserves insertion order, which would make an
+ * otherwise-identical confirm call fail purely on key order — a failure mode
+ * that would be maddening to diagnose and would train callers to distrust the
+ * handshake.
+ */
+function canonicalize(value: unknown): string {
+    if (value === null || typeof value !== 'object') return JSON.stringify(value) ?? 'null';
+    if (Array.isArray(value)) return `[${value.map(canonicalize).join(',')}]`;
+
+    const entries = Object.entries(value as Record<string, unknown>)
+        .filter(([, v]) => v !== undefined)
+        .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+    return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${canonicalize(v)}`).join(',')}}`;
+}
+
+const intentPayload = (intent: WriteIntent): string =>
+    canonicalize({
+        tool: intent.tool,
+        service: intent.service,
+        tier: intent.tier,
+        operation: intent.operation,
+        target: intent.target,
+        args: intent.args ?? {}
+    });
+
+/** Timing-safe compare that tolerates unequal lengths without leaking them. */
+function signatureMatches(presented: string, expected: string): boolean {
+    const a = Buffer.from(presented);
+    const b = Buffer.from(expected);
+    if (a.length !== b.length) {
+        timingSafeEqual(b, b);
+        return false;
+    }
+    return timingSafeEqual(a, b);
+}
+
+export class ConfirmTokens {
+    readonly #key: Buffer;
+    readonly #now: Clock;
+    readonly #ttlMs: number;
+    /** token signature → the moment it stops mattering that it was used. */
+    readonly #consumed = new Map<string, number>();
+
+    constructor(opts: { clock?: Clock; ttlMs?: number; key?: Buffer } = {}) {
+        this.#key = opts.key ?? randomBytes(32);
+        this.#now = opts.clock ?? Date.now;
+        this.#ttlMs = opts.ttlMs ?? CONFIRM_TTL_MS;
+    }
+
+    /** `v1.<issuedAt>.<signature>` — the timestamp is in the clear because it is
+     *  covered by the signature, so it cannot be edited to extend a token's life. */
+    issue(intent: WriteIntent): string {
+        const issuedAt = this.#now();
+        return `v1.${issuedAt.toString(36)}.${this.#sign(intent, issuedAt)}`;
+    }
+
+    /**
+     * Verifies **and consumes**. Deliberately one operation: a separate
+     * `verify` then `consume` invites a caller to verify, perform the write,
+     * and forget to consume — leaving the token replayable. The consume
+     * happens before the write is attempted, so a write that fails still burns
+     * the token; re-previewing after a failure is the correct flow, because the
+     * failure may well have changed what the preview would say.
+     */
+    verifyAndConsume(presented: string, intent: WriteIntent): ConfirmResult {
+        this.#sweep();
+
+        const parts = presented.split('.');
+        if (parts.length !== 3 || parts[0] !== 'v1') return { ok: false, failure: 'malformed', remedy: REMEDY.malformed };
+
+        const issuedAt = Number.parseInt(parts[1] ?? '', 36);
+        const signature = parts[2] ?? '';
+        if (!Number.isFinite(issuedAt) || signature === '') {
+            return { ok: false, failure: 'malformed', remedy: REMEDY.malformed };
+        }
+
+        // Expiry is checked before the signature so an old token for the right
+        // operation reports "expired" rather than the misleading "mismatch".
+        // A clock that went backwards (NTP step) makes `age` negative, which
+        // must not read as fresh-forever, so the window is bounded both ways.
+        const age = this.#now() - issuedAt;
+        if (age < 0 || age > this.#ttlMs) return { ok: false, failure: 'expired', remedy: REMEDY.expired };
+
+        if (!signatureMatches(signature, this.#sign(intent, issuedAt))) {
+            return { ok: false, failure: 'mismatch', remedy: REMEDY.mismatch };
+        }
+
+        // Checked after the signature: an unsigned guess must not be able to
+        // probe which tokens have been spent.
+        if (this.#consumed.has(signature)) return { ok: false, failure: 'used', remedy: REMEDY.used };
+
+        this.#consumed.set(signature, issuedAt + this.#ttlMs);
+        return { ok: true };
+    }
+
+    #sign(intent: WriteIntent, issuedAt: number): string {
+        return createHmac('sha256', this.#key)
+            .update(`${issuedAt}\n${intentPayload(intent)}`)
+            .digest('base64url');
+    }
+
+    /**
+     * A consumed token only needs remembering until it would expire anyway —
+     * after that the expiry check rejects it regardless, so the entry is dead
+     * weight. That bounds the map by (writes per TTL window) rather than by
+     * uptime.
+     */
+    #sweep(): void {
+        const now = this.#now();
+        for (const [signature, deadAt] of this.#consumed) {
+            if (deadAt <= now) this.#consumed.delete(signature);
+        }
+        // Only reachable if a caller drives more than MAX_CONSUMED writes
+        // inside one TTL window; dropping the oldest is safe because the worst
+        // case is that a long-spent token becomes replayable for the remainder
+        // of its window, and reaching here at all means something is very wrong.
+        while (this.#consumed.size > MAX_CONSUMED) {
+            const oldest = this.#consumed.keys().next().value;
+            if (oldest === undefined) break;
+            this.#consumed.delete(oldest);
+        }
+    }
+}

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -7,6 +7,7 @@ export type ServiceErrorKind =
     | 'RateLimited'
     | 'Timeout'
     | 'VersionUnsupported'
+    | 'PermissionDenied'
     | 'UpstreamError';
 
 const PROSE: Record<ServiceErrorKind, string> = {
@@ -16,6 +17,11 @@ const PROSE: Record<ServiceErrorKind, string> = {
     RateLimited: 'rate limited',
     Timeout: 'timed out',
     VersionUnsupported: 'version unsupported',
+    // The only kind that is not a fault of the service. It reads as
+    // "radarr permission denied: destructive writes are disabled for radarr",
+    // which is repetitive but keeps every error one shape — and the service
+    // name is what tells the model *whose* config to change.
+    PermissionDenied: 'permission denied',
     UpstreamError: 'upstream error'
 };
 

--- a/src/core/permissions.ts
+++ b/src/core/permissions.ts
@@ -1,0 +1,91 @@
+import type { AnyServiceConfig, ServiceId } from '../config/schema.ts';
+import { ServiceError } from './errors.ts';
+
+/**
+ * Design spec §10's two tiers, as an **ordered** pair rather than two
+ * independent switches.
+ *
+ * `safe` is a mutation the service itself can undo: monitor a movie, trigger a
+ * search, pause a download. `destructive` loses something — files on disk, a
+ * request's history, a queue item and its blocklist entry.
+ *
+ * Ordering is the whole point. `destructive: true` grants `safe` as well,
+ * because a config that permits deleting a film but refuses to let it be
+ * re-monitored describes no coherent policy anyone would choose on purpose —
+ * and a user who set the scarier-sounding flag and then found `add_media`
+ * refused would reasonably read that as a bug. Someone who genuinely wants
+ * neither leaves both off, which is the default (see PermissionsSchema).
+ */
+export const WRITE_TIERS = ['safe', 'destructive'] as const;
+export type WriteTier = (typeof WRITE_TIERS)[number];
+
+/** The YAML key each tier is granted by, for error messages that can be acted on. */
+const TIER_KEY: Record<WriteTier, string> = {
+    safe: 'safe_write',
+    destructive: 'destructive'
+};
+
+export type PermissionVerdict =
+    | { allowed: true; tier: WriteTier }
+    | { allowed: false; tier: WriteTier; reason: string; remedy: string };
+
+/**
+ * Config-shaped rather than adapter-shaped on purpose: the gate answers from
+ * `config.yaml` alone, so a compromised or buggy adapter cannot widen its own
+ * permissions by reporting a capability it was never granted.
+ */
+export type PermissionSource = {
+    get(service: ServiceId): AnyServiceConfig | undefined;
+};
+
+/** The property type is written out rather than as `Partial<Record<…>>` so it
+ *  accepts `config.services` under `exactOptionalPropertyTypes`, where an
+ *  explicitly-`undefined` key and a missing one are different types. */
+export function permissionSourceFrom(services: { [K in ServiceId]?: AnyServiceConfig | undefined }): PermissionSource {
+    return { get: service => services[service] };
+}
+
+/**
+ * Never throws. A denial is a *value* here because two callers need it in
+ * different shapes: a live write turns it into a `PermissionDenied` error, and
+ * a dry run reports it as part of the preview without failing (see
+ * `src/tools/write.ts` for why a dry run is not gated).
+ */
+export function checkPermission(source: PermissionSource, service: ServiceId, tier: WriteTier): PermissionVerdict {
+    const config = source.get(service);
+
+    if (config === undefined) {
+        return {
+            allowed: false,
+            tier,
+            reason: `${service} is not configured`,
+            remedy: `Add a \`services.${service}\` block to config.yaml and restart. Writes additionally need \`services.${service}.permissions.${TIER_KEY[tier]}: true\`.`
+        };
+    }
+
+    // The ordering rule, in the one place it exists. Note this reads
+    // `destructive` for *both* tiers — a safe write is permitted by either
+    // flag, a destructive one only by `destructive`.
+    const granted = tier === 'safe' ? config.permissions.safe_write || config.permissions.destructive : config.permissions.destructive;
+
+    if (granted) return { allowed: true, tier };
+
+    return {
+        allowed: false,
+        tier,
+        reason: `${tier} writes are disabled for ${service}`,
+        remedy: `Set \`services.${service}.permissions.${TIER_KEY[tier]}: true\` in config.yaml and restart arr-mcp. This is off by default; nothing but a deliberate edit turns it on.`
+    };
+}
+
+/**
+ * The live-write form of the same check. Throws the §15-shaped error, so a
+ * refusal reaches the model as a sentence naming the exact YAML key to change
+ * rather than as a bare "forbidden" it would then have to guess about.
+ */
+export function assertPermitted(source: PermissionSource, service: ServiceId, tier: WriteTier): void {
+    const verdict = checkPermission(source, service, tier);
+    if (verdict.allowed) return;
+
+    throw new ServiceError('PermissionDenied', service, verdict.reason, { remedy: verdict.remedy });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { serve } from '@hono/node-server';
 import { buildApp } from './app.ts';
 import { loadConfig } from './config/load.ts';
+import { WriteAudit } from './core/audit.ts';
 import { logger } from './core/logger.ts';
 import { buildAdapters } from './services/registry.ts';
 
@@ -17,6 +18,11 @@ if (created) {
 
 const adapters = buildAdapters(config);
 
+// Opened at startup, not lazily on the first write: a config volume that
+// cannot hold the audit trail should be a loud failure now, while someone is
+// watching `docker logs`, rather than the first time they ask for a deletion.
+const audit = WriteAudit.open(CONFIG_DIR);
+
 if (adapters.length === 0) {
     logger.warn(
         { config: `${CONFIG_DIR}/config.yaml` },
@@ -24,6 +30,6 @@ if (adapters.length === 0) {
     );
 }
 
-serve({ fetch: buildApp({ config, adapters }).fetch, port: PORT, hostname: '0.0.0.0' }, info => {
+serve({ fetch: buildApp({ config, adapters, audit }).fetch, port: PORT, hostname: '0.0.0.0' }, info => {
     logger.info({ port: info.port, adapters: adapters.map(a => a.id) }, 'arr-mcp listening');
 });

--- a/src/services/radarr.ts
+++ b/src/services/radarr.ts
@@ -22,9 +22,11 @@ import {
     type QueueItem,
     type ScanState,
     type ScanStateCapable,
+    type CommandHandle,
     type SearchCapable,
     type SearchHit,
     type SearchSource,
+    type SearchTriggerCapable,
     type ServiceAdapter
 } from './types.ts';
 
@@ -53,6 +55,7 @@ type RawStatus = components['schemas']['SystemResource'];
 type RawDiskSpace = components['schemas']['DiskSpaceResource'];
 type RawHealthCheck = components['schemas']['HealthResource'];
 type RawTask = components['schemas']['TaskResource'];
+type RawCommand = components['schemas']['CommandResource'];
 
 /**
  * The task that actually rescans the film library, confirmed against a live
@@ -78,7 +81,8 @@ export class RadarrAdapter
         CalendarCapable,
         MediaDetailCapable,
         SearchCapable,
-        LibraryCapable
+        LibraryCapable,
+        SearchTriggerCapable
 {
     readonly id: ServiceId = 'radarr';
     readonly #http: ServiceHttp;
@@ -167,6 +171,38 @@ export class RadarrAdapter
                 ...(m.imdbId === undefined ? {} : { imdb: m.imdbId })
             },
             ...(ratings === undefined ? {} : { ratings })
+        };
+    }
+
+    /**
+     * The first write in the codebase, and the only one Phase 4 ships at the
+     * `safe` tier: it asks Radarr to look for releases for a film it already
+     * tracks. Nothing is deleted, nothing is added, and the worst outcome is a
+     * grab the user did not want — which the queue tools can then undo.
+     *
+     * The id is coerced to a number rather than interpolated: `movieIds` is a
+     * JSON array of integers, and a string there is silently accepted by Radarr
+     * and matches nothing, which would report a successful search that never
+     * ran.
+     */
+    async triggerSearch(id: string): Promise<CommandHandle> {
+        const movieId = Number(id);
+        if (!Number.isInteger(movieId)) {
+            throw new ServiceError('NotFound', this.id, `"${id}" is not a Radarr movie id`, {
+                remedy: 'Radarr movie ids are integers. Get one from get_media_details or get_library.'
+            });
+        }
+
+        const command = await this.#http.post<RawCommand>('/api/v3/command', {
+            name: 'MoviesSearch',
+            movieIds: [movieId]
+        });
+
+        return {
+            service: this.id,
+            commandId: command.id ?? 0,
+            name: command.name ?? 'MoviesSearch',
+            ...(typeof command.status === 'string' ? { status: command.status } : {})
         };
     }
 

--- a/src/services/sonarr.ts
+++ b/src/services/sonarr.ts
@@ -24,9 +24,11 @@ import {
     type QueueItem,
     type ScanState,
     type ScanStateCapable,
+    type CommandHandle,
     type SearchCapable,
     type SearchHit,
     type SearchSource,
+    type SearchTriggerCapable,
     type ServiceAdapter
 } from './types.ts';
 
@@ -59,6 +61,7 @@ type RawStatus = components['schemas']['SystemResource'];
 type RawDiskSpace = components['schemas']['DiskSpaceResource'];
 type RawHealthCheck = components['schemas']['HealthResource'];
 type RawTask = components['schemas']['TaskResource'];
+type RawCommand = components['schemas']['CommandResource'];
 
 /**
  * The task that rescans the series library, confirmed against a live Sonarr
@@ -82,7 +85,8 @@ export class SonarrAdapter
         CalendarCapable,
         MediaDetailCapable,
         SearchCapable,
-        LibraryCapable
+        LibraryCapable,
+        SearchTriggerCapable
 {
     readonly id: ServiceId = 'sonarr';
     readonly #http: ServiceHttp;
@@ -137,6 +141,38 @@ export class SonarrAdapter
     async getCalendar(range: { start: Date; end: Date }): Promise<CalendarEntry[]> {
         const episodes = await this.#http.get<Parameters<typeof readSonarrCalendar>[0]>(sonarrCalendarPath(range));
         return readSonarrCalendar(episodes, this.id);
+    }
+
+    /**
+     * Radarr's counterpart, with the one asymmetry upstream insists on:
+     * `SeriesSearch` takes a bare `seriesId`, not an array, where Radarr's
+     * `MoviesSearch` takes `movieIds: []`. Passing Radarr's shape here is
+     * accepted and searches nothing.
+     *
+     * Whole-series scope is deliberate for this first slice: per-episode search
+     * is a different command (`EpisodeSearch`) keyed on episode ids, and
+     * conflating the two behind one argument is how a model asking for one
+     * episode triggers a season-wide grab.
+     */
+    async triggerSearch(id: string): Promise<CommandHandle> {
+        const seriesId = Number(id);
+        if (!Number.isInteger(seriesId)) {
+            throw new ServiceError('NotFound', this.id, `"${id}" is not a Sonarr series id`, {
+                remedy: 'Sonarr series ids are integers. Get one from get_media_details or get_library.'
+            });
+        }
+
+        const command = await this.#http.post<RawCommand>('/api/v3/command', {
+            name: 'SeriesSearch',
+            seriesId
+        });
+
+        return {
+            service: this.id,
+            commandId: command.id ?? 0,
+            name: command.name ?? 'SeriesSearch',
+            ...(typeof command.status === 'string' ? { status: command.status } : {})
+        };
     }
 
     async getMediaDetails(id: string, opts: { includeEpisodes: boolean; episodeLimit: number }): Promise<MediaDetails> {

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -275,6 +275,24 @@ export interface SearchCapable {
 export const hasSearch = (a: ServiceAdapter): a is ServiceAdapter & SearchCapable =>
     typeof (a as Partial<SearchCapable>).search === 'function';
 
+// --- Phase 4 write capabilities ---
+
+/**
+ * What the *arrs hand back when told to do something: a queued command, not a
+ * result. The search itself runs asynchronously, which is why `trigger_search`
+ * reports "asked Radarr to search" rather than "found a release" — claiming the
+ * latter would be a confident lie about work that has not happened yet.
+ */
+export type CommandHandle = { service: ServiceId; commandId: number; name: string; status?: string };
+
+export interface SearchTriggerCapable {
+    /** Asks the service to look for releases for one item it already tracks. */
+    triggerSearch(id: string): Promise<CommandHandle>;
+}
+
+export const hasSearchTrigger = (a: ServiceAdapter): a is ServiceAdapter & SearchTriggerCapable =>
+    typeof (a as Partial<SearchTriggerCapable>).triggerSearch === 'function';
+
 /**
  * A whole-library read, shaped for the identity resolver rather than for a
  * tool. Phase 3 joins three of these into one index; nothing else consumes it.

--- a/src/tools/library.ts
+++ b/src/tools/library.ts
@@ -55,6 +55,23 @@ export class LibraryLoader {
     }
 
     /**
+     * §16's write-invalidation seam, and the reason `TtlCache.invalidate`
+     * existed unused until now. Called after a successful write, so the next
+     * `get_library` reflects the change rather than up to five minutes of a
+     * library that no longer exists.
+     *
+     * Clears every entry rather than one key: this cache holds nothing but
+     * library snapshots, and a Radarr write invalidates *every* user's
+     * snapshot, not just the writer's — the keys are per Jellyfin user, and the
+     * film that was just deleted is gone from all of them. Recomputing a
+     * household's worth of snapshots costs one library read each; serving a
+     * stale one costs a wrong answer.
+     */
+    invalidate(): void {
+        this.#cache.clear();
+    }
+
+    /**
      * Returns undefined when there is no Jellyfin half to fetch. The decision
      * to propagate or degrade turns on the error's *kind*, not on whether a
      * user was named — naming someone must not turn a plain Jellyfin outage

--- a/src/tools/register.ts
+++ b/src/tools/register.ts
@@ -1,6 +1,9 @@
 import type { McpServer } from '@modelcontextprotocol/server';
 import type { Config } from '../config/schema.ts';
+import type { WriteAudit } from '../core/audit.ts';
+import { ConfirmTokens } from '../core/confirm.ts';
 import { IdentityResolver } from '../core/identity.ts';
+import { permissionSourceFrom } from '../core/permissions.ts';
 import { JellyfinAdapter } from '../services/jellyfin.ts';
 import { SeerrAdapter } from '../services/seerr.ts';
 import { hasIndexers, hasSubtitles, type ServiceAdapter } from '../services/types.ts';
@@ -18,6 +21,8 @@ import { LibraryLoader } from './library.ts';
 import { registerLookupMedia } from './lookupMedia.ts';
 import { registerSearchMedia } from './searchMedia.ts';
 import { registerStackHealth } from './stackHealth.ts';
+import { registerTriggerSearch } from './triggerSearch.ts';
+import type { WriteContext } from './write.ts';
 
 /**
  * Identity resolvers built once, here, rather than inside the per-request
@@ -29,9 +34,20 @@ export type ToolContext = {
     jellyfinIdentity: IdentityResolver | undefined;
     seerrIdentity: IdentityResolver | undefined;
     library: LibraryLoader;
+    /**
+     * The write half (§10). Built once alongside the resolvers rather than per
+     * request: `ConfirmTokens` holds the signing key and the spent-token set,
+     * and rebuilding it per request would make every confirmation token invalid
+     * the moment it was issued — the handshake spans two calls by construction.
+     */
+    write: WriteContext;
 };
 
-export function buildToolContext(adapters: readonly ServiceAdapter[], config: Config): ToolContext {
+export function buildToolContext(
+    adapters: readonly ServiceAdapter[],
+    config: Config,
+    audit: WriteAudit
+): ToolContext {
     const jellyfin = adapters.find((a): a is JellyfinAdapter => a instanceof JellyfinAdapter);
     const seerr = adapters.find((a): a is SeerrAdapter => a instanceof SeerrAdapter);
 
@@ -40,6 +56,8 @@ export function buildToolContext(adapters: readonly ServiceAdapter[], config: Co
             ? new IdentityResolver(jellyfin, config.services.jellyfin)
             : undefined;
 
+    const library = new LibraryLoader(adapters, jellyfinIdentity);
+
     return {
         adapters,
         jellyfinIdentity,
@@ -47,7 +65,16 @@ export function buildToolContext(adapters: readonly ServiceAdapter[], config: Co
             seerr !== undefined && config.services.seerr !== undefined
                 ? new IdentityResolver(seerr, config.services.seerr)
                 : undefined,
-        library: new LibraryLoader(adapters, jellyfinIdentity)
+        library,
+        write: {
+            // From `config.services` directly, not from the adapters: the gate
+            // must answer from the file, so an adapter cannot widen its own
+            // permissions by reporting a capability it was never granted.
+            permissions: permissionSourceFrom(config.services),
+            confirm: new ConfirmTokens(),
+            audit,
+            library
+        }
     };
 }
 
@@ -61,7 +88,7 @@ export function buildToolContext(adapters: readonly ServiceAdapter[], config: Co
  * not find it missing after a config edit.
  */
 export function registerAllTools(server: McpServer, context: ToolContext): void {
-    const { adapters, jellyfinIdentity, seerrIdentity, library } = context;
+    const { adapters, jellyfinIdentity, seerrIdentity, library, write } = context;
     const jellyfin = adapters.find((a): a is JellyfinAdapter => a instanceof JellyfinAdapter);
     const seerr = adapters.find((a): a is SeerrAdapter => a instanceof SeerrAdapter);
 
@@ -78,6 +105,13 @@ export function registerAllTools(server: McpServer, context: ToolContext): void 
     registerSearchMedia(server, adapters);
     registerLookupMedia(server, adapters);
     registerDiscoverMedia(server, seerr);
+
+    // Registered unconditionally like every read tool, and for the same §18
+    // reason: the tool surface is the public API and must not depend on
+    // configuration. A stack with no write permission still *has*
+    // trigger_search — it refuses, naming the key to set, which is a far better
+    // answer than a tool the model was told about and cannot find.
+    registerTriggerSearch(server, write, adapters);
 }
 
 /** The tool surface, frozen. §18: renaming one breaks users' saved prompts. */
@@ -94,5 +128,6 @@ export const TOOL_NAMES = [
     'get_library',
     'search_media',
     'lookup_media',
-    'discover_media'
+    'discover_media',
+    'trigger_search'
 ] as const;

--- a/src/tools/triggerSearch.ts
+++ b/src/tools/triggerSearch.ts
@@ -1,0 +1,96 @@
+import type { McpServer } from '@modelcontextprotocol/server';
+import * as z from 'zod/v4';
+import { ServiceIdSchema, type ServiceId } from '../config/schema.ts';
+import { ServiceError } from '../core/errors.ts';
+import { hasMediaDetails, hasSearchTrigger, type ServiceAdapter } from '../services/types.ts';
+import { registerWriteTool, type WriteContext, type WritePlan } from './write.ts';
+
+/**
+ * Phase 4's first write, and the shape every later one follows.
+ *
+ * It takes `service` plus `id` and **not** a title. Every read tool accepts a
+ * fuzzy title because the cost of resolving one wrongly is a wrong answer the
+ * user can see; for a write the cost is an action against the wrong item. The
+ * model is expected to establish identity through `get_media_details` or
+ * `get_library` first — which also means the id in the audit trail is one the
+ * user could have seen before the write, not one this tool invented.
+ */
+
+const findAdapter = (adapters: readonly ServiceAdapter[], service: ServiceId) => {
+    const adapter = adapters.find(a => a.id === service);
+    if (adapter === undefined) {
+        throw new ServiceError('NotFound', service, `${service} is not configured`, {
+            remedy: `Add a services.${service} block to config.yaml and restart, or name a configured service.`
+        });
+    }
+    if (!hasSearchTrigger(adapter)) {
+        throw new ServiceError('NotFound', service, `${service} cannot be told to search`, {
+            remedy: 'Only radarr and sonarr support trigger_search.'
+        });
+    }
+    return adapter;
+};
+
+export function registerTriggerSearch(
+    server: McpServer,
+    context: WriteContext,
+    adapters: readonly ServiceAdapter[]
+): void {
+    registerWriteTool(server, context, {
+        name: 'trigger_search',
+        description:
+            'Asks Radarr or Sonarr to go looking for releases for one item it already tracks — the "it never downloaded, try again" action. Takes `service` and `id`, deliberately not a title: get those from get_media_details or get_library first. This queues a search and returns immediately; it does not wait for a release to be found, and finding one is not guaranteed. Previews by default — call again with the returned `confirm` token to actually run it.',
+        inputSchema: z.object({
+            service: ServiceIdSchema.describe('radarr or sonarr.'),
+            id: z.string().min(1).describe("The item's id within that service, as an integer string.")
+        }),
+        // The permission check follows the argument, so enabling `safe_write`
+        // on Radarr does not quietly enable it on Sonarr.
+        service: ({ service }) => service,
+        operation: 'trigger_search',
+        tier: 'safe',
+
+        async plan({ service, id }): Promise<WritePlan> {
+            const adapter = findAdapter(adapters, service);
+
+            // A read before the write, for two reasons: it fails early and
+            // legibly if the id does not exist ("Radarr has no movie 9999"
+            // rather than a 404 from a command endpoint), and it puts a real
+            // title in the preview — a confirmation prompt that says "search
+            // for item 5" is one nobody can meaningfully approve.
+            if (!hasMediaDetails(adapter)) {
+                throw new ServiceError('NotFound', service, `${service} cannot describe its own items`);
+            }
+            const details = await adapter.getMediaDetails(id, { includeEpisodes: false, episodeLimit: 0 });
+            const label = `${details.title}${details.year === undefined ? '' : ` (${details.year})`}`;
+
+            const effects = [
+                `Queues a ${service === 'sonarr' ? 'whole-series' : 'movie'} search on ${service} for ${label}.`,
+                'May grab and start downloading a release, which will appear in get_queue.'
+            ];
+
+            // Not a no-op — an unmonitored item can still be searched, and
+            // upstream will happily run the command — but the model should say
+            // so rather than let the user wonder why nothing arrives.
+            if (details.monitored === false) {
+                effects.push(
+                    `${label} is not monitored on ${service}, so the search may find a release and still not grab it.`
+                );
+            }
+            if (details.hasFile === true) {
+                effects.push('This item already has a file; a search may replace it with an upgrade.');
+            }
+
+            return {
+                target: `${service}:${id}`,
+                summary: `Ask ${service} to search for releases for ${label}.`,
+                effects,
+                args: { service, id }
+            };
+        },
+
+        async apply(_plan, { service, id }) {
+            return findAdapter(adapters, service).triggerSearch(id);
+        }
+    });
+}

--- a/src/tools/write.ts
+++ b/src/tools/write.ts
@@ -1,0 +1,300 @@
+import type { McpServer } from '@modelcontextprotocol/server';
+import * as z from 'zod/v4';
+import type { ServiceId } from '../config/schema.ts';
+import type { WriteAudit } from '../core/audit.ts';
+import type { ConfirmTokens, WriteIntent } from '../core/confirm.ts';
+import { ServiceError } from '../core/errors.ts';
+import { checkPermission, type PermissionSource, type WriteTier } from '../core/permissions.ts';
+import type { LibraryLoader } from './library.ts';
+
+/**
+ * Design spec §10, assembled once.
+ *
+ * The four properties a write must have — permission tier, `dry_run`, an audit
+ * record, per-call confirmation — are not four things each write tool
+ * remembers to do. They are this function, and a write tool supplies only the
+ * two halves that are actually specific to it: `plan`, which resolves
+ * arguments into a concrete described effect without touching anything, and
+ * `apply`, which is reached only once all four gates have passed.
+ *
+ * That split is the design. A tool physically cannot mutate during the preview
+ * phase, because the preview phase only ever calls `plan` — the mutating code
+ * is in a callback the harness declines to invoke. Reviewing a new write tool
+ * therefore means reading its `plan`/`apply` pair, not auditing whether it
+ * remembered to check permissions.
+ */
+
+/** What `plan` resolved the request into: a concrete target and a description
+ *  of the effect, in the model's words rather than the service's. */
+export type WritePlan = {
+    /** The resolved id the write will act on. The confirmation token binds to
+     *  this, so a token cannot survive re-resolving a title to a different film. */
+    target: string;
+    /** One sentence, safe to show a human: "Delete Alien (1979) from Radarr, leaving files on disk." */
+    summary: string;
+    /** Itemised consequences, most severe first. Empty is legitimate for a
+     *  no-op — see the `noop` field. */
+    effects: string[];
+    /** Effect-bearing arguments, folded into the token binding. Anything that
+     *  changes what `apply` does belongs here or the token would not commit to it. */
+    args?: Record<string, unknown>;
+    /**
+     * Set when the plan resolved successfully but there is nothing to do — the
+     * film is already monitored, the request is already approved. The harness
+     * short-circuits: no token, no confirmation, no write, and the audit
+     * records it as a dry run. A confirmation prompt for a no-op trains a
+     * model to confirm reflexively.
+     */
+    noop?: boolean;
+};
+
+export type WriteToolSpec<Schema extends z.ZodObject> = {
+    name: string;
+    description: string;
+    /** Tool-specific arguments. `dry_run` and `confirm` are added here, so no
+     *  write tool can accidentally omit or redefine them. */
+    inputSchema: Schema;
+    /**
+     * Which service's permissions govern this call — a fixed id for a
+     * single-service tool, or a function of the arguments for one that spans
+     * several (`trigger_search` reaches both Radarr and Sonarr).
+     *
+     * It must be derived from the arguments and nothing else. Resolving it from
+     * the *plan* would let a tool that had already done a read decide its own
+     * permission scope, and a fixed id on a multi-service tool is worse still:
+     * it would check Sonarr writes against Radarr's `permissions` block, so
+     * enabling one service would quietly enable the other.
+     */
+    service: ServiceId | ((args: z.infer<Schema>) => ServiceId);
+    /** The adapter-level verb, e.g. `delete_movie`; one tool may reach several. */
+    operation: string;
+    tier: WriteTier;
+    plan(args: z.infer<Schema>): Promise<WritePlan>;
+    apply(plan: WritePlan, args: z.infer<Schema>): Promise<unknown>;
+};
+
+export type WriteContext = {
+    permissions: PermissionSource;
+    confirm: ConfirmTokens;
+    audit: WriteAudit;
+    /** Invalidated after a successful write (§16). */
+    library: LibraryLoader;
+};
+
+const DryRunSchema = z
+    .boolean()
+    .default(false)
+    .describe(
+        'Preview only: resolve the target and describe exactly what would happen, then stop. Never mutates anything and never returns a confirmation token. Use this to answer "what would happen if…" — not as the first step of actually doing it.'
+    );
+
+const ConfirmSchema = z
+    .string()
+    .optional()
+    .describe(
+        'The confirmation token from this same tool\'s preview of this same operation. Omit it to get a preview and a token; pass the token back verbatim to apply the change. Tokens are single-use, expire, and are bound to the exact operation and arguments previewed.'
+    );
+
+export type WriteToolResult = {
+    applied: boolean;
+    dry_run: boolean;
+    tool: string;
+    service: ServiceId;
+    operation: string;
+    tier: WriteTier;
+    target: string;
+    summary: string;
+    effects: string[];
+    noop: boolean;
+    permission: { allowed: boolean; reason?: string; remedy?: string };
+    confirm_token?: string;
+    /** Why a presented token was rejected. Present only when one was presented. */
+    confirm_error?: string;
+    /** Whatever `apply` returned, on a real write. */
+    result?: unknown;
+    audit_id?: number;
+};
+
+/**
+ * The one place a write tool is turned into an MCP tool. Every branch below
+ * either records an audit row or is a pure preview that records one as
+ * `dry_run` — there is no path from arguments to `apply` that skips the tier
+ * check, the confirmation, or the trail.
+ */
+export function registerWriteTool<Schema extends z.ZodObject>(
+    server: McpServer,
+    context: WriteContext,
+    spec: WriteToolSpec<Schema>
+): void {
+    const { permissions, confirm, audit, library } = context;
+
+    server.registerTool(
+        spec.name,
+        {
+            description: spec.description,
+            inputSchema: spec.inputSchema.extend({ dry_run: DryRunSchema, confirm: ConfirmSchema })
+        },
+        async (raw: Record<string, unknown>) => {
+            const { dry_run: dryRun, confirm: presented, ...rest } = raw as {
+                dry_run: boolean;
+                confirm?: string;
+            };
+            const args = rest as z.infer<Schema>;
+
+            // Resolved from the arguments alone, before anything else runs, so
+            // the service whose permissions are checked is the service the
+            // audit names and the token binds to. Deriving it later — from the
+            // plan, say — would let the three disagree.
+            const service = typeof spec.service === 'function' ? spec.service(args) : spec.service;
+
+            // Resolution happens first, and for every path including a denied
+            // one. A refusal that cannot even name what it refused ("permission
+            // denied" with no film attached) is not actionable, and resolving
+            // is a read — already permitted, and already what the model could
+            // do for itself with get_media_details.
+            const plan = await spec.plan(args);
+
+            const verdict = checkPermission(permissions, service, spec.tier);
+            const permission: WriteToolResult['permission'] = verdict.allowed
+                ? { allowed: true }
+                : { allowed: false, reason: verdict.reason, remedy: verdict.remedy };
+
+            const record = {
+                tool: spec.name,
+                service,
+                operation: spec.operation,
+                tier: spec.tier,
+                target: plan.target,
+                args: plan.args ?? {}
+            };
+
+            const preview = (extra: Partial<WriteToolResult>): WriteToolResult => ({
+                applied: false,
+                dry_run: dryRun,
+                tool: spec.name,
+                service,
+                operation: spec.operation,
+                tier: spec.tier,
+                target: plan.target,
+                summary: plan.summary,
+                effects: plan.effects,
+                noop: plan.noop === true,
+                permission,
+                ...extra
+            });
+
+            const respond = (result: WriteToolResult, text: string) => ({
+                content: [{ type: 'text' as const, text }],
+                structuredContent: result
+            });
+
+            // --- 1. Nothing to do -------------------------------------------------
+            if (plan.noop === true) {
+                const id = audit.begin(record);
+                audit.settle(id, 'dry_run', 'no-op: already in the requested state');
+                return respond(
+                    preview({ audit_id: id }),
+                    `Nothing to do — ${plan.summary} No change was made and no confirmation is needed.`
+                );
+            }
+
+            // --- 2. dry_run: terminal preview, never gated ------------------------
+            //
+            // A dry run is deliberately *not* refused when the tier is off. It
+            // performs no mutation, and everything it reveals is already
+            // reachable through the read tools — so refusing it would withhold
+            // nothing while making "what would I need to enable to do this?"
+            // unanswerable. The verdict rides along in `permission` instead, so
+            // the model learns the write would be refused and can say so.
+            if (dryRun) {
+                const id = audit.begin(record);
+                audit.settle(id, 'dry_run', verdict.allowed ? undefined : verdict.reason);
+                return respond(
+                    preview({ audit_id: id }),
+                    `Dry run — nothing was changed. ${plan.summary}` +
+                        (verdict.allowed
+                            ? ' Omit `dry_run` to preview it for real and receive a confirmation token.'
+                            : ` Note that this write would currently be refused: ${verdict.reason}. ${verdict.remedy}`)
+                );
+            }
+
+            // --- 3. Permission tier ----------------------------------------------
+            if (!verdict.allowed) {
+                const id = audit.begin(record);
+                audit.settle(id, 'denied', verdict.reason);
+                throw new ServiceError('PermissionDenied', service, verdict.reason, { remedy: verdict.remedy });
+            }
+
+            const intent: WriteIntent = {
+                tool: spec.name,
+                service,
+                tier: spec.tier,
+                operation: spec.operation,
+                target: plan.target,
+                ...(plan.args === undefined ? {} : { args: plan.args })
+            };
+
+            // --- 4. Confirmation --------------------------------------------------
+            if (presented !== undefined) {
+                const check = confirm.verifyAndConsume(presented, intent);
+                if (!check.ok) {
+                    // An already-spent token is the one rejection that does not
+                    // get a fresh one. The write it authorised may well have
+                    // happened, and handing back a new token invites a model
+                    // that lost track to apply it twice — the exact duplicate
+                    // single-use exists to prevent. Every other rejection is a
+                    // caller mistake with no such risk, so it degrades to a
+                    // normal preview carrying the reason.
+                    if (check.failure === 'used') {
+                        const id = audit.begin(record);
+                        audit.settle(id, 'denied', 'confirmation token already used');
+                        throw new ServiceError('PermissionDenied', service, 'confirmation token already used', {
+                            remedy: check.remedy
+                        });
+                    }
+
+                    const id = audit.begin(record);
+                    audit.settle(id, 'unconfirmed', `confirmation ${check.failure}`);
+                    return respond(
+                        preview({
+                            audit_id: id,
+                            confirm_error: check.remedy,
+                            confirm_token: confirm.issue(intent)
+                        }),
+                        `Not applied — the confirmation token was rejected (${check.failure}). ${check.remedy} A fresh token for this exact operation is in \`confirm_token\`.`
+                    );
+                }
+            } else {
+                const id = audit.begin(record);
+                audit.settle(id, 'unconfirmed');
+                return respond(
+                    preview({ audit_id: id, confirm_token: confirm.issue(intent) }),
+                    `Not applied yet. ${plan.summary}\n\n` +
+                        `${plan.effects.map(e => `- ${e}`).join('\n')}\n\n` +
+                        `To apply this, call ${spec.name} again with the same arguments plus \`confirm\` set to the token in \`confirm_token\`.`
+                );
+            }
+
+            // --- 5. Apply ---------------------------------------------------------
+            const id = audit.begin(record);
+            let outcome: unknown;
+            try {
+                outcome = await spec.apply(plan, args);
+            } catch (err) {
+                audit.settle(id, 'failed', err instanceof Error ? err.message : String(err));
+                throw err;
+            }
+
+            // Only after a write that actually landed: a failed write changed
+            // nothing, and dropping the cache for it would cost every cached
+            // library snapshot for no reason.
+            library.invalidate();
+            audit.settle(id, 'applied');
+
+            return respond(
+                { ...preview({ audit_id: id }), applied: true, ...(outcome === undefined ? {} : { result: outcome }) },
+                `Applied. ${plan.summary}`
+            );
+        }
+    );
+}

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -1,14 +1,18 @@
 import { describe, expect, it } from 'vitest';
 import { buildApp } from '../src/app.ts';
 import { ConfigSchema } from '../src/config/schema.ts';
+import { WriteAudit } from '../src/core/audit.ts';
 import { RadarrAdapter } from '../src/services/radarr.ts';
 import { TOOL_NAMES } from '../src/tools/register.ts';
 
 const TOKEN = 'a'.repeat(64);
 const WRONG = 'b'.repeat(64);
 
+/** In-memory, so these tests never touch a config directory. */
+const audit = () => WriteAudit.ephemeral();
+
 const config = ConfigSchema.parse({ auth: { bearer_token: TOKEN }, services: {} });
-const app = () => buildApp({ config, adapters: [] });
+const app = () => buildApp({ config, adapters: [], audit: audit() });
 
 const rpc = (body: unknown, headers: Record<string, string> = {}) => ({
     method: 'POST',
@@ -132,7 +136,8 @@ describe('DNS rebinding protection', () => {
                 auth: { bearer_token: TOKEN, allowed_hosts: ['arr.example.com'] },
                 services: {}
             }),
-            adapters: []
+            adapters: [],
+            audit: audit()
         });
 
         // Hono's synthetic request helper does not derive a Host header from
@@ -209,7 +214,11 @@ describe('a thrown ServiceError reaches the client with its remedy', () => {
                 status: 401,
                 headers: { 'content-type': 'application/json' }
             });
-        const withRadarr = buildApp({ config, adapters: [new RadarrAdapter(radarrConfig, unauthorized)] });
+        const withRadarr = buildApp({
+            config,
+            adapters: [new RadarrAdapter(radarrConfig, unauthorized)],
+            audit: audit()
+        });
 
         const callTool = {
             jsonrpc: '2.0',
@@ -241,7 +250,11 @@ describe('a thrown ServiceError reaches the client with its remedy', () => {
                 status: 404,
                 headers: { 'content-type': 'application/json' }
             });
-        const withRadarr = buildApp({ config, adapters: [new RadarrAdapter(radarrConfig, notFound)] });
+        const withRadarr = buildApp({
+            config,
+            adapters: [new RadarrAdapter(radarrConfig, notFound)],
+            audit: audit()
+        });
 
         const callTool = {
             jsonrpc: '2.0',

--- a/test/audit.test.ts
+++ b/test/audit.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { WriteAudit, type AuditRecord } from '../src/core/audit.ts';
+
+type Row = {
+    tool: string;
+    service: string;
+    operation: string;
+    tier: string;
+    target: string;
+    args: string;
+    outcome: string;
+    detail: string | null;
+    settled_at: string | null;
+    at: string;
+};
+
+const record = (over: Partial<AuditRecord> = {}): AuditRecord => ({
+    tool: 'delete_media',
+    service: 'radarr',
+    operation: 'delete_movie',
+    tier: 'destructive',
+    target: '5',
+    args: { deleteFiles: true },
+    ...over
+});
+
+let audit: WriteAudit | undefined;
+const open = (): WriteAudit => (audit = WriteAudit.ephemeral());
+
+afterEach(() => {
+    audit?.close();
+    audit = undefined;
+});
+
+describe('write audit', () => {
+    it('records the intent before the service is called', () => {
+        const trail = open();
+        trail.begin(record());
+
+        const [row] = trail.recent() as Row[];
+        expect(row?.outcome).toBe('attempted');
+        expect(row?.tool).toBe('delete_media');
+        expect(row?.target).toBe('5');
+    });
+
+    it('settles an attempt into its outcome', () => {
+        const trail = open();
+        const id = trail.begin(record());
+        trail.settle(id, 'applied');
+
+        const [row] = trail.recent() as Row[];
+        expect(row?.outcome).toBe('applied');
+        expect(row?.settled_at).not.toBeNull();
+    });
+
+    // The case an after-the-fact-only log cannot show: the process died between
+    // calling the service and learning what happened.
+    it('leaves a row reading attempted when nothing settles it', () => {
+        const trail = open();
+        trail.begin(record());
+        const [row] = trail.recent() as Row[];
+        expect(row?.outcome).toBe('attempted');
+        expect(row?.settled_at).toBeNull();
+    });
+
+    it('keeps one row per operation rather than appending a second', () => {
+        const trail = open();
+        const id = trail.begin(record());
+        trail.settle(id, 'failed', 'radarr upstream error: HTTP 500');
+        expect(trail.recent()).toHaveLength(1);
+    });
+
+    it('carries the failure detail so the trail says why', () => {
+        const trail = open();
+        trail.settle(trail.begin(record()), 'failed', 'radarr upstream error: HTTP 500');
+        const [row] = trail.recent() as Row[];
+        expect(row?.detail).toContain('HTTP 500');
+    });
+
+    it('records denials and dry runs, not only writes that happened', () => {
+        const trail = open();
+        trail.settle(trail.begin(record()), 'denied', 'destructive writes are disabled for radarr');
+        trail.settle(trail.begin(record({ target: '6' })), 'dry_run');
+
+        const outcomes = (trail.recent() as Row[]).map(r => r.outcome);
+        expect(outcomes).toEqual(['dry_run', 'denied']);
+    });
+
+    it('returns newest first', () => {
+        const trail = open();
+        trail.begin(record({ target: 'first' }));
+        trail.begin(record({ target: 'second' }));
+        expect((trail.recent() as Row[])[0]?.target).toBe('second');
+    });
+
+    it('honours the limit', () => {
+        const trail = open();
+        for (let i = 0; i < 5; i += 1) trail.begin(record({ target: String(i) }));
+        expect(trail.recent(2)).toHaveLength(2);
+    });
+
+    it('stores the arguments as JSON so the trail says what was asked for', () => {
+        const trail = open();
+        trail.begin(record({ args: { deleteFiles: true, addImportExclusion: false } }));
+        const [row] = trail.recent() as Row[];
+        expect(JSON.parse(row?.args ?? '{}')).toEqual({ deleteFiles: true, addImportExclusion: false });
+    });
+
+    // No write tool takes a credential today; this keeps that true by
+    // construction rather than by everyone remembering.
+    it('redacts anything credential-shaped that reaches it', () => {
+        const trail = open();
+        trail.begin(record({ args: { api_key: 'sk-secret', password: 'hunter2', deleteFiles: true } }));
+
+        const [row] = trail.recent() as Row[];
+        const args = JSON.parse(row?.args ?? '{}') as Record<string, unknown>;
+        expect(args.api_key).toBe('__REDACTED__');
+        expect(args.password).toBe('__REDACTED__');
+        expect(args.deleteFiles).toBe(true);
+        expect(row?.args).not.toContain('hunter2');
+    });
+});

--- a/test/confirm.test.ts
+++ b/test/confirm.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+import { ConfirmTokens, CONFIRM_TTL_MS, type WriteIntent } from '../src/core/confirm.ts';
+
+const intent = (over: Partial<WriteIntent> = {}): WriteIntent => ({
+    tool: 'delete_media',
+    service: 'radarr',
+    tier: 'destructive',
+    operation: 'delete_movie',
+    target: '5',
+    args: { deleteFiles: true },
+    ...over
+});
+
+/** A clock the test drives, so expiry is asserted rather than waited for. */
+const stoppedClock = (start = 1_700_000_000_000) => {
+    let now = start;
+    return { now: () => now, advance: (ms: number) => (now += ms) };
+};
+
+describe('confirmation tokens', () => {
+    it('accepts a token for the operation it was issued for', () => {
+        const tokens = new ConfirmTokens();
+        const token = tokens.issue(intent());
+        expect(tokens.verifyAndConsume(token, intent()).ok).toBe(true);
+    });
+
+    // The property that makes the handshake worth having: previewing something
+    // harmless must not yield a token that authorises something else.
+    it('refuses a token issued for a different target', () => {
+        const tokens = new ConfirmTokens();
+        const token = tokens.issue(intent({ target: '5' }));
+
+        const result = tokens.verifyAndConsume(token, intent({ target: '9' }));
+        expect(result.ok).toBe(false);
+        if (result.ok) return;
+        expect(result.failure).toBe('mismatch');
+    });
+
+    it('refuses a token when an effect-bearing argument changed', () => {
+        const tokens = new ConfirmTokens();
+        const token = tokens.issue(intent({ args: { deleteFiles: false } }));
+
+        const result = tokens.verifyAndConsume(token, intent({ args: { deleteFiles: true } }));
+        expect(result.ok).toBe(false);
+    });
+
+    it('refuses a token issued for a different tool or operation', () => {
+        const tokens = new ConfirmTokens();
+        const token = tokens.issue(intent());
+
+        expect(tokens.verifyAndConsume(token, intent({ tool: 'other_tool' })).ok).toBe(false);
+        expect(tokens.verifyAndConsume(token, intent({ operation: 'unmonitor_movie' })).ok).toBe(false);
+    });
+
+    // Key order is an accident of how the object was built; failing on it would
+    // be maddening to diagnose and would train callers to distrust the handshake.
+    it('does not care about argument key order', () => {
+        const tokens = new ConfirmTokens();
+        const token = tokens.issue(intent({ args: { a: 1, b: 2 } }));
+        expect(tokens.verifyAndConsume(token, intent({ args: { b: 2, a: 1 } })).ok).toBe(true);
+    });
+
+    it('is single-use, so one preview cannot be applied twice', () => {
+        const tokens = new ConfirmTokens();
+        const token = tokens.issue(intent());
+
+        expect(tokens.verifyAndConsume(token, intent()).ok).toBe(true);
+        const second = tokens.verifyAndConsume(token, intent());
+        expect(second.ok).toBe(false);
+        if (second.ok) return;
+        expect(second.failure).toBe('used');
+    });
+
+    it('expires', () => {
+        const clock = stoppedClock();
+        const tokens = new ConfirmTokens({ clock: clock.now });
+        const token = tokens.issue(intent());
+
+        clock.advance(CONFIRM_TTL_MS + 1);
+        const result = tokens.verifyAndConsume(token, intent());
+        expect(result.ok).toBe(false);
+        if (result.ok) return;
+        expect(result.failure).toBe('expired');
+    });
+
+    // Reported as expired rather than mismatched, so the remedy tells the caller
+    // to re-preview rather than to go hunting for an argument that differs.
+    it('reports an expired token as expired even when the operation still matches', () => {
+        const clock = stoppedClock();
+        const tokens = new ConfirmTokens({ clock: clock.now });
+        const token = tokens.issue(intent());
+
+        clock.advance(CONFIRM_TTL_MS * 2);
+        const result = tokens.verifyAndConsume(token, intent());
+        if (result.ok) throw new Error('expected a rejection');
+        expect(result.failure).toBe('expired');
+    });
+
+    // An NTP step backwards must not make a token valid forever.
+    it('refuses a token that claims to be from the future', () => {
+        const clock = stoppedClock();
+        const tokens = new ConfirmTokens({ clock: clock.now });
+        const token = tokens.issue(intent());
+
+        clock.advance(-60_000);
+        const result = tokens.verifyAndConsume(token, intent());
+        expect(result.ok).toBe(false);
+    });
+
+    it('rejects a forged token rather than trusting its timestamp', () => {
+        const tokens = new ConfirmTokens();
+        const forged = `v1.${Date.now().toString(36)}.not-a-real-signature`;
+
+        const result = tokens.verifyAndConsume(forged, intent());
+        expect(result.ok).toBe(false);
+        if (result.ok) return;
+        expect(result.failure).toBe('mismatch');
+    });
+
+    it('rejects malformed tokens', () => {
+        const tokens = new ConfirmTokens();
+        for (const bad of ['', 'nonsense', 'v2.abc.def', 'v1.abc']) {
+            const result = tokens.verifyAndConsume(bad, intent());
+            expect(result.ok, bad).toBe(false);
+        }
+    });
+
+    // Two servers, or one server restarted, must not honour each other's tokens.
+    it('does not honour a token from a different instance', () => {
+        const a = new ConfirmTokens();
+        const b = new ConfirmTokens();
+        expect(b.verifyAndConsume(a.issue(intent()), intent()).ok).toBe(false);
+    });
+
+    it('every rejection carries a remedy saying what to do next', () => {
+        const tokens = new ConfirmTokens();
+        const result = tokens.verifyAndConsume('nonsense', intent());
+        if (result.ok) throw new Error('expected a rejection');
+        expect(result.remedy.length).toBeGreaterThan(20);
+    });
+});

--- a/test/permissions.test.ts
+++ b/test/permissions.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import type { AnyServiceConfig, ServiceId } from '../src/config/schema.ts';
+import { ServiceError } from '../src/core/errors.ts';
+import { assertPermitted, checkPermission, permissionSourceFrom } from '../src/core/permissions.ts';
+
+const service = (safe_write: boolean, destructive: boolean): AnyServiceConfig =>
+    ({
+        url: 'http://192.0.2.10:7878',
+        api_key: 'k',
+        timeout_ms: 10_000,
+        permissions: { safe_write, destructive }
+    }) as AnyServiceConfig;
+
+const sourceFor = (permissions: Partial<Record<ServiceId, AnyServiceConfig>>) => permissionSourceFrom(permissions);
+
+describe('permission tiers', () => {
+    it('refuses both tiers by default — nothing but a deliberate edit grants a write', () => {
+        const source = sourceFor({ radarr: service(false, false) });
+        expect(checkPermission(source, 'radarr', 'safe').allowed).toBe(false);
+        expect(checkPermission(source, 'radarr', 'destructive').allowed).toBe(false);
+    });
+
+    it('grants safe writes from safe_write', () => {
+        const source = sourceFor({ radarr: service(true, false) });
+        expect(checkPermission(source, 'radarr', 'safe').allowed).toBe(true);
+    });
+
+    it('does not let safe_write grant a destructive write', () => {
+        const source = sourceFor({ radarr: service(true, false) });
+        const verdict = checkPermission(source, 'radarr', 'destructive');
+        expect(verdict.allowed).toBe(false);
+    });
+
+    // The ordering rule. A config that permits deleting a film but refuses to
+    // re-monitor it describes no policy anyone would choose on purpose.
+    it('lets destructive grant safe writes too, because the tiers are ordered', () => {
+        const source = sourceFor({ radarr: service(false, true) });
+        expect(checkPermission(source, 'radarr', 'safe').allowed).toBe(true);
+        expect(checkPermission(source, 'radarr', 'destructive').allowed).toBe(true);
+    });
+
+    it('is per service — enabling Radarr does not enable Sonarr', () => {
+        const source = sourceFor({ radarr: service(true, true), sonarr: service(false, false) });
+        expect(checkPermission(source, 'radarr', 'safe').allowed).toBe(true);
+        expect(checkPermission(source, 'sonarr', 'safe').allowed).toBe(false);
+    });
+
+    it('refuses an unconfigured service, naming the block to add', () => {
+        const verdict = checkPermission(sourceFor({}), 'sonarr', 'safe');
+        expect(verdict.allowed).toBe(false);
+        if (verdict.allowed) return;
+        expect(verdict.reason).toContain('not configured');
+        expect(verdict.remedy).toContain('services.sonarr');
+    });
+
+    it('names the exact YAML key a denial needs, per tier', () => {
+        const source = sourceFor({ radarr: service(false, false) });
+        const safe = checkPermission(source, 'radarr', 'safe');
+        const destructive = checkPermission(source, 'radarr', 'destructive');
+
+        if (safe.allowed || destructive.allowed) throw new Error('expected both to be denied');
+        expect(safe.remedy).toContain('services.radarr.permissions.safe_write: true');
+        expect(destructive.remedy).toContain('services.radarr.permissions.destructive: true');
+    });
+});
+
+describe('assertPermitted', () => {
+    it('passes silently when granted', () => {
+        expect(() => assertPermitted(sourceFor({ radarr: service(true, false) }), 'radarr', 'safe')).not.toThrow();
+    });
+
+    // §15: the remedy has to live in `.message`, because a generic catcher —
+    // including the MCP SDK's own dispatch loop — reads nothing else.
+    it('throws a ServiceError whose message already carries the remedy', () => {
+        try {
+            assertPermitted(sourceFor({ radarr: service(false, false) }), 'radarr', 'destructive');
+            throw new Error('expected a throw');
+        } catch (err) {
+            expect(err).toBeInstanceOf(ServiceError);
+            const se = err as ServiceError;
+            expect(se.kind).toBe('PermissionDenied');
+            expect(se.service).toBe('radarr');
+            expect(se.message).toContain('permissions.destructive: true');
+        }
+    });
+});

--- a/test/triggerSearch.test.ts
+++ b/test/triggerSearch.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it, vi } from 'vitest';
+import * as z from 'zod/v4';
+import type { AnyServiceConfig, KeyedServiceConfig, ServiceId } from '../src/config/schema.ts';
+import { WriteAudit } from '../src/core/audit.ts';
+import { ConfirmTokens } from '../src/core/confirm.ts';
+import { ServiceError } from '../src/core/errors.ts';
+import { permissionSourceFrom } from '../src/core/permissions.ts';
+import { RadarrAdapter } from '../src/services/radarr.ts';
+import { SonarrAdapter } from '../src/services/sonarr.ts';
+import type { ServiceAdapter } from '../src/services/types.ts';
+import type { LibraryLoader } from '../src/tools/library.ts';
+import { registerTriggerSearch } from '../src/tools/triggerSearch.ts';
+import type { WriteToolResult } from '../src/tools/write.ts';
+import { jsonResponse } from './helpers/serve.ts';
+
+const keyed = (port: number): KeyedServiceConfig => ({
+    url: `http://192.0.2.10:${port}`,
+    api_key: 'k',
+    timeout_ms: 10_000,
+    permissions: { safe_write: false, destructive: false }
+});
+
+const permissive = (safe_write: boolean, destructive = false): AnyServiceConfig =>
+    ({ ...keyed(7878), permissions: { safe_write, destructive } }) as AnyServiceConfig;
+
+/** Records what was actually sent, which is the whole point for a write. */
+function recordingFetch(routes: Record<string, unknown>) {
+    const sent: { url: string; method: string; body: unknown }[] = [];
+    const impl = (async (input: string | URL | Request, init?: RequestInit) => {
+        const url = new URL(input instanceof Request ? input.url : String(input));
+        sent.push({
+            url: url.pathname,
+            method: init?.method ?? 'GET',
+            body: typeof init?.body === 'string' ? JSON.parse(init.body) : undefined
+        });
+        if (url.pathname in routes) return jsonResponse(routes[url.pathname]);
+        return jsonResponse({ message: 'not found' }, 404);
+    }) as unknown as typeof fetch;
+
+    return { impl, sent };
+}
+
+const MOVIE = { id: 5, title: 'Alien', year: 1979, monitored: true, hasFile: true };
+const SERIES = { id: 7, title: 'Alien: Earth', year: 2025, monitored: true, statistics: { episodeFileCount: 3 } };
+const COMMAND = { id: 4321, name: 'MoviesSearch', status: 'queued' };
+
+describe('RadarrAdapter.triggerSearch', () => {
+    it('posts MoviesSearch with the id in an array, as Radarr requires', async () => {
+        const { impl, sent } = recordingFetch({ '/api/v3/command': COMMAND });
+        const handle = await new RadarrAdapter(keyed(7878), impl).triggerSearch('5');
+
+        const post = sent.find(s => s.method === 'POST');
+        expect(post?.url).toBe('/api/v3/command');
+        expect(post?.body).toEqual({ name: 'MoviesSearch', movieIds: [5] });
+        expect(handle).toEqual({ service: 'radarr', commandId: 4321, name: 'MoviesSearch', status: 'queued' });
+    });
+
+    // A string in `movieIds` is accepted by Radarr and matches nothing, so a
+    // search that never ran would report success.
+    it('sends the id as a number, not a string', async () => {
+        const { impl, sent } = recordingFetch({ '/api/v3/command': COMMAND });
+        await new RadarrAdapter(keyed(7878), impl).triggerSearch('5');
+
+        const body = sent.find(s => s.method === 'POST')?.body as { movieIds: unknown[] };
+        expect(body.movieIds[0]).toBeTypeOf('number');
+    });
+
+    it('refuses a non-numeric id rather than posting a search for NaN', async () => {
+        const { impl, sent } = recordingFetch({ '/api/v3/command': COMMAND });
+        await expect(new RadarrAdapter(keyed(7878), impl).triggerSearch('Alien')).rejects.toThrow(ServiceError);
+        expect(sent.filter(s => s.method === 'POST')).toHaveLength(0);
+    });
+});
+
+describe('SonarrAdapter.triggerSearch', () => {
+    // Upstream's own asymmetry: a bare id here, an array in Radarr. Passing
+    // Radarr's shape is accepted and searches nothing.
+    it('posts SeriesSearch with a bare seriesId, not an array', async () => {
+        const { impl, sent } = recordingFetch({ '/api/v3/command': { id: 99, name: 'SeriesSearch' } });
+        const handle = await new SonarrAdapter(keyed(8989), impl).triggerSearch('7');
+
+        expect(sent.find(s => s.method === 'POST')?.body).toEqual({ name: 'SeriesSearch', seriesId: 7 });
+        expect(handle.service).toBe('sonarr');
+        expect(handle.commandId).toBe(99);
+    });
+});
+
+// --- the tool ------------------------------------------------------------
+
+type Call = (args: Record<string, unknown>) => Promise<{
+    content: { type: 'text'; text: string }[];
+    structuredContent: WriteToolResult;
+}>;
+
+function harness(opts: { permissions?: Partial<Record<ServiceId, AnyServiceConfig>>; adapters?: ServiceAdapter[] } = {}) {
+    const radarrFetch = recordingFetch({ '/api/v3/movie/5': MOVIE, '/api/v3/command': COMMAND });
+    const sonarrFetch = recordingFetch({
+        '/api/v3/series/7': SERIES,
+        '/api/v3/command': { id: 99, name: 'SeriesSearch' }
+    });
+
+    const adapters = opts.adapters ?? [
+        new RadarrAdapter(keyed(7878), radarrFetch.impl),
+        new SonarrAdapter(keyed(8989), sonarrFetch.impl)
+    ];
+
+    let call: Call = () => Promise.reject(new Error('not registered'));
+    const server = {
+        registerTool(_name: string, config: { inputSchema: z.ZodObject }, handler: Call) {
+            call = args => handler(config.inputSchema.parse(args) as Record<string, unknown>);
+        }
+    };
+
+    const invalidate = vi.fn();
+    registerTriggerSearch(
+        server as never,
+        {
+            permissions: permissionSourceFrom(opts.permissions ?? { radarr: permissive(true), sonarr: permissive(true) }),
+            confirm: new ConfirmTokens(),
+            audit: WriteAudit.ephemeral(),
+            library: { invalidate } as unknown as LibraryLoader
+        },
+        adapters
+    );
+
+    return { call: (args: Record<string, unknown>) => call(args), radarrFetch, sonarrFetch, invalidate };
+}
+
+describe('trigger_search', () => {
+    it('previews with the real title, not the bare id', async () => {
+        const h = harness();
+        const { structuredContent } = await h.call({ service: 'radarr', id: '5', dry_run: true });
+
+        expect(structuredContent.summary).toContain('Alien');
+        expect(structuredContent.summary).toContain('1979');
+        expect(structuredContent.target).toBe('radarr:5');
+    });
+
+    it('changes nothing on a dry run', async () => {
+        const h = harness();
+        await h.call({ service: 'radarr', id: '5', dry_run: true });
+        expect(h.radarrFetch.sent.filter(s => s.method === 'POST')).toHaveLength(0);
+    });
+
+    it('does not search on the first call, then does on the confirmed one', async () => {
+        const h = harness();
+        const first = await h.call({ service: 'radarr', id: '5' });
+        expect(h.radarrFetch.sent.filter(s => s.method === 'POST')).toHaveLength(0);
+
+        const second = await h.call({ service: 'radarr', id: '5', confirm: first.structuredContent.confirm_token });
+        expect(second.structuredContent.applied).toBe(true);
+        expect(h.radarrFetch.sent.filter(s => s.method === 'POST')).toHaveLength(1);
+    });
+
+    it('warns that an upgrade may replace an existing file', async () => {
+        const h = harness();
+        const { structuredContent } = await h.call({ service: 'radarr', id: '5', dry_run: true });
+        expect(structuredContent.effects.join(' ')).toContain('upgrade');
+    });
+
+    it('says so when the item is not monitored, rather than letting it look like a no-op', async () => {
+        const unmonitored = recordingFetch({ '/api/v3/movie/5': { ...MOVIE, monitored: false } });
+        const h = harness({ adapters: [new RadarrAdapter(keyed(7878), unmonitored.impl)] });
+
+        const { structuredContent } = await h.call({ service: 'radarr', id: '5', dry_run: true });
+        expect(structuredContent.effects.join(' ')).toContain('not monitored');
+    });
+
+    // The reason the harness resolves `service` from the arguments: a fixed id
+    // would have checked Sonarr writes against Radarr's permissions block.
+    it('checks the permission of the service named in the arguments', async () => {
+        const h = harness({ permissions: { radarr: permissive(true), sonarr: permissive(false) } });
+
+        const allowed = await h.call({ service: 'radarr', id: '5' });
+        expect(allowed.structuredContent.confirm_token).toBeTypeOf('string');
+
+        await expect(h.call({ service: 'sonarr', id: '7' })).rejects.toThrow(
+            /services\.sonarr\.permissions\.safe_write: true/
+        );
+    });
+
+    it('is a safe-tier write, so safe_write alone is enough', async () => {
+        const h = harness({ permissions: { radarr: permissive(true, false) } });
+        const first = await h.call({ service: 'radarr', id: '5' });
+        expect(first.structuredContent.tier).toBe('safe');
+        expect(first.structuredContent.confirm_token).toBeTypeOf('string');
+    });
+
+    it('refuses a configured service that has no search to trigger', async () => {
+        // Present in the adapter list, so this exercises the capability check
+        // rather than falling through to "not configured" — two different
+        // refusals with two different remedies.
+        const jellyfin = {
+            id: 'jellyfin' as ServiceId,
+            testConnection: () => Promise.reject(new Error('unused')),
+            getVersion: () => Promise.resolve('10.8.0')
+        } as unknown as ServiceAdapter;
+
+        const h = harness({ adapters: [jellyfin], permissions: { jellyfin: permissive(true) } });
+        await expect(h.call({ service: 'jellyfin', id: '5', dry_run: true })).rejects.toThrow(/cannot be told to search/);
+    });
+
+    it('refuses an unconfigured service by name', async () => {
+        const h = harness({ adapters: [] });
+        await expect(h.call({ service: 'radarr', id: '5', dry_run: true })).rejects.toThrow(/not configured/);
+    });
+
+    // The read before the write: a bad id fails legibly at plan time rather
+    // than as a confusing 404 from a command endpoint.
+    it('fails naming the item when the id does not exist', async () => {
+        const empty = recordingFetch({});
+        const h = harness({ adapters: [new RadarrAdapter(keyed(7878), empty.impl)] });
+
+        await expect(h.call({ service: 'radarr', id: '9999', dry_run: true })).rejects.toThrow(ServiceError);
+        expect(empty.sent.filter(s => s.method === 'POST')).toHaveLength(0);
+    });
+
+    it('reports the queued command rather than claiming a release was found', async () => {
+        const h = harness();
+        const first = await h.call({ service: 'radarr', id: '5' });
+        const second = await h.call({ service: 'radarr', id: '5', confirm: first.structuredContent.confirm_token });
+
+        expect(second.structuredContent.result).toMatchObject({ commandId: 4321, name: 'MoviesSearch' });
+        expect(second.content[0]?.text).not.toContain('found');
+    });
+});

--- a/test/writeTool.test.ts
+++ b/test/writeTool.test.ts
@@ -1,0 +1,325 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as z from 'zod/v4';
+import type { AnyServiceConfig, ServiceId } from '../src/config/schema.ts';
+import { WriteAudit } from '../src/core/audit.ts';
+import { ConfirmTokens } from '../src/core/confirm.ts';
+import { ServiceError } from '../src/core/errors.ts';
+import { permissionSourceFrom } from '../src/core/permissions.ts';
+import type { LibraryLoader } from '../src/tools/library.ts';
+import { registerWriteTool, type WritePlan, type WriteToolResult } from '../src/tools/write.ts';
+
+/**
+ * A stand-in for McpServer that keeps the one behaviour the harness depends on:
+ * arguments are parsed against the declared schema — including its defaults —
+ * before the handler sees them. A fake that skipped the parse would hide the
+ * fact that `dry_run` gets its `false` from the schema.
+ */
+type Handler = (args: Record<string, unknown>) => Promise<{
+    content: { type: 'text'; text: string }[];
+    structuredContent: WriteToolResult;
+}>;
+
+function fakeServer() {
+    const tools = new Map<string, { schema: z.ZodObject; handler: Handler }>();
+    const server = {
+        registerTool(name: string, config: { inputSchema: z.ZodObject }, handler: Handler) {
+            tools.set(name, { schema: config.inputSchema, handler });
+        }
+    };
+
+    const call = async (name: string, args: Record<string, unknown> = {}) => {
+        const tool = tools.get(name);
+        if (tool === undefined) throw new Error(`no such tool: ${name}`);
+        return tool.handler(tool.schema.parse(args) as Record<string, unknown>);
+    };
+
+    return { server: server as never, call, tools };
+}
+
+const service = (safe_write: boolean, destructive: boolean): AnyServiceConfig =>
+    ({
+        url: 'http://192.0.2.10:7878',
+        api_key: 'k',
+        timeout_ms: 10_000,
+        permissions: { safe_write, destructive }
+    }) as AnyServiceConfig;
+
+const PLAN: WritePlan = {
+    target: '5',
+    summary: 'Delete Alien (1979) from Radarr, deleting files from disk.',
+    effects: ['Deletes 1 file totalling 24.1 GB from disk.', 'Removes the film from Radarr.'],
+    args: { deleteFiles: true }
+};
+
+type Harness = ReturnType<typeof buildHarness>;
+
+function buildHarness(
+    opts: {
+        permissions?: Partial<Record<ServiceId, AnyServiceConfig>>;
+        plan?: WritePlan;
+        apply?: () => Promise<unknown>;
+        tier?: 'safe' | 'destructive';
+    } = {}
+) {
+    const audit = WriteAudit.ephemeral();
+    const confirm = new ConfirmTokens();
+    const invalidate = vi.fn();
+    const apply = vi.fn(opts.apply ?? (() => Promise.resolve({ ok: true })));
+    const plan = vi.fn(() => Promise.resolve(opts.plan ?? PLAN));
+
+    const { server, call } = fakeServer();
+    registerWriteTool(
+        server,
+        {
+            permissions: permissionSourceFrom(opts.permissions ?? { radarr: service(false, true) }),
+            confirm,
+            audit,
+            library: { invalidate } as unknown as LibraryLoader
+        },
+        {
+            name: 'delete_media',
+            description: 'Deletes a film.',
+            inputSchema: z.object({ id: z.string() }),
+            service: 'radarr',
+            operation: 'delete_movie',
+            tier: opts.tier ?? 'destructive',
+            plan,
+            apply
+        }
+    );
+
+    return { audit, call, apply, plan, invalidate };
+}
+
+const outcomes = (h: Harness): string[] =>
+    (h.audit.recent() as { outcome: string }[]).map(r => r.outcome).reverse();
+
+let harness: Harness;
+beforeEach(() => {
+    harness = buildHarness();
+});
+
+describe('write tool harness — preview and confirm', () => {
+    it('does not apply anything on the first call, and returns a token', async () => {
+        const { structuredContent } = await harness.call('delete_media', { id: '5' });
+
+        expect(structuredContent.applied).toBe(false);
+        expect(structuredContent.confirm_token).toBeTypeOf('string');
+        expect(harness.apply).not.toHaveBeenCalled();
+    });
+
+    it('applies once the token from that preview comes back', async () => {
+        const first = await harness.call('delete_media', { id: '5' });
+        const second = await harness.call('delete_media', {
+            id: '5',
+            confirm: first.structuredContent.confirm_token
+        });
+
+        expect(second.structuredContent.applied).toBe(true);
+        expect(second.structuredContent.result).toEqual({ ok: true });
+        expect(harness.apply).toHaveBeenCalledTimes(1);
+    });
+
+    it('tells the model exactly how to apply it', async () => {
+        const { content } = await harness.call('delete_media', { id: '5' });
+        expect(content[0]?.text).toContain('confirm');
+        expect(content[0]?.text).toContain('delete_media');
+    });
+
+    it('refuses to apply the same token twice', async () => {
+        const first = await harness.call('delete_media', { id: '5' });
+        const token = first.structuredContent.confirm_token;
+
+        await harness.call('delete_media', { id: '5', confirm: token });
+        await expect(harness.call('delete_media', { id: '5', confirm: token })).rejects.toThrow(/already used/);
+        expect(harness.apply).toHaveBeenCalledTimes(1);
+    });
+
+    // A rejected-but-not-spent token is a caller mistake with no risk of a
+    // double-apply, so it degrades to a normal preview carrying the reason —
+    // more useful than an error the model then has to work backwards from.
+    it('returns a fresh preview, not an error, when the token is simply wrong', async () => {
+        const { structuredContent } = await harness.call('delete_media', { id: '5', confirm: 'nonsense' });
+
+        expect(structuredContent.applied).toBe(false);
+        expect(structuredContent.confirm_error).toBeTypeOf('string');
+        expect(structuredContent.confirm_token).toBeTypeOf('string');
+        expect(harness.apply).not.toHaveBeenCalled();
+    });
+
+    it('lets the fresh token from a rejection be used', async () => {
+        const rejected = await harness.call('delete_media', { id: '5', confirm: 'nonsense' });
+        const applied = await harness.call('delete_media', {
+            id: '5',
+            confirm: rejected.structuredContent.confirm_token
+        });
+        expect(applied.structuredContent.applied).toBe(true);
+    });
+});
+
+describe('write tool harness — dry_run', () => {
+    it('describes the effect and changes nothing', async () => {
+        const { structuredContent, content } = await harness.call('delete_media', { id: '5', dry_run: true });
+
+        expect(structuredContent.applied).toBe(false);
+        expect(structuredContent.dry_run).toBe(true);
+        expect(structuredContent.effects).toEqual(PLAN.effects);
+        expect(content[0]?.text).toContain('nothing was changed');
+        expect(harness.apply).not.toHaveBeenCalled();
+    });
+
+    // Issuing one would blur the two mechanisms: dry_run answers "what would
+    // happen", the handshake is for when you mean to do it.
+    it('issues no token, so a dry run cannot become a write', async () => {
+        const { structuredContent } = await harness.call('delete_media', { id: '5', dry_run: true });
+        expect(structuredContent.confirm_token).toBeUndefined();
+    });
+
+    // Refusing it would withhold nothing — everything in a preview is already
+    // reachable through the read tools — while making "what would I need to
+    // enable?" unanswerable.
+    it('still previews when the tier is off, and says the write would be refused', async () => {
+        const denied = buildHarness({ permissions: { radarr: service(false, false) } });
+        const { structuredContent, content } = await denied.call('delete_media', { id: '5', dry_run: true });
+
+        expect(structuredContent.permission.allowed).toBe(false);
+        expect(structuredContent.permission.remedy).toContain('permissions.destructive: true');
+        expect(content[0]?.text).toContain('would currently be refused');
+    });
+});
+
+describe('write tool harness — permission tiers', () => {
+    it('refuses a live write when the tier is off, before touching the service', async () => {
+        const denied = buildHarness({ permissions: { radarr: service(false, false) } });
+
+        await expect(denied.call('delete_media', { id: '5' })).rejects.toThrow(ServiceError);
+        expect(denied.apply).not.toHaveBeenCalled();
+    });
+
+    it('names the YAML key in the refusal', async () => {
+        const denied = buildHarness({ permissions: { radarr: service(false, false) } });
+        await expect(denied.call('delete_media', { id: '5' })).rejects.toThrow(
+            /services\.radarr\.permissions\.destructive: true/
+        );
+    });
+
+    it('refuses before issuing a token, so a denial cannot be confirmed around', async () => {
+        const denied = buildHarness({ permissions: { radarr: service(true, false) } });
+        await expect(denied.call('delete_media', { id: '5' })).rejects.toThrow(ServiceError);
+        expect(outcomes(denied)).toEqual(['denied']);
+    });
+
+    it('lets a safe-tier tool through on safe_write alone', async () => {
+        const safe = buildHarness({ tier: 'safe', permissions: { radarr: service(true, false) } });
+        const first = await safe.call('delete_media', { id: '5' });
+        expect(first.structuredContent.confirm_token).toBeTypeOf('string');
+    });
+});
+
+describe('write tool harness — no-op plans', () => {
+    const noopPlan: WritePlan = {
+        target: '5',
+        summary: 'Alien (1979) is already unmonitored in Radarr.',
+        effects: [],
+        noop: true
+    };
+
+    it('short-circuits without asking for a confirmation nobody needs', async () => {
+        const noop = buildHarness({ plan: noopPlan });
+        const { structuredContent, content } = await noop.call('delete_media', { id: '5' });
+
+        expect(structuredContent.applied).toBe(false);
+        expect(structuredContent.noop).toBe(true);
+        expect(structuredContent.confirm_token).toBeUndefined();
+        expect(content[0]?.text).toContain('Nothing to do');
+        expect(noop.apply).not.toHaveBeenCalled();
+    });
+});
+
+describe('write tool harness — the audit trail', () => {
+    it('records a preview, then the write it turned into', async () => {
+        const first = await harness.call('delete_media', { id: '5' });
+        await harness.call('delete_media', { id: '5', confirm: first.structuredContent.confirm_token });
+
+        expect(outcomes(harness)).toEqual(['unconfirmed', 'applied']);
+    });
+
+    it('records a dry run', async () => {
+        await harness.call('delete_media', { id: '5', dry_run: true });
+        expect(outcomes(harness)).toEqual(['dry_run']);
+    });
+
+    it('records a write the service refused, with the reason', async () => {
+        const failing = buildHarness({
+            apply: () => Promise.reject(new ServiceError('UpstreamError', 'radarr', 'HTTP 500 at /api/v3/movie/5'))
+        });
+        const first = await failing.call('delete_media', { id: '5' });
+
+        await expect(
+            failing.call('delete_media', { id: '5', confirm: first.structuredContent.confirm_token })
+        ).rejects.toThrow(ServiceError);
+
+        const rows = failing.audit.recent() as { outcome: string; detail: string | null }[];
+        expect(rows[0]?.outcome).toBe('failed');
+        expect(rows[0]?.detail).toContain('HTTP 500');
+    });
+
+    it('records the resolved target, not the argument the caller typed', async () => {
+        const resolving = buildHarness({ plan: { ...PLAN, target: 'radarr:5' } });
+        await resolving.call('delete_media', { id: 'Alien', dry_run: true });
+
+        const [row] = resolving.audit.recent() as { target: string }[];
+        expect(row?.target).toBe('radarr:5');
+    });
+});
+
+describe('write tool harness — cache invalidation', () => {
+    it('drops the library cache after a write that landed (§16)', async () => {
+        const first = await harness.call('delete_media', { id: '5' });
+        await harness.call('delete_media', { id: '5', confirm: first.structuredContent.confirm_token });
+        expect(harness.invalidate).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not drop it for a preview or a dry run', async () => {
+        await harness.call('delete_media', { id: '5' });
+        await harness.call('delete_media', { id: '5', dry_run: true });
+        expect(harness.invalidate).not.toHaveBeenCalled();
+    });
+
+    it('does not drop it when the write failed and changed nothing', async () => {
+        const failing = buildHarness({ apply: () => Promise.reject(new Error('nope')) });
+        const first = await failing.call('delete_media', { id: '5' });
+        await expect(
+            failing.call('delete_media', { id: '5', confirm: first.structuredContent.confirm_token })
+        ).rejects.toThrow();
+        expect(failing.invalidate).not.toHaveBeenCalled();
+    });
+});
+
+describe('write tool harness — argument binding', () => {
+    it('will not let a token previewed for one target apply to another', async () => {
+        // Two tools over one harness would be closer to the real thing, but the
+        // binding is per-plan: re-planning to a different target must invalidate
+        // a token issued for the first.
+        const first_plan: WritePlan = { ...PLAN, target: '5' };
+        const second_plan: WritePlan = { ...PLAN, target: '9' };
+
+        let called = false;
+        const shifting = buildHarness({ plan: first_plan });
+        shifting.plan.mockImplementation(() => {
+            const next = called ? second_plan : first_plan;
+            called = true;
+            return Promise.resolve(next);
+        });
+
+        const first = await shifting.call('delete_media', { id: '5' });
+        const second = await shifting.call('delete_media', {
+            id: '9',
+            confirm: first.structuredContent.confirm_token
+        });
+
+        expect(second.structuredContent.applied).toBe(false);
+        expect(second.structuredContent.confirm_error).toContain('different operation');
+        expect(shifting.apply).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Opens Phase 4. The four guarantees §10 asks of a write — permission tiers, `dry_run`, an audit record, per-call confirmation — are built as **one harness** rather than four things each write tool remembers to do, plus the first write tool to prove the whole path is reachable.

## The harness

`registerWriteTool` (`src/tools/write.ts`) owns all four gates. A write tool supplies only two callbacks:

- **`plan(args)`** — resolves arguments into a concrete described effect. Never mutates.
- **`apply(plan, args)`** — reached only once the tier passed, a valid single-use token was presented, and an audit row was opened.

That split is the design: a tool is *structurally* incapable of mutating during the preview phase, because the preview phase only ever calls `plan`. Reviewing a new write tool means reading its `plan`/`apply` pair, not auditing whether it remembered to check permissions.

## Decisions worth arguing with

**Tiers are ordered, not independent.** `destructive: true` implies `safe_write`. A config that permits deleting a film but refuses to re-monitor it describes no policy anyone would choose on purpose, and someone who set the scarier flag and then found `add_media` refused would reasonably read that as a bug. Both still default off, and the gate answers from `config.yaml` — never from an adapter — so no adapter can widen its own permissions by reporting a capability it was never granted.

**`dry_run` is terminal and deliberately *not* permission-gated.** It performs no mutation and reveals nothing already unreachable through the read tools, so refusing it would withhold nothing while making *"what would I need to enable to do this?"* unanswerable. The verdict rides along in the response instead, naming the exact YAML key. This is also what lets the integration script exercise the real write path against a live stack without write access enabled.

**`dry_run` and the confirmation handshake are separate mechanisms**, not one thing twice. `dry_run` answers "what would happen"; omitting `confirm` is for when you mean to do it and want to see it first. A dry run issues no token at all, so it can never turn into a write.

**Tokens are HMACs over the exact operation**, bound to the resolved target and the effect-bearing arguments, single-use, TTL'd, and keyed per process. Stateless transport keeps working. A token previewed for one film cannot be replayed against another — without that binding a model could preview something harmless and confirm something else, which is strictly worse than no confirmation because it looks like protection. Argument key order is canonicalised, so an otherwise-identical confirm call cannot fail on an accident of object construction.

**A rejected token degrades to a fresh preview — except when it was already spent.** An expired or mismatched token is a caller mistake with no risk, so it comes back as a normal preview carrying the reason and a new token. An *already-used* token throws: the write it authorised may well have happened, and handing back a new one invites a double-apply.

**No record, no write.** The audit trail is SQLite beside `config.yaml` (`better-sqlite3` was already a dependency, and 0.6's config page has to read this back). It is opened at startup so a read-only volume fails loudly while someone is watching `docker logs`, not at the first deletion. Rows are written *before* the service is called, so a row still reading `attempted` means we died mid-write — the one case an after-the-fact log cannot show. If the trail cannot be written, writes are refused rather than proceeding unlogged.

**A write that lands drops the library cache** — the `invalidate()` seam `cache.ts` has been holding since Phase 3, now with a caller.

## `trigger_search`

The first write, and the worked example. Safe tier, `MoviesSearch` on Radarr and `SeriesSearch` on Sonarr.

It takes `service` + `id`, **never a title**. Every read tool accepts a fuzzy title because the cost of resolving one wrongly is a wrong answer the user can see; for a write the cost is an action against the wrong item. It reads the item back before writing, so the preview names a real film rather than an id nobody can meaningfully approve.

Its `service` is derived from the arguments rather than fixed. I got this wrong first and caught it in review — a fixed id would have checked Sonarr writes against Radarr's `permissions` block, so enabling one service would have quietly enabled the other. There is a test for it.

## Verification

- 782 tests / 40 files pass; typecheck, lint and build clean.
- **23/23 integration calls against a live eight-service stack.** The `trigger_search` dry run previewed a real Radarr film and reported the permission verdict with write access still disabled.
- That live run also caught a bug the whole green suite missed: the integration script was feeding `trigger_search` a Jellyfin id, because the first library search hit routinely is one. The tool refused correctly; the script was wrong. Fixed here.

## Not in this PR

No destructive-tier tool exists yet. The tier is fully tested but has no caller — deletes, queue removal with blocklisting, and Seerr approve/deny deserve their own review pass rather than being tacked onto the foundation.

README and CONTRIBUTING updated: a Writes section covering the config, the handshake and the audit trail, and a "adding a write tool" section covering how to pick a tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
