### PR TITLE
feat: add the destructive writes (remove_queue_item, delete_media)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ Jellyfin. arr-mcp correlates them and gives you the causal chain.
 > to playable and names the first thing that explains a gap, even with
 > services down. See [the roadmap](#roadmap).
 >
-> **On `main`, ahead of the 0.4 tag:** the write foundation described under
-> [Writes](#writes) — permission tiers, `dry_run`, confirmation tokens, the
-> audit trail — plus the first write tool, `trigger_search`. Released images
-> tagged `0.4` are still read-only.
+> **On `main`, ahead of the 0.4 tag:** writes, as described under
+> [Writes](#writes) — permission tiers, `dry_run`, confirmation tokens and the
+> audit trail, with `trigger_search`, `remove_queue_item` and `delete_media`.
+> Released images tagged `0.4` are still read-only.
 
 ## Services
 
@@ -53,7 +53,9 @@ All eight are supported as of 0.3.
 | `get_requests` | What has been requested, and what is still pending |
 | `lookup_media` | Tell me about this, without adding it |
 | `discover_media` | What exists in this genre, year, or rating band |
-| `trigger_search` | Go look for this again — the one write in 0.5 so far |
+| `trigger_search` | Go look for this again |
+| `remove_queue_item` | Get rid of this stuck or wrong download |
+| `delete_media` | Remove this film or series, optionally from disk |
 
 Every tool but `diagnose` takes `detail` (`minimal`/`standard`/`full`) and
 `limit`, and reports `{ total, returned, truncated }` — a truncated answer
@@ -68,8 +70,9 @@ only — a series has no series-level quality, and Sonarr carries one flat
 TVDB rating rather than per-source scores. Asking either of series returns a
 refusal explaining why, not an empty list.
 
-Every tool except `trigger_search` is a read. See [Writes](#writes) for how that
-one — and every write after it — is gated.
+The first thirteen are reads. The last three write, and are gated as described
+under [Writes](#writes) — off by default, previewed before they act, recorded
+either way.
 
 ### Why is this not playable?
 
@@ -112,6 +115,19 @@ write access by doing so. The tiers are ordered: `destructive: true` implies
 `safe_write`, so you never have to reason about a config that permits deleting
 a film but refuses to re-monitor it.
 
+| Tool | Tier | Needs |
+| --- | --- | --- |
+| `trigger_search` | safe | `safe_write` |
+| `remove_queue_item` | destructive | `destructive` |
+| `delete_media` | destructive | `destructive` |
+
+`remove_queue_item` is destructive rather than safe because it deletes partial
+data, and because `blocklist: true` durably teaches Radarr or Sonarr to refuse a
+release — which is hard to notice and hard to undo months later, when the same
+film mysteriously never grabs. SABnzbd and Transmission have no blocklist of
+their own; ask for one there and the preview tells you it is being ignored
+rather than silently accepting a flag that does nothing.
+
 A write tool called without a confirmation token **does not write**. It resolves
 the target, reports exactly what it would do, and hands back a token:
 
@@ -129,8 +145,22 @@ trigger_search { service: "radarr", id: "5" }
 
 Tokens are single-use, expire after five minutes, and are cryptographically
 bound to the exact operation and arguments previewed — a token issued for one
-film cannot be replayed against another. Restarting arr-mcp invalidates any
-outstanding ones.
+film cannot be replayed against another, and a token from a `delete_media`
+preview that left files on disk cannot be used to wipe them. Restarting arr-mcp
+invalidates any outstanding ones.
+
+A destructive preview says what it costs in the units that matter:
+
+```
+delete_media { service: "radarr", id: "1535", delete_files: true }
+```
+
+> Not applied yet. Delete They Will Kill You (2026) from radarr, deleting
+> 18.8 GB from disk.
+>
+> - Deletes 18.8 GB from disk. This cannot be undone.
+> - Removes They Will Kill You (2026) from radarr, along with its monitoring
+>   and history.
 
 `dry_run: true` is the separate, terminal form: it describes the effect and
 issues no token at all, so it can never turn into a write. It works even with
@@ -212,7 +242,7 @@ container** to pick up changes.
 | 0.1 / 0.2 | Walking skeleton: stateless MCP transport, bearer auth, Radarr, `stack_health` |
 | 0.3 | The remaining seven service adapters and ten read tools |
 | 0.4 | Cross-service correlation: identity resolver, three-way library join, `diagnose` |
-| 0.5 | Writes: permission tiers, `dry_run`, write audit, per-call confirmation — foundation and `trigger_search` on `main` |
+| 0.5 | Writes: permission tiers, `dry_run`, write audit, per-call confirmation — on `main`, unreleased |
 | 0.6 | Web config page: dashboard, diagnosing connection tests, log streams |
 | 0.7 → 1.0 | Metadata providers, MCP resources and prompts |
 

--- a/scripts/integration.ts
+++ b/scripts/integration.ts
@@ -103,7 +103,7 @@ const hosts = hostsOf(config);
  * needs a real id would either fail the check forever or, worse, be given a
  * made-up id just to satisfy it.
  */
-const DYNAMIC_TOOLS: ToolName[] = ['trigger_search'];
+const DYNAMIC_TOOLS: ToolName[] = ['trigger_search', 'remove_queue_item', 'delete_media'];
 
 const missing = TOOL_NAMES.filter(
     name => !CASES.some(c => c.tool === name) && !DYNAMIC_TOOLS.includes(name)
@@ -187,11 +187,13 @@ async function run(tool: string, args: Record<string, unknown>, note?: string): 
 
 let libraryResult: ToolCallResult | undefined;
 let searchResult: ToolCallResult | undefined;
+let queueResult: ToolCallResult | undefined;
 
 for (const { tool, args } of CASES) {
     const result = await run(tool, args);
     if (tool === 'get_library' && args.detail === 'standard') libraryResult = result;
     if (tool === 'search_media') searchResult = result;
+    if (tool === 'get_queue') queueResult = result;
 }
 
 /**
@@ -266,6 +268,46 @@ if (typeof searchableHit?.service === 'string' && searchableHit.id !== undefined
     );
 } else {
     console.log('SKIP trigger_search — search_media returned no Radarr or Sonarr hit to take a service+id from.');
+}
+
+/**
+ * The destructive pair, **dry run only, without exception**.
+ *
+ * These two are the reason `dry_run` exists as a terminal form rather than as
+ * the first half of the handshake. A live case here would delete a maintainer's
+ * film or wipe a partial download on every run, and no amount of care in a
+ * script makes that an acceptable default. The dry run still exercises
+ * everything worth exercising against a real service: the id resolves, the item
+ * is read back, the effect is described from real data (including the real size
+ * on disk), and the permission verdict is reported.
+ *
+ * If you want to test the apply path, do it by hand against something you are
+ * willing to lose.
+ */
+if (typeof searchableHit?.service === 'string' && searchableHit.id !== undefined) {
+    await run(
+        'delete_media',
+        { service: searchableHit.service, id: String(searchableHit.id), delete_files: true, dry_run: true },
+        'DRY RUN ONLY — never applied from this script'
+    );
+} else {
+    console.log('SKIP delete_media — search_media returned no Radarr or Sonarr hit to take a service+id from.');
+}
+
+const queueItem = (queueResult?.structuredContent as { items?: unknown[] } | undefined)?.items?.[0] as
+    | { service?: unknown; id?: unknown }
+    | undefined;
+
+if (typeof queueItem?.service === 'string' && queueItem.id !== undefined) {
+    await run(
+        'remove_queue_item',
+        { service: queueItem.service, id: String(queueItem.id), blocklist: true, dry_run: true },
+        'DRY RUN ONLY — never applied from this script'
+    );
+} else {
+    // Routine, not a failure: a healthy stack with nothing downloading has an
+    // empty queue most of the time.
+    console.log('SKIP remove_queue_item — the queue is empty, so there is no real item to preview against.');
 }
 
 console.log(`\n${passes}/${passes + failures} calls succeeded.`);

--- a/src/core/http.ts
+++ b/src/core/http.ts
@@ -39,9 +39,29 @@ export class ServiceHttp {
         return this.#request<T>('POST', path, body, false);
     }
 
+    /**
+     * Deletes return no body worth reading — Radarr and Sonarr answer 200 with
+     * an empty one — so this discards it rather than parsing it. Typing it
+     * `void` is the honest signature: a `delete<T>` would invite a caller to
+     * read fields that are never there, and routing a delete through `post`'s
+     * JSON parse turns every successful deletion into "response was not valid
+     * JSON".
+     *
+     * Like every write, it never auto-retries.
+     */
+    async delete(path: string): Promise<void> {
+        await this.#request<unknown>('DELETE', path, undefined, false, true);
+    }
+
     // --- internals ---
 
-    async #request<T>(method: string, path: string, body: unknown, retryOnTimeout: boolean): Promise<T> {
+    async #request<T>(
+        method: string,
+        path: string,
+        body: unknown,
+        retryOnTimeout: boolean,
+        discardBody = false
+    ): Promise<T> {
         if (this.#circuitOpen()) {
             throw new ServiceError(
                 'Unreachable',
@@ -52,13 +72,13 @@ export class ServiceHttp {
         }
 
         try {
-            const result = await this.#attempt<T>(method, path, body);
+            const result = await this.#attempt<T>(method, path, body, true, discardBody);
             this.#recordSuccess();
             return result;
         } catch (err) {
             if (retryOnTimeout && err instanceof ServiceError && err.kind === 'Timeout') {
                 try {
-                    const result = await this.#attempt<T>(method, path, body);
+                    const result = await this.#attempt<T>(method, path, body, true, discardBody);
                     this.#recordSuccess();
                     return result;
                 } catch (retryErr) {
@@ -76,7 +96,13 @@ export class ServiceHttp {
      * recovery inside it — Transmission's 409 handshake — which by construction
      * neither consumes the timeout retry above nor reaches the breaker.
      */
-    async #attempt<T>(method: string, path: string, body: unknown, allowRecovery = true): Promise<T> {
+    async #attempt<T>(
+        method: string,
+        path: string,
+        body: unknown,
+        allowRecovery = true,
+        discardBody = false
+    ): Promise<T> {
         const url = new URL(path, this.#baseUrl);
         const headers = new Headers({ Accept: 'application/json' });
         if (body !== undefined) headers.set('content-type', 'application/json');
@@ -101,11 +127,15 @@ export class ServiceHttp {
         }
 
         if (allowRecovery && this.#auth.recover?.(response) === true) {
-            return this.#attempt<T>(method, path, body, false);
+            return this.#attempt<T>(method, path, body, false, discardBody);
         }
 
         const httpError = classifyHttpStatus(response.status, this.#id, safeUrl);
         if (httpError) throw httpError;
+
+        // The status line already said it worked, and nothing reads what comes
+        // back. Parsing it anyway is how a successful delete becomes an error.
+        if (discardBody) return undefined as T;
 
         try {
             return (await response.json()) as T;

--- a/src/services/arrQueue.ts
+++ b/src/services/arrQueue.ts
@@ -1,7 +1,8 @@
 import type { ServiceId } from '../config/schema.ts';
+import { ServiceError } from '../core/errors.ts';
 import { fenceText } from '../core/fence.ts';
 import type { ServiceHttp } from '../core/http.ts';
-import type { CalendarEntry, QueueItem } from './types.ts';
+import type { CalendarEntry, DeleteMediaOptions, QueueItem, RemoveQueueOptions } from './types.ts';
 
 /**
  * Radarr and Sonarr share a framework, so their queue and calendar responses
@@ -47,6 +48,53 @@ export async function readArrQueue(http: ServiceHttp, service: ServiceId): Promi
                 ...(r.errorMessage ? { errorMessage: fenceText(r.errorMessage, { service, field: 'errorMessage' }) } : {})
             };
         });
+}
+
+/**
+ * Shared for the same reason the read above is: Radarr and Sonarr expose the
+ * identical `DELETE /api/v3/queue/{id}` with the identical two flags. Writing
+ * it twice is how the two drift into disagreeing about what `blocklist` means.
+ */
+export async function removeArrQueueItem(
+    http: ServiceHttp,
+    service: ServiceId,
+    id: string,
+    opts: RemoveQueueOptions
+): Promise<void> {
+    const numeric = Number(id);
+    if (!Number.isInteger(numeric)) {
+        throw new ServiceError('NotFound', service, `"${id}" is not a ${service} queue id`, {
+            remedy: 'Queue ids are integers on Radarr and Sonarr. Take one from get_queue.'
+        });
+    }
+
+    // Both flags are serialised explicitly rather than omitted when false:
+    // Radarr defaults `removeFromClient` to true, so leaving it out on a
+    // remove-from-*arr-only request would also wipe it from the download
+    // client — the opposite of what was asked for.
+    await http.delete(
+        `/api/v3/queue/${numeric}?removeFromClient=${String(opts.removeFromClient)}&blocklist=${String(opts.blocklist)}`
+    );
+}
+
+/** Radarr's `/movie/{id}`, Sonarr's `/series/{id}` — same flags, different noun. */
+export async function deleteArrMedia(
+    http: ServiceHttp,
+    service: ServiceId,
+    resource: 'movie' | 'series',
+    id: string,
+    opts: DeleteMediaOptions
+): Promise<void> {
+    const numeric = Number(id);
+    if (!Number.isInteger(numeric)) {
+        throw new ServiceError('NotFound', service, `"${id}" is not a ${service} ${resource} id`, {
+            remedy: `${service} ids are integers. Get one from get_media_details or get_library.`
+        });
+    }
+
+    await http.delete(
+        `/api/v3/${resource}/${numeric}?deleteFiles=${String(opts.deleteFiles)}&addImportExclusion=${String(opts.addImportExclusion)}`
+    );
 }
 
 type RawCalendarMovie = {

--- a/src/services/radarr.ts
+++ b/src/services/radarr.ts
@@ -4,7 +4,7 @@ import { ServiceError } from '../core/errors.ts';
 import { ServiceHttp } from '../core/http.ts';
 import { fenceText } from '../core/fence.ts';
 import type { IndexInput } from '../core/resolver.ts';
-import { calendarPath, readArrQueue, readRadarrCalendar } from './arrQueue.ts';
+import { calendarPath, deleteArrMedia, readArrQueue, readRadarrCalendar, removeArrQueueItem } from './arrQueue.ts';
 import { flattenRatings, toMergedRatings, type RawRating } from './arrRatings.ts';
 import {
     diagnoseConnection,
@@ -23,6 +23,10 @@ import {
     type ScanState,
     type ScanStateCapable,
     type CommandHandle,
+    type DeleteMediaOptions,
+    type MediaDeleteCapable,
+    type QueueRemoveCapable,
+    type RemoveQueueOptions,
     type SearchCapable,
     type SearchHit,
     type SearchSource,
@@ -82,7 +86,9 @@ export class RadarrAdapter
         MediaDetailCapable,
         SearchCapable,
         LibraryCapable,
-        SearchTriggerCapable
+        SearchTriggerCapable,
+        QueueRemoveCapable,
+        MediaDeleteCapable
 {
     readonly id: ServiceId = 'radarr';
     readonly #http: ServiceHttp;
@@ -139,6 +145,16 @@ export class RadarrAdapter
 
     async getQueue(): Promise<QueueItem[]> {
         return readArrQueue(this.#http, this.id);
+    }
+
+    readonly supportsBlocklist = true;
+
+    async removeQueueItem(id: string, opts: RemoveQueueOptions): Promise<void> {
+        return removeArrQueueItem(this.#http, this.id, id, opts);
+    }
+
+    async deleteMedia(id: string, opts: DeleteMediaOptions): Promise<void> {
+        return deleteArrMedia(this.#http, this.id, 'movie', id, opts);
     }
 
     async getCalendar(range: { start: Date; end: Date }): Promise<CalendarEntry[]> {

--- a/src/services/sabnzbd.ts
+++ b/src/services/sabnzbd.ts
@@ -10,6 +10,8 @@ import {
     type DiskSpaceCapable,
     type QueueCapable,
     type QueueItem,
+    type QueueRemoveCapable,
+    type RemoveQueueOptions,
     type ServiceAdapter
 } from './types.ts';
 
@@ -67,7 +69,7 @@ const gigabytesToBytes = (value: string | undefined): number | undefined => {
     return Number.isFinite(parsed) ? Math.round(parsed * BYTES_PER_GB) : undefined;
 };
 
-export class SabnzbdAdapter implements ServiceAdapter, DiskSpaceCapable, QueueCapable {
+export class SabnzbdAdapter implements ServiceAdapter, DiskSpaceCapable, QueueCapable, QueueRemoveCapable {
     readonly id: ServiceId = 'sabnzbd';
     readonly #http: ServiceHttp;
 
@@ -134,6 +136,31 @@ export class SabnzbdAdapter implements ServiceAdapter, DiskSpaceCapable, QueueCa
                     ...(eta === undefined ? {} : { etaSeconds: eta })
                 };
             });
+    }
+
+    /** SABnzbd has no blocklist — that lives in the *arr that queued the grab. */
+    readonly supportsBlocklist = false;
+
+    /**
+     * A write over GET, because that is SABnzbd's entire API — every mode,
+     * read or write, is a query parameter on `/api`. It answers
+     * `{"status": true}` on success and, notably, **also 200 with
+     * `{"status": false}`** for an nzo_id it does not have, so the body has to
+     * be checked. Trusting the status line would report a deletion that never
+     * happened.
+     */
+    async removeQueueItem(id: string, opts: RemoveQueueOptions): Promise<void> {
+        const body = await this.#http.get<{ status?: boolean; error?: string }>(
+            `/api?mode=queue&name=delete&value=${encodeURIComponent(id)}&del_files=${opts.removeFromClient ? 1 : 0}&output=json`
+        );
+
+        if (body.status !== true) {
+            throw new ServiceError('UpstreamError', this.id, `queue delete of ${id} was refused`, {
+                remedy:
+                    body.error ??
+                    'SABnzbd reported no failure reason. Check the item is still in the queue — take a current id from get_queue.'
+            });
+        }
     }
 
     async testConnection(): Promise<ConnectionDiagnosis> {

--- a/src/services/sonarr.ts
+++ b/src/services/sonarr.ts
@@ -5,7 +5,7 @@ import { ServiceHttp } from '../core/http.ts';
 import { fenceText } from '../core/fence.ts';
 import { applyLimit } from '../core/shape.ts';
 import type { IndexInput } from '../core/resolver.ts';
-import { readArrQueue, readSonarrCalendar, sonarrCalendarPath } from './arrQueue.ts';
+import { deleteArrMedia, readArrQueue, readSonarrCalendar, removeArrQueueItem, sonarrCalendarPath } from './arrQueue.ts';
 import { flattenSeriesRating, type RawRating } from './arrRatings.ts';
 import type { components } from './generated/sonarr.ts';
 import {
@@ -25,6 +25,10 @@ import {
     type ScanState,
     type ScanStateCapable,
     type CommandHandle,
+    type DeleteMediaOptions,
+    type MediaDeleteCapable,
+    type QueueRemoveCapable,
+    type RemoveQueueOptions,
     type SearchCapable,
     type SearchHit,
     type SearchSource,
@@ -86,7 +90,9 @@ export class SonarrAdapter
         MediaDetailCapable,
         SearchCapable,
         LibraryCapable,
-        SearchTriggerCapable
+        SearchTriggerCapable,
+        QueueRemoveCapable,
+        MediaDeleteCapable
 {
     readonly id: ServiceId = 'sonarr';
     readonly #http: ServiceHttp;
@@ -136,6 +142,18 @@ export class SonarrAdapter
 
     async getQueue(): Promise<QueueItem[]> {
         return readArrQueue(this.#http, this.id);
+    }
+
+    readonly supportsBlocklist = true;
+
+    async removeQueueItem(id: string, opts: RemoveQueueOptions): Promise<void> {
+        return removeArrQueueItem(this.#http, this.id, id, opts);
+    }
+
+    /** Deletes the whole series. Sonarr has no per-episode delete on this path,
+     *  which is why `delete_media` refuses to pretend otherwise. */
+    async deleteMedia(id: string, opts: DeleteMediaOptions): Promise<void> {
+        return deleteArrMedia(this.#http, this.id, 'series', id, opts);
     }
 
     async getCalendar(range: { start: Date; end: Date }): Promise<CalendarEntry[]> {

--- a/src/services/transmission.ts
+++ b/src/services/transmission.ts
@@ -10,6 +10,8 @@ import {
     type DiskSpaceCapable,
     type QueueCapable,
     type QueueItem,
+    type QueueRemoveCapable,
+    type RemoveQueueOptions,
     type ServiceAdapter
 } from './types.ts';
 
@@ -48,7 +50,7 @@ const TORRENT_STATUS: Record<number, string> = {
     6: 'seeding'
 };
 
-export class TransmissionAdapter implements ServiceAdapter, DiskSpaceCapable, QueueCapable {
+export class TransmissionAdapter implements ServiceAdapter, DiskSpaceCapable, QueueCapable, QueueRemoveCapable {
     readonly id: ServiceId = 'transmission';
     readonly #http: ServiceHttp;
 
@@ -114,6 +116,36 @@ export class TransmissionAdapter implements ServiceAdapter, DiskSpaceCapable, Qu
                     ? { errorMessage: fenceText(t.errorString, { service: this.id, field: 'errorString' }) }
                     : {})
             }));
+    }
+
+    /** Transmission has no blocklist of grabbed releases — that is an *arr concept. */
+    readonly supportsBlocklist = false;
+
+    /**
+     * `delete-local-data` is the destructive half, and it maps to
+     * `removeFromClient`: leaving it false removes the torrent but keeps what
+     * has already downloaded, which is the recoverable choice.
+     *
+     * Like every Transmission call, a failure arrives as HTTP 200 with a
+     * `result` other than "success", so the body is what says whether the
+     * torrent was actually removed.
+     */
+    async removeQueueItem(id: string, opts: RemoveQueueOptions): Promise<void> {
+        const torrentId = Number(id);
+        if (!Number.isInteger(torrentId)) {
+            throw new ServiceError('NotFound', this.id, `"${id}" is not a Transmission torrent id`, {
+                remedy: 'Transmission torrent ids are integers. Take one from get_queue.'
+            });
+        }
+
+        const body = await this.#http.post<RpcResponse<unknown>>(RPC_PATH, {
+            method: 'torrent-remove',
+            arguments: { ids: [torrentId], 'delete-local-data': opts.removeFromClient }
+        });
+
+        if (body.result !== 'success') {
+            throw new ServiceError('UpstreamError', this.id, `torrent-remove failed: ${body.result ?? 'no result field'}`);
+        }
     }
 
     async testConnection(): Promise<ConnectionDiagnosis> {

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -294,6 +294,46 @@ export const hasSearchTrigger = (a: ServiceAdapter): a is ServiceAdapter & Searc
     typeof (a as Partial<SearchTriggerCapable>).triggerSearch === 'function';
 
 /**
+ * Both flags default to the *least* destructive reading at every layer — the
+ * tool schema, the adapter signature and the service call — so a caller that
+ * forgets one deletes less than they asked for rather than more.
+ */
+export type DeleteMediaOptions = {
+    /** Delete the files from disk, not just the entry from the *arr's database. */
+    deleteFiles: boolean;
+    /** Also add an import exclusion, so it is never re-imported automatically. */
+    addImportExclusion: boolean;
+};
+
+export interface MediaDeleteCapable {
+    deleteMedia(id: string, opts: DeleteMediaOptions): Promise<void>;
+}
+
+export const hasMediaDelete = (a: ServiceAdapter): a is ServiceAdapter & MediaDeleteCapable =>
+    typeof (a as Partial<MediaDeleteCapable>).deleteMedia === 'function';
+
+export type RemoveQueueOptions = {
+    /** Also tell the download client to drop it, and delete partial data. */
+    removeFromClient: boolean;
+    /**
+     * Blocklist the release so the *arr will not grab it again. Meaningless on
+     * SABnzbd and Transmission, which have no blocklist of their own — the
+     * adapters there ignore it, and `remove_queue_item` says so in the preview
+     * rather than silently accepting a flag that does nothing.
+     */
+    blocklist: boolean;
+};
+
+export interface QueueRemoveCapable {
+    removeQueueItem(id: string, opts: RemoveQueueOptions): Promise<void>;
+    /** True when this service can actually honour `blocklist`. */
+    readonly supportsBlocklist: boolean;
+}
+
+export const hasQueueRemove = (a: ServiceAdapter): a is ServiceAdapter & QueueRemoveCapable =>
+    typeof (a as Partial<QueueRemoveCapable>).removeQueueItem === 'function';
+
+/**
  * A whole-library read, shaped for the identity resolver rather than for a
  * tool. Phase 3 joins three of these into one index; nothing else consumes it.
  */

--- a/src/tools/deleteMedia.ts
+++ b/src/tools/deleteMedia.ts
@@ -1,0 +1,128 @@
+import type { McpServer } from '@modelcontextprotocol/server';
+import * as z from 'zod/v4';
+import { ServiceIdSchema, type ServiceId } from '../config/schema.ts';
+import { ServiceError } from '../core/errors.ts';
+import { hasMediaDelete, hasMediaDetails, type ServiceAdapter } from '../services/types.ts';
+import { registerWriteTool, type WriteContext, type WritePlan } from './write.ts';
+
+/**
+ * The first destructive-tier write. Everything the harness does matters more
+ * here than it did for `trigger_search`: this is the tool where a preview the
+ * user did not read is a film they cannot get back.
+ *
+ * Which is why `plan` reads the item first and reports the size on disk. "Delete
+ * radarr:412" is not something anyone can meaningfully approve; "Delete Alien
+ * (1979) from Radarr, deleting 24.1 GB from disk" is.
+ */
+
+const GIB = 1024 ** 3;
+
+/** Deliberately coarse. This number exists to make someone hesitate, not to
+ *  balance a ledger, and false precision reads as machine noise. */
+function humanSize(bytes: number | undefined): string | undefined {
+    if (bytes === undefined || bytes <= 0) return undefined;
+    return bytes >= GIB ? `${(bytes / GIB).toFixed(1)} GB` : `${Math.round(bytes / 1024 ** 2)} MB`;
+}
+
+const findAdapter = (adapters: readonly ServiceAdapter[], service: ServiceId) => {
+    const adapter = adapters.find(a => a.id === service);
+    if (adapter === undefined) {
+        throw new ServiceError('NotFound', service, `${service} is not configured`, {
+            remedy: `Add a services.${service} block to config.yaml and restart, or name a configured service.`
+        });
+    }
+    if (!hasMediaDelete(adapter)) {
+        throw new ServiceError('NotFound', service, `${service} has no media to delete`, {
+            remedy: 'Only radarr and sonarr manage media that delete_media can remove.'
+        });
+    }
+    return adapter;
+};
+
+export function registerDeleteMedia(
+    server: McpServer,
+    context: WriteContext,
+    adapters: readonly ServiceAdapter[]
+): void {
+    registerWriteTool(server, context, {
+        name: 'delete_media',
+        description:
+            'Removes a film from Radarr or a whole series from Sonarr, optionally deleting its files from disk. Destructive and not undoable — files are gone, not moved to a recycle bin unless the service itself is configured for one. Takes `service` and `id`, never a title: get those from get_media_details or get_library first. Sonarr deletes the entire series; there is no per-episode form. Previews by default — call again with the returned `confirm` token to actually delete.',
+        inputSchema: z.object({
+            service: ServiceIdSchema.describe('radarr or sonarr.'),
+            id: z.string().min(1).describe("The item's id within that service, as an integer string."),
+            delete_files: z
+                .boolean()
+                .default(false)
+                .describe(
+                    'Also delete the files from disk. Defaults to false, which removes only the entry and leaves the media where it is.'
+                ),
+            add_import_exclusion: z
+                .boolean()
+                .default(false)
+                .describe(
+                    'Also add an import exclusion so it is never re-added automatically. Defaults to false.'
+                )
+        }),
+        service: ({ service }) => service,
+        operation: 'delete_media',
+        tier: 'destructive',
+
+        async plan({ service, id, delete_files, add_import_exclusion }): Promise<WritePlan> {
+            const adapter = findAdapter(adapters, service);
+            if (!hasMediaDetails(adapter)) {
+                throw new ServiceError('NotFound', service, `${service} cannot describe its own items`);
+            }
+
+            // The read that makes the preview approvable, and that fails
+            // legibly on a bad id rather than issuing a DELETE into the dark.
+            const details = await adapter.getMediaDetails(id, { includeEpisodes: false, episodeLimit: 0 });
+            const label = `${details.title}${details.year === undefined ? '' : ` (${details.year})`}`;
+            const noun = service === 'sonarr' ? 'series' : 'film';
+
+            const effects: string[] = [];
+            const size = humanSize(details.sizeBytes);
+
+            if (delete_files) {
+                effects.push(
+                    size === undefined
+                        ? `Deletes this ${noun}'s files from disk. This cannot be undone.`
+                        : `Deletes ${size} from disk. This cannot be undone.`
+                );
+                if (service === 'sonarr') {
+                    effects.push('Deletes every episode of the series, not one season or one episode.');
+                }
+            } else {
+                effects.push(`Leaves the files on disk — only the ${service} entry is removed.`);
+            }
+
+            effects.push(`Removes ${label} from ${service}, along with its monitoring and history.`);
+
+            if (add_import_exclusion) {
+                effects.push('Adds an import exclusion, so it will not be re-added automatically by a list or request.');
+            }
+
+            return {
+                target: `${service}:${id}`,
+                summary:
+                    `Delete ${label} from ${service}` +
+                    (delete_files
+                        ? `, deleting ${size ?? 'its files'} from disk.`
+                        : ', leaving its files on disk.'),
+                effects,
+                // Both flags are effect-bearing, so the confirmation token
+                // commits to them: a token previewed for a database-only
+                // removal must not be usable to also wipe the disk.
+                args: { service, id, deleteFiles: delete_files, addImportExclusion: add_import_exclusion }
+            };
+        },
+
+        async apply(_plan, { service, id, delete_files, add_import_exclusion }) {
+            await findAdapter(adapters, service).deleteMedia(id, {
+                deleteFiles: delete_files,
+                addImportExclusion: add_import_exclusion
+            });
+            return { deleted: `${service}:${id}` };
+        }
+    });
+}

--- a/src/tools/register.ts
+++ b/src/tools/register.ts
@@ -7,6 +7,7 @@ import { permissionSourceFrom } from '../core/permissions.ts';
 import { JellyfinAdapter } from '../services/jellyfin.ts';
 import { SeerrAdapter } from '../services/seerr.ts';
 import { hasIndexers, hasSubtitles, type ServiceAdapter } from '../services/types.ts';
+import { registerDeleteMedia } from './deleteMedia.ts';
 import { registerDiagnose } from './diagnose/index.ts';
 import { registerDiscoverMedia } from './discoverMedia.ts';
 import { registerGetCalendar } from './getCalendar.ts';
@@ -19,6 +20,7 @@ import { registerGetRequests } from './getRequests.ts';
 import { registerGetSubtitles } from './getSubtitles.ts';
 import { LibraryLoader } from './library.ts';
 import { registerLookupMedia } from './lookupMedia.ts';
+import { registerRemoveQueueItem } from './removeQueueItem.ts';
 import { registerSearchMedia } from './searchMedia.ts';
 import { registerStackHealth } from './stackHealth.ts';
 import { registerTriggerSearch } from './triggerSearch.ts';
@@ -112,6 +114,8 @@ export function registerAllTools(server: McpServer, context: ToolContext): void 
     // trigger_search — it refuses, naming the key to set, which is a far better
     // answer than a tool the model was told about and cannot find.
     registerTriggerSearch(server, write, adapters);
+    registerRemoveQueueItem(server, write, adapters);
+    registerDeleteMedia(server, write, adapters);
 }
 
 /** The tool surface, frozen. §18: renaming one breaks users' saved prompts. */
@@ -129,5 +133,7 @@ export const TOOL_NAMES = [
     'search_media',
     'lookup_media',
     'discover_media',
-    'trigger_search'
+    'trigger_search',
+    'remove_queue_item',
+    'delete_media'
 ] as const;

--- a/src/tools/removeQueueItem.ts
+++ b/src/tools/removeQueueItem.ts
@@ -1,0 +1,122 @@
+import type { McpServer } from '@modelcontextprotocol/server';
+import * as z from 'zod/v4';
+import { ServiceIdSchema, type ServiceId } from '../config/schema.ts';
+import { ServiceError } from '../core/errors.ts';
+import { hasQueue, hasQueueRemove, type ServiceAdapter } from '../services/types.ts';
+import { registerWriteTool, type WriteContext, type WritePlan } from './write.ts';
+
+/**
+ * "This has been stuck at 0% for two days, get rid of it" — the other thing
+ * people actually want to write.
+ *
+ * Destructive tier rather than safe, even though a removed download can be
+ * searched for again: `remove_from_client` deletes partial data, and
+ * `blocklist` durably teaches the *arr to refuse a release, which is
+ * genuinely hard to notice and hard to undo months later when the same film
+ * mysteriously never grabs.
+ */
+
+const findAdapter = (adapters: readonly ServiceAdapter[], service: ServiceId) => {
+    const adapter = adapters.find(a => a.id === service);
+    if (adapter === undefined) {
+        throw new ServiceError('NotFound', service, `${service} is not configured`, {
+            remedy: `Add a services.${service} block to config.yaml and restart, or name a configured service.`
+        });
+    }
+    if (!hasQueueRemove(adapter)) {
+        throw new ServiceError('NotFound', service, `${service} has no download queue`, {
+            remedy: 'Queue items live on radarr, sonarr, sabnzbd and transmission. Take a service and id from get_queue.'
+        });
+    }
+    return adapter;
+};
+
+export function registerRemoveQueueItem(
+    server: McpServer,
+    context: WriteContext,
+    adapters: readonly ServiceAdapter[]
+): void {
+    registerWriteTool(server, context, {
+        name: 'remove_queue_item',
+        description:
+            'Removes one item from a download queue — the stuck-at-0%, wrong-release, or stalled download. Works against Radarr, Sonarr, SABnzbd and Transmission; take `service` and `id` from get_queue. Optionally deletes partial data and, on Radarr and Sonarr only, blocklists the release so it will not be grabbed again. Previews by default — call again with the returned `confirm` token to actually remove it.',
+        inputSchema: z.object({
+            service: ServiceIdSchema.describe('radarr, sonarr, sabnzbd or transmission.'),
+            id: z.string().min(1).describe('The queue item id, exactly as get_queue reported it.'),
+            remove_from_client: z
+                .boolean()
+                .default(true)
+                .describe(
+                    'Also drop it from the download client and delete partial data. Defaults to true, which is what "get rid of it" normally means.'
+                ),
+            blocklist: z
+                .boolean()
+                .default(false)
+                .describe(
+                    'Blocklist the release so it is not grabbed again. Radarr and Sonarr only; ignored elsewhere. Defaults to false.'
+                )
+        }),
+        service: ({ service }) => service,
+        operation: 'remove_queue_item',
+        tier: 'destructive',
+
+        async plan({ service, id, remove_from_client, blocklist }): Promise<WritePlan> {
+            const adapter = findAdapter(adapters, service);
+
+            // Read the live queue so the preview names the release rather than
+            // an opaque id, and so an id that has already finished downloading
+            // fails here instead of as a confusing 404 from a delete.
+            if (!hasQueue(adapter)) {
+                throw new ServiceError('NotFound', service, `${service} cannot list its own queue`);
+            }
+            const item = (await adapter.getQueue()).find(q => q.id === id);
+            if (item === undefined) {
+                throw new ServiceError('NotFound', service, `nothing in ${service}'s queue has id "${id}"`, {
+                    remedy:
+                        'It may have finished or already been removed. Call get_queue for a current list — queue ids are not stable once an item leaves the queue.'
+                });
+            }
+
+            const effects = [
+                remove_from_client
+                    ? `Removes it from ${service} and deletes any partial data already downloaded.`
+                    : `Removes it from ${service}'s queue but leaves the download itself alone.`
+            ];
+
+            // Accepting a flag that silently does nothing is how someone
+            // believes a release is blocklisted for a year. Say it plainly.
+            if (blocklist) {
+                effects.push(
+                    adapter.supportsBlocklist
+                        ? 'Blocklists this release, so it will not be grabbed again. Undoing this means finding it in the service\'s blocklist by hand.'
+                        : `Ignored: ${service} has no blocklist of its own. To blocklist a release, remove it from the Radarr or Sonarr queue instead.`
+                );
+            }
+
+            return {
+                target: `${service}:${id}`,
+                summary: `Remove ${item.title} from ${service}'s queue (currently ${item.status}).`,
+                effects,
+                args: {
+                    service,
+                    id,
+                    removeFromClient: remove_from_client,
+                    // The *effective* value, not the requested one, so the
+                    // token and the audit row record what will actually happen
+                    // rather than what was asked for on a service that cannot
+                    // do it.
+                    blocklist: blocklist && adapter.supportsBlocklist
+                }
+            };
+        },
+
+        async apply(_plan, { service, id, remove_from_client, blocklist }) {
+            const adapter = findAdapter(adapters, service);
+            await adapter.removeQueueItem(id, {
+                removeFromClient: remove_from_client,
+                blocklist: blocklist && adapter.supportsBlocklist
+            });
+            return { removed: `${service}:${id}` };
+        }
+    });
+}

--- a/test/destructiveWrites.test.ts
+++ b/test/destructiveWrites.test.ts
@@ -1,0 +1,429 @@
+import { describe, expect, it, vi } from 'vitest';
+import * as z from 'zod/v4';
+import type { AnyServiceConfig, KeyedServiceConfig, ServiceId, TransmissionServiceConfig } from '../src/config/schema.ts';
+import { WriteAudit } from '../src/core/audit.ts';
+import { ConfirmTokens } from '../src/core/confirm.ts';
+import { ServiceError } from '../src/core/errors.ts';
+import { permissionSourceFrom } from '../src/core/permissions.ts';
+import { RadarrAdapter } from '../src/services/radarr.ts';
+import { SabnzbdAdapter } from '../src/services/sabnzbd.ts';
+import { SonarrAdapter } from '../src/services/sonarr.ts';
+import { TransmissionAdapter } from '../src/services/transmission.ts';
+import type { ServiceAdapter } from '../src/services/types.ts';
+import { registerDeleteMedia } from '../src/tools/deleteMedia.ts';
+import type { LibraryLoader } from '../src/tools/library.ts';
+import { registerRemoveQueueItem } from '../src/tools/removeQueueItem.ts';
+import type { WriteToolResult } from '../src/tools/write.ts';
+import { jsonResponse } from './helpers/serve.ts';
+
+const keyed = (port: number): KeyedServiceConfig => ({
+    url: `http://192.0.2.10:${port}`,
+    api_key: 'k',
+    timeout_ms: 10_000,
+    permissions: { safe_write: false, destructive: false }
+});
+
+const transmissionConfig: TransmissionServiceConfig = {
+    url: 'http://192.0.2.10:9091',
+    timeout_ms: 10_000,
+    permissions: { safe_write: false, destructive: false }
+};
+
+const tiered = (safe_write: boolean, destructive: boolean): AnyServiceConfig =>
+    ({ ...keyed(7878), permissions: { safe_write, destructive } }) as AnyServiceConfig;
+
+/**
+ * Records method, path, query and body. For a destructive write the exact query
+ * string *is* the behaviour — `deleteFiles=false` and an omitted `deleteFiles`
+ * are different outcomes on disk.
+ */
+function recordingFetch(routes: Record<string, unknown>, opts: { emptyBody?: boolean } = {}) {
+    const sent: { path: string; search: string; method: string; body: unknown }[] = [];
+    const impl = (async (input: string | URL | Request, init?: RequestInit) => {
+        const url = new URL(input instanceof Request ? input.url : String(input));
+        const method = init?.method ?? 'GET';
+        sent.push({
+            path: url.pathname,
+            search: url.search,
+            method,
+            body: typeof init?.body === 'string' ? JSON.parse(init.body) : undefined
+        });
+
+        if (method === 'DELETE') {
+            // What Radarr and Sonarr actually answer: 200 with nothing in it.
+            return opts.emptyBody === false ? jsonResponse({}) : new Response('', { status: 200 });
+        }
+        if (url.pathname in routes) return jsonResponse(routes[url.pathname]);
+        if (`${url.pathname}${url.search}` in routes) return jsonResponse(routes[`${url.pathname}${url.search}`]);
+        return jsonResponse({ message: 'not found' }, 404);
+    }) as unknown as typeof fetch;
+
+    return { impl, sent };
+}
+
+const MOVIE = { id: 412, title: 'Alien', year: 1979, monitored: true, hasFile: true, movieFile: { size: 25_900_000_000 } };
+const SERIES = { id: 7, title: 'Alien: Earth', year: 2025, monitored: true, statistics: { sizeOnDisk: 3_000_000_000, episodeFileCount: 8 } };
+
+const ARR_QUEUE = {
+    records: [{ id: 91, title: 'Alien.1979.2160p-GROUP', status: 'stalled', size: 1000, sizeleft: 900 }]
+};
+
+// --- adapters ------------------------------------------------------------
+
+describe('deleting media', () => {
+    it('sends both flags explicitly rather than relying on Radarr defaults', async () => {
+        const { impl, sent } = recordingFetch({});
+        await new RadarrAdapter(keyed(7878), impl).deleteMedia('412', {
+            deleteFiles: false,
+            addImportExclusion: false
+        });
+
+        const del = sent.find(s => s.method === 'DELETE');
+        expect(del?.path).toBe('/api/v3/movie/412');
+        expect(del?.search).toContain('deleteFiles=false');
+        expect(del?.search).toContain('addImportExclusion=false');
+    });
+
+    it('deletes files when asked', async () => {
+        const { impl, sent } = recordingFetch({});
+        await new RadarrAdapter(keyed(7878), impl).deleteMedia('412', {
+            deleteFiles: true,
+            addImportExclusion: true
+        });
+
+        const del = sent.find(s => s.method === 'DELETE');
+        expect(del?.search).toContain('deleteFiles=true');
+        expect(del?.search).toContain('addImportExclusion=true');
+    });
+
+    it('uses series, not movie, on Sonarr', async () => {
+        const { impl, sent } = recordingFetch({});
+        await new SonarrAdapter(keyed(8989), impl).deleteMedia('7', { deleteFiles: true, addImportExclusion: false });
+        expect(sent.find(s => s.method === 'DELETE')?.path).toBe('/api/v3/series/7');
+    });
+
+    // The empty-body case: routing a delete through the JSON parse would turn
+    // every successful deletion into "response was not valid JSON".
+    it('succeeds on the empty 200 the arrs actually return', async () => {
+        const { impl } = recordingFetch({});
+        await expect(
+            new RadarrAdapter(keyed(7878), impl).deleteMedia('412', { deleteFiles: false, addImportExclusion: false })
+        ).resolves.toBeUndefined();
+    });
+
+    it('refuses a non-numeric id rather than issuing a delete into the dark', async () => {
+        const { impl, sent } = recordingFetch({});
+        await expect(
+            new RadarrAdapter(keyed(7878), impl).deleteMedia('Alien', { deleteFiles: true, addImportExclusion: false })
+        ).rejects.toThrow(ServiceError);
+        expect(sent.filter(s => s.method === 'DELETE')).toHaveLength(0);
+    });
+});
+
+describe('removing a queue item', () => {
+    it('sends removeFromClient explicitly, because Radarr defaults it to true', async () => {
+        const { impl, sent } = recordingFetch({});
+        await new RadarrAdapter(keyed(7878), impl).removeQueueItem('91', {
+            removeFromClient: false,
+            blocklist: false
+        });
+
+        const del = sent.find(s => s.method === 'DELETE');
+        expect(del?.path).toBe('/api/v3/queue/91');
+        expect(del?.search).toContain('removeFromClient=false');
+        expect(del?.search).toContain('blocklist=false');
+    });
+
+    it('blocklists when asked, on Sonarr too', async () => {
+        const { impl, sent } = recordingFetch({});
+        await new SonarrAdapter(keyed(8989), impl).removeQueueItem('91', {
+            removeFromClient: true,
+            blocklist: true
+        });
+        expect(sent.find(s => s.method === 'DELETE')?.search).toContain('blocklist=true');
+    });
+
+    it('deletes from SABnzbd by nzo_id, on the mode/name query SABnzbd expects', async () => {
+        const seen: string[] = [];
+        const impl = (async (input: string | URL | Request) => {
+            seen.push(new URL(input instanceof Request ? input.url : String(input)).search);
+            return jsonResponse({ status: true });
+        }) as unknown as typeof fetch;
+
+        await new SabnzbdAdapter(keyed(8080), impl).removeQueueItem('SABnzbd_nzo_ab12', {
+            removeFromClient: true,
+            blocklist: false
+        });
+
+        expect(seen[0]).toContain('mode=queue');
+        expect(seen[0]).toContain('name=delete');
+        expect(seen[0]).toContain('value=SABnzbd_nzo_ab12');
+        // del_files is what actually removes the partial download.
+        expect(seen[0]).toContain('del_files=1');
+    });
+
+    it('leaves SABnzbd partial data alone when removeFromClient is false', async () => {
+        const seen: string[] = [];
+        const impl = (async (input: string | URL | Request) => {
+            seen.push(new URL(input instanceof Request ? input.url : String(input)).search);
+            return jsonResponse({ status: true });
+        }) as unknown as typeof fetch;
+
+        await new SabnzbdAdapter(keyed(8080), impl).removeQueueItem('SABnzbd_nzo_ab12', {
+            removeFromClient: false,
+            blocklist: false
+        });
+        expect(seen[0]).toContain('del_files=0');
+    });
+
+    // SABnzbd answers 200 with {"status": false} for an id it does not have.
+    // Trusting the status line would report a deletion that never happened.
+    it('treats SABnzbd status:false as a failure, not a success', async () => {
+        const impl = (async () =>
+            jsonResponse({ status: false, error: 'nzo_id not found' })) as unknown as typeof fetch;
+
+        await expect(
+            new SabnzbdAdapter(keyed(8080), impl).removeQueueItem('nope', {
+                removeFromClient: true,
+                blocklist: false
+            })
+        ).rejects.toThrow(/refused/);
+    });
+
+    it('accepts SABnzbd status:true', async () => {
+        const impl = (async () => jsonResponse({ status: true })) as unknown as typeof fetch;
+        await expect(
+            new SabnzbdAdapter(keyed(8080), impl).removeQueueItem('SABnzbd_nzo_ab12', {
+                removeFromClient: true,
+                blocklist: false
+            })
+        ).resolves.toBeUndefined();
+    });
+
+    it('maps removeFromClient to Transmission delete-local-data', async () => {
+        const { impl, sent } = recordingFetch({});
+        const impl2 = (async (input: string | URL | Request, init?: RequestInit) => {
+            await impl(input, init);
+            return jsonResponse({ result: 'success' });
+        }) as unknown as typeof fetch;
+
+        await new TransmissionAdapter(transmissionConfig, impl2).removeQueueItem('3', {
+            removeFromClient: true,
+            blocklist: false
+        });
+
+        const rpc = sent.find(s => s.method === 'POST')?.body as {
+            method: string;
+            arguments: Record<string, unknown>;
+        };
+        expect(rpc.method).toBe('torrent-remove');
+        expect(rpc.arguments).toEqual({ ids: [3], 'delete-local-data': true });
+    });
+
+    // Transmission reports failure as HTTP 200 with a non-success result.
+    it('treats a non-success Transmission result as a failure', async () => {
+        const impl = (async () => jsonResponse({ result: 'invalid argument' })) as unknown as typeof fetch;
+        await expect(
+            new TransmissionAdapter(transmissionConfig, impl).removeQueueItem('3', {
+                removeFromClient: true,
+                blocklist: false
+            })
+        ).rejects.toThrow(/torrent-remove failed/);
+    });
+});
+
+// --- the tools -----------------------------------------------------------
+
+type Call = (args: Record<string, unknown>) => Promise<{
+    content: { type: 'text'; text: string }[];
+    structuredContent: WriteToolResult;
+}>;
+
+function harness(
+    register: typeof registerDeleteMedia,
+    opts: { permissions?: Partial<Record<ServiceId, AnyServiceConfig>>; adapters?: ServiceAdapter[] } = {}
+) {
+    const radarr = recordingFetch({ '/api/v3/movie/412': MOVIE, '/api/v3/queue': ARR_QUEUE });
+    const sonarr = recordingFetch({ '/api/v3/series/7': SERIES, '/api/v3/queue': ARR_QUEUE });
+
+    const adapters = opts.adapters ?? [
+        new RadarrAdapter(keyed(7878), radarr.impl),
+        new SonarrAdapter(keyed(8989), sonarr.impl)
+    ];
+
+    let call: Call = () => Promise.reject(new Error('not registered'));
+    const server = {
+        registerTool(_n: string, config: { inputSchema: z.ZodObject }, handler: Call) {
+            call = args => handler(config.inputSchema.parse(args) as Record<string, unknown>);
+        }
+    };
+
+    const invalidate = vi.fn();
+    const audit = WriteAudit.ephemeral();
+    register(
+        server as never,
+        {
+            permissions: permissionSourceFrom(
+                opts.permissions ?? { radarr: tiered(false, true), sonarr: tiered(false, true) }
+            ),
+            confirm: new ConfirmTokens(),
+            audit,
+            library: { invalidate } as unknown as LibraryLoader
+        },
+        adapters
+    );
+
+    return { call: (a: Record<string, unknown>) => call(a), radarr, sonarr, audit, invalidate };
+}
+
+describe('delete_media', () => {
+    it('names the film and the size on disk, not the id', async () => {
+        const h = harness(registerDeleteMedia);
+        const { structuredContent } = await h.call({ service: 'radarr', id: '412', delete_files: true, dry_run: true });
+
+        expect(structuredContent.summary).toContain('Alien');
+        expect(structuredContent.summary).toContain('24.1 GB');
+        expect(structuredContent.tier).toBe('destructive');
+    });
+
+    it('says plainly that files stay when delete_files is false', async () => {
+        const h = harness(registerDeleteMedia);
+        const { structuredContent } = await h.call({ service: 'radarr', id: '412', dry_run: true });
+        expect(structuredContent.effects.join(' ')).toContain('Leaves the files on disk');
+    });
+
+    it('warns that a Sonarr delete takes the whole series', async () => {
+        const h = harness(registerDeleteMedia);
+        const { structuredContent } = await h.call({ service: 'sonarr', id: '7', delete_files: true, dry_run: true });
+        expect(structuredContent.effects.join(' ')).toContain('every episode');
+    });
+
+    it('deletes nothing on a dry run', async () => {
+        const h = harness(registerDeleteMedia);
+        await h.call({ service: 'radarr', id: '412', delete_files: true, dry_run: true });
+        expect(h.radarr.sent.filter(s => s.method === 'DELETE')).toHaveLength(0);
+    });
+
+    it('deletes nothing on an unconfirmed call', async () => {
+        const h = harness(registerDeleteMedia);
+        const first = await h.call({ service: 'radarr', id: '412', delete_files: true });
+        expect(first.structuredContent.applied).toBe(false);
+        expect(h.radarr.sent.filter(s => s.method === 'DELETE')).toHaveLength(0);
+    });
+
+    it('deletes once confirmed', async () => {
+        const h = harness(registerDeleteMedia);
+        const first = await h.call({ service: 'radarr', id: '412', delete_files: true });
+        const second = await h.call({
+            service: 'radarr',
+            id: '412',
+            delete_files: true,
+            confirm: first.structuredContent.confirm_token
+        });
+
+        expect(second.structuredContent.applied).toBe(true);
+        expect(h.radarr.sent.find(s => s.method === 'DELETE')?.search).toContain('deleteFiles=true');
+        expect(h.invalidate).toHaveBeenCalledTimes(1);
+    });
+
+    // The token commits to the flags, so escalating after the preview fails.
+    it('will not let a token previewed without delete_files be used to wipe the disk', async () => {
+        const h = harness(registerDeleteMedia);
+        const preview = await h.call({ service: 'radarr', id: '412', delete_files: false });
+
+        const escalated = await h.call({
+            service: 'radarr',
+            id: '412',
+            delete_files: true,
+            confirm: preview.structuredContent.confirm_token
+        });
+
+        expect(escalated.structuredContent.applied).toBe(false);
+        expect(escalated.structuredContent.confirm_error).toContain('different operation');
+        expect(h.radarr.sent.filter(s => s.method === 'DELETE')).toHaveLength(0);
+    });
+
+    // safe_write must not reach a destructive tool.
+    it('is refused by safe_write alone', async () => {
+        const h = harness(registerDeleteMedia, { permissions: { radarr: tiered(true, false) } });
+        await expect(h.call({ service: 'radarr', id: '412' })).rejects.toThrow(
+            /services\.radarr\.permissions\.destructive: true/
+        );
+        expect(h.radarr.sent.filter(s => s.method === 'DELETE')).toHaveLength(0);
+    });
+
+    it('records the deletion in the audit trail with its arguments', async () => {
+        const h = harness(registerDeleteMedia);
+        const first = await h.call({ service: 'radarr', id: '412', delete_files: true });
+        await h.call({
+            service: 'radarr',
+            id: '412',
+            delete_files: true,
+            confirm: first.structuredContent.confirm_token
+        });
+
+        const rows = h.audit.recent() as { outcome: string; target: string; args: string }[];
+        expect(rows[0]?.outcome).toBe('applied');
+        expect(rows[0]?.target).toBe('radarr:412');
+        expect(JSON.parse(rows[0]?.args ?? '{}')).toMatchObject({ deleteFiles: true });
+    });
+});
+
+describe('remove_queue_item', () => {
+    it('names the release and its current status', async () => {
+        const h = harness(registerRemoveQueueItem);
+        const { structuredContent } = await h.call({ service: 'radarr', id: '91', dry_run: true });
+
+        expect(structuredContent.summary).toContain('Alien.1979.2160p-GROUP');
+        expect(structuredContent.summary).toContain('stalled');
+    });
+
+    it('fails legibly when the id is no longer in the queue', async () => {
+        const h = harness(registerRemoveQueueItem);
+        await expect(h.call({ service: 'radarr', id: '999', dry_run: true })).rejects.toThrow(
+            /nothing in radarr's queue has id/
+        );
+    });
+
+    it('removes once confirmed, deleting partial data by default', async () => {
+        const h = harness(registerRemoveQueueItem);
+        const first = await h.call({ service: 'radarr', id: '91' });
+        await h.call({ service: 'radarr', id: '91', confirm: first.structuredContent.confirm_token });
+
+        const del = h.radarr.sent.find(s => s.method === 'DELETE');
+        expect(del?.path).toBe('/api/v3/queue/91');
+        expect(del?.search).toContain('removeFromClient=true');
+    });
+
+    it('says the blocklist flag is ignored on a service that has none', async () => {
+        const sabQueue = {
+            queue: { slots: [{ nzo_id: 'SABnzbd_nzo_ab12', filename: 'Alien.1979-GROUP', status: 'Downloading' }] }
+        };
+        const sab = recordingFetch({});
+        const impl = (async (input: string | URL | Request, init?: RequestInit) => {
+            await sab.impl(input, init);
+            return jsonResponse(sabQueue);
+        }) as unknown as typeof fetch;
+
+        const h = harness(registerRemoveQueueItem, {
+            adapters: [new SabnzbdAdapter(keyed(8080), impl)],
+            permissions: { sabnzbd: tiered(false, true) }
+        });
+
+        const { structuredContent } = await h.call({
+            service: 'sabnzbd',
+            id: 'SABnzbd_nzo_ab12',
+            blocklist: true,
+            dry_run: true
+        });
+
+        expect(structuredContent.effects.join(' ')).toContain('has no blocklist of its own');
+    });
+
+    it('is refused by safe_write alone', async () => {
+        const h = harness(registerRemoveQueueItem, { permissions: { radarr: tiered(true, false) } });
+        await expect(h.call({ service: 'radarr', id: '91' })).rejects.toThrow(
+            /services\.radarr\.permissions\.destructive: true/
+        );
+    });
+});


### PR DESCRIPTION
Follows #45, which is already merged. Targets `main` directly.

Gives the destructive tier a caller — it landed in #45 fully tested but with nothing calling it. `remove_queue_item` across all four queue services, and `delete_media` on Radarr and Sonarr. Both sit on the Phase 4 harness, so neither reimplements a gate — the whole diff for each tool is a `plan` and an `apply`.

## `ServiceHttp.delete`

New, and typed `void` deliberately. Radarr and Sonarr answer a delete with **200 and an empty body**, so routing one through the existing JSON parse turns every successful deletion into `response was not valid JSON`. A `delete<T>` would also invite a caller to read fields that are never there. There's a test asserting the empty-200 case specifically, because it is the one that would have shipped broken.

## Things the *arr APIs will bite you with

**Both flags are serialised explicitly, never omitted when false.** Radarr defaults `removeFromClient` to **true**, so leaving it out of a remove-from-Radarr-only request would also wipe the item from the download client — the exact opposite of what was asked for. Same reasoning for `deleteFiles`.

**Two services report failure as HTTP 200.** SABnzbd answers `{"status": false}` for an `nzo_id` it does not have; Transmission returns a non-success `result`. Both are checked on the body, not the status line — trusting the status line would report a deletion that never happened. Tested both ways for both services.

**Sonarr's delete takes the whole series.** There is no per-episode form on that path, so the tool says so in the preview rather than letting someone discover it afterwards.

## `blocklist` is honoured only where it exists

SABnzbd and Transmission have no blocklist of their own — that is an *arr concept. Rather than accept a flag that quietly does nothing, `supportsBlocklist` is part of the capability, the preview says the flag is being ignored and names where to go instead, and **the token and the audit row record the effective value rather than the requested one**. Silently accepting `blocklist: true` on SABnzbd is how someone believes a release is blocklisted for a year.

## Why both are `destructive`, not `safe`

`delete_media` is obvious. `remove_queue_item` is the arguable one: a removed download can be searched for again. It is destructive anyway because `remove_from_client` deletes partial data, and because a blocklist entry is durable, easy to miss, and genuinely hard to undo months later when the same film mysteriously never grabs. Per the tier guidance added in #45: when unsure, it is `destructive` — the cost of over-classifying is one config flag.

## The preview is the product here

Both tools read the item before writing it. That is what makes a confirmation approvable:

> Not applied yet. Delete They Will Kill You (2026) from radarr, deleting 18.8 GB from disk.
>
> - Deletes 18.8 GB from disk. This cannot be undone.
> - Removes They Will Kill You (2026) from radarr, along with its monitoring and history.

"Delete radarr:1535" is not something anyone can meaningfully approve. The read also turns a stale queue id into a legible failure — *"nothing in radarr's queue has id 91; it may have finished or already been removed"* — instead of a confusing 404 from a delete.

There's a test that a token previewed with `delete_files: false` cannot be replayed with `delete_files: true`. That escalation is the one I'd most want to be sure about, and it falls straight out of the token binding from #45.

## Verification

- 809 tests / 41 files; typecheck, lint and build clean.
- **24/24 integration calls against a live eight-service stack.** The `delete_media` dry run read a real film, reported its real size on disk, and refused because the tier is off.
- The integration script **previews these two and never applies them.** A live case would delete a maintainer's film or wipe a partial download on every run, and no amount of care in a script makes that an acceptable default. `remove_queue_item` skips when the queue is empty and says so rather than passing silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
