### PR TITLE
feat: manage Seerr requests (respond_to_request, delete_request)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Jellyfin. arr-mcp correlates them and gives you the causal chain.
 >
 > **On `main`, ahead of the 0.4 tag:** writes, as described under
 > [Writes](#writes) — permission tiers, `dry_run`, confirmation tokens and the
-> audit trail, with `trigger_search`, `remove_queue_item` and `delete_media`.
-> Released images tagged `0.4` are still read-only.
+> audit trail, with five write tools covering searches, the download queue,
+> media and Seerr requests. Released images tagged `0.4` are still read-only.
 
 ## Services
 
@@ -56,6 +56,8 @@ All eight are supported as of 0.3.
 | `trigger_search` | Go look for this again |
 | `remove_queue_item` | Get rid of this stuck or wrong download |
 | `delete_media` | Remove this film or series, optionally from disk |
+| `respond_to_request` | Approve or decline what someone asked for |
+| `delete_request` | Drop a request record entirely |
 
 Every tool but `diagnose` takes `detail` (`minimal`/`standard`/`full`) and
 `limit`, and reports `{ total, returned, truncated }` — a truncated answer
@@ -70,7 +72,7 @@ only — a series has no series-level quality, and Sonarr carries one flat
 TVDB rating rather than per-source scores. Asking either of series returns a
 refusal explaining why, not an empty list.
 
-The first thirteen are reads. The last three write, and are gated as described
+The first thirteen are reads. The last five write, and are gated as described
 under [Writes](#writes) — off by default, previewed before they act, recorded
 either way.
 
@@ -118,8 +120,16 @@ a film but refuses to re-monitor it.
 | Tool | Tier | Needs |
 | --- | --- | --- |
 | `trigger_search` | safe | `safe_write` |
+| `respond_to_request` | safe | `safe_write` |
 | `remove_queue_item` | destructive | `destructive` |
 | `delete_media` | destructive | `destructive` |
+| `delete_request` | destructive | `destructive` |
+
+Approving and declining a request are one tool and deleting one is another,
+because that is where the tier boundary falls: a verdict can be reversed, a
+deleted record cannot. `delete_request` removes the *request*, never the media —
+anything already downloaded stays on disk, and the preview says so before you
+confirm rather than after.
 
 `remove_queue_item` is destructive rather than safe because it deletes partial
 data, and because `blocklist: true` durably teaches Radarr or Sonarr to refuse a

--- a/scripts/integration.ts
+++ b/scripts/integration.ts
@@ -103,7 +103,13 @@ const hosts = hostsOf(config);
  * needs a real id would either fail the check forever or, worse, be given a
  * made-up id just to satisfy it.
  */
-const DYNAMIC_TOOLS: ToolName[] = ['trigger_search', 'remove_queue_item', 'delete_media'];
+const DYNAMIC_TOOLS: ToolName[] = [
+    'trigger_search',
+    'remove_queue_item',
+    'delete_media',
+    'respond_to_request',
+    'delete_request'
+];
 
 const missing = TOOL_NAMES.filter(
     name => !CASES.some(c => c.tool === name) && !DYNAMIC_TOOLS.includes(name)
@@ -188,12 +194,14 @@ async function run(tool: string, args: Record<string, unknown>, note?: string): 
 let libraryResult: ToolCallResult | undefined;
 let searchResult: ToolCallResult | undefined;
 let queueResult: ToolCallResult | undefined;
+let requestsResult: ToolCallResult | undefined;
 
 for (const { tool, args } of CASES) {
     const result = await run(tool, args);
     if (tool === 'get_library' && args.detail === 'standard') libraryResult = result;
     if (tool === 'search_media') searchResult = result;
     if (tool === 'get_queue') queueResult = result;
+    if (tool === 'get_requests') requestsResult = result;
 }
 
 /**
@@ -308,6 +316,30 @@ if (typeof queueItem?.service === 'string' && queueItem.id !== undefined) {
     // Routine, not a failure: a healthy stack with nothing downloading has an
     // empty queue most of the time.
     console.log('SKIP remove_queue_item — the queue is empty, so there is no real item to preview against.');
+}
+
+/**
+ * The Seerr pair, dry run only for the same reason as the two above —
+ * approving a request really does start a download, and deleting one really
+ * does destroy the record.
+ */
+const request = (requestsResult?.structuredContent as { items?: unknown[] } | undefined)?.items?.[0] as
+    | { id?: unknown }
+    | undefined;
+
+if (request?.id !== undefined) {
+    await run(
+        'respond_to_request',
+        { id: String(request.id), verdict: 'approve', dry_run: true },
+        'DRY RUN ONLY — never applied from this script'
+    );
+    await run(
+        'delete_request',
+        { id: String(request.id), dry_run: true },
+        'DRY RUN ONLY — never applied from this script'
+    );
+} else {
+    console.log('SKIP respond_to_request and delete_request — get_requests returned nothing to preview against.');
 }
 
 console.log(`\n${passes}/${passes + failures} calls succeeded.`);

--- a/src/services/seerr.ts
+++ b/src/services/seerr.ts
@@ -3,12 +3,15 @@ import { apiKeyHeader } from '../core/auth.ts';
 import { ServiceError } from '../core/errors.ts';
 import { ServiceHttp } from '../core/http.ts';
 import { fenceText } from '../core/fence.ts';
+import { logger } from '../core/logger.ts';
 import {
     diagnoseConnection,
     type ConnectionDiagnosis,
     type DiscoverCapable,
     type MediaRequest,
+    type RequestManageCapable,
     type RequestStatus,
+    type RequestVerdict,
     type SearchCapable,
     type SearchHit,
     type SearchSource,
@@ -27,6 +30,13 @@ type RawSearchResult = {
 };
 
 type RawStatus = { version?: string; commitTag?: string };
+
+/**
+ * `/movie/{tmdbId}` and `/tv/{tmdbId}` in one shape. Upstream names the title
+ * differently per media type — `title`/`releaseDate` for films, `name`/
+ * `firstAirDate` for series — so both spellings are read.
+ */
+type RawMediaDetails = { title?: string; name?: string; releaseDate?: string; firstAirDate?: string };
 type RawRequest = {
     id?: number;
     status?: number;
@@ -55,6 +65,23 @@ const STATUS: Record<number, RequestStatus> = { 1: 'pending', 2: 'approved', 3: 
  */
 const SEERR_FILTERS_SERVER_SIDE = true;
 
+/**
+ * A release year, or nothing.
+ *
+ * `Number(''.slice(0, 4))` is **0**, not NaN, so a `Number.isFinite` guard
+ * happily lets it through — which is how a live preview came out reading
+ * "The Origin of Hide and Seek (0)". Seerr returns an empty `releaseDate` for
+ * anything TMDB has no date for, which on a real instance is common. Requiring
+ * four leading digits and a plausible value is what makes the absent case
+ * absent rather than zero.
+ */
+const yearOf = (date: string | undefined): number | undefined => {
+    if (date === undefined || !/^\d{4}/.test(date)) return undefined;
+    const year = Number(date.slice(0, 4));
+    // 1878 is the first motion picture; anything below is a data error, not a film.
+    return year >= 1878 ? year : undefined;
+};
+
 /** Narrowed through a typed helper: an inline ternary widens this to `string`. */
 const mediaTypeOf = (value: string | undefined): MediaRequest['mediaType'] =>
     value === 'movie' || value === 'tv' ? value : 'unknown';
@@ -68,7 +95,9 @@ type RawUserPage = { results?: RawUser[] };
  */
 const nameOf = (u: RawUser): string | undefined => u.displayName ?? u.username ?? u.email?.split('@')[0];
 
-export class SeerrAdapter implements ServiceAdapter, UserDirectoryCapable, SearchCapable, DiscoverCapable {
+export class SeerrAdapter
+    implements ServiceAdapter, UserDirectoryCapable, SearchCapable, DiscoverCapable, RequestManageCapable
+{
     readonly id: ServiceId = 'seerr';
     readonly #http: ServiceHttp;
 
@@ -100,22 +129,7 @@ export class SeerrAdapter implements ServiceAdapter, UserDirectoryCapable, Searc
 
         return (page.results ?? [])
             .filter((r): r is RawRequest & { id: number } => typeof r.id === 'number')
-            .map(r => ({
-                service: this.id,
-                id: r.id,
-                status: STATUS[r.status ?? -1] ?? ('unknown' as const),
-                mediaType: mediaTypeOf(r.media?.mediaType),
-                ...(r.media?.tmdbId === undefined ? {} : { tmdbId: r.media.tmdbId }),
-                // Seerr's MediaInfo carries tvdbId nullable (specs/seerr.json):
-                // populated for tv media, always null for movies. Matching the
-                // movie fixture, which carries the key present but null.
-                ...(r.media?.tvdbId === undefined || r.media?.tvdbId === null ? {} : { tvdbId: r.media.tvdbId }),
-                ...(r.media?.title === undefined
-                    ? {}
-                    : { title: fenceText(r.media.title, { service: this.id, field: 'title' }) }),
-                requestedBy: nameOf(r.requestedBy ?? {}) ?? 'unknown',
-                ...(r.createdAt === undefined ? {} : { requestedAt: r.createdAt })
-            }))
+            .map(r => this.#toRequest(r))
             // The in-memory user filter runs unconditionally, even when the
             // server filtered too. It costs nothing, and it means flipping
             // SEERR_FILTERS_SERVER_SIDE can never silently widen what a user sees.
@@ -123,15 +137,117 @@ export class SeerrAdapter implements ServiceAdapter, UserDirectoryCapable, Searc
             .filter(r => opts.status === undefined || r.status === opts.status);
     }
 
+    /**
+     * Shared by the read above and the write below, so a request reported by
+     * `get_requests` and the same request reported back by `respond_to_request`
+     * cannot disagree about their own shape.
+     */
+    #toRequest(r: RawRequest & { id: number }): MediaRequest {
+        return {
+            service: this.id,
+            id: r.id,
+            status: STATUS[r.status ?? -1] ?? ('unknown' as const),
+            mediaType: mediaTypeOf(r.media?.mediaType),
+            ...(r.media?.tmdbId === undefined ? {} : { tmdbId: r.media.tmdbId }),
+            // Seerr's MediaInfo carries tvdbId nullable (specs/seerr.json):
+            // populated for tv media, always null for movies. Matching the
+            // movie fixture, which carries the key present but null.
+            ...(r.media?.tvdbId === undefined || r.media?.tvdbId === null ? {} : { tvdbId: r.media.tvdbId }),
+            ...(r.media?.title === undefined
+                ? {}
+                : { title: fenceText(r.media.title, { service: this.id, field: 'title' }) }),
+            requestedBy: nameOf(r.requestedBy ?? {}) ?? 'unknown',
+            ...(r.createdAt === undefined ? {} : { requestedAt: r.createdAt })
+        };
+    }
+
+    /**
+     * Approving is what actually sets a download in motion: Seerr hands the
+     * request to Radarr or Sonarr, which searches and grabs. It is still the
+     * `safe` tier because the state is reversible from Seerr's own UI and by
+     * this same call — but `respond_to_request`'s preview says what it will
+     * cost, because "approve" reads much cheaper than it is.
+     */
+    async respondToRequest(id: string, verdict: RequestVerdict): Promise<MediaRequest> {
+        const requestId = Number(id);
+        if (!Number.isInteger(requestId)) {
+            throw new ServiceError('NotFound', this.id, `"${id}" is not a Seerr request id`, {
+                remedy: 'Seerr request ids are integers. Take one from get_requests.'
+            });
+        }
+
+        // Seerr wants a POST with no meaningful body; it rejects one with no
+        // content-type at all, so an empty object is sent rather than nothing.
+        const updated = await this.#http.post<RawRequest>(`/api/v1/request/${requestId}/${verdict}`, {});
+
+        // The response is the updated request. If it comes back without an id
+        // we cannot honestly report what it became, and saying "approved"
+        // anyway would be a claim we did not verify.
+        if (typeof updated.id !== 'number') {
+            throw new ServiceError('UpstreamError', this.id, `${verdict} returned no request in its response`, {
+                remedy: 'The change may still have been applied — call get_requests to check before retrying.'
+            });
+        }
+        return this.#toRequest(updated as RawRequest & { id: number });
+    }
+
+    /**
+     * One extra call, made only by the write previews and deliberately **not**
+     * by `getRequests`: a 500-row request list would mean 500 lookups, while a
+     * preview concerns exactly one request and is the place a real title is
+     * worth paying for.
+     *
+     * Movies and series answer on different paths with differently-named title
+     * fields — `title`/`releaseDate` against `name`/`firstAirDate` — which is
+     * why this cannot be one generic fetch.
+     */
+    async describeRequestMedia(request: MediaRequest): Promise<{ title: string; year?: number } | undefined> {
+        if (request.tmdbId === undefined || request.mediaType === 'unknown') return undefined;
+
+        const path = request.mediaType === 'movie' ? `/api/v1/movie/${request.tmdbId}` : `/api/v1/tv/${request.tmdbId}`;
+
+        try {
+            const raw = await this.#http.get<RawMediaDetails>(path);
+            const title = raw.title ?? raw.name;
+            if (title === undefined || title === '') return undefined;
+
+            const year = yearOf(raw.releaseDate ?? raw.firstAirDate);
+
+            return {
+                title: fenceText(title, { service: this.id, field: 'title' }),
+                ...(year === undefined ? {} : { year })
+            };
+        } catch (err) {
+            // Degrades rather than propagating: a lookup failure must not stop
+            // someone deleting a request. The preview says the title is
+            // unavailable instead of inventing one.
+            logger.warn({ service: this.id, err, request: request.id }, 'could not resolve a title for a request');
+            return undefined;
+        }
+    }
+
+    async deleteRequest(id: string): Promise<void> {
+        const requestId = Number(id);
+        if (!Number.isInteger(requestId)) {
+            throw new ServiceError('NotFound', this.id, `"${id}" is not a Seerr request id`, {
+                remedy: 'Seerr request ids are integers. Take one from get_requests.'
+            });
+        }
+        await this.#http.delete(`/api/v1/request/${requestId}`);
+    }
+
     #toHit(r: RawSearchResult & { id: number }, kind: 'movie' | 'series'): SearchHit {
-        const date = r.releaseDate ?? r.firstAirDate;
+        // Same `yearOf` as the request lookup, and for the same reason: this
+        // path had the identical bug, so an undated title in search_media or
+        // discover_media has been reporting `year: 0` since 0.3.
+        const year = yearOf(r.releaseDate ?? r.firstAirDate);
         return {
             service: this.id,
             source: 'discover',
             kind,
             id: String(r.id),
             title: fenceText(r.title ?? r.name ?? '', { service: this.id, field: 'title' }),
-            ...(date === undefined ? {} : { year: Number(date.slice(0, 4)) }),
+            ...(year === undefined ? {} : { year }),
             ids: { tmdb: r.id }
         };
     }

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -334,6 +334,39 @@ export const hasQueueRemove = (a: ServiceAdapter): a is ServiceAdapter & QueueRe
     typeof (a as Partial<QueueRemoveCapable>).removeQueueItem === 'function';
 
 /**
+ * The two reversible verdicts on a request. Deliberately not including
+ * "delete": approving and declining move a request between states it can be
+ * moved back out of, and deleting destroys the record. That difference is a
+ * permission tier, so it is also a different capability method and a different
+ * tool.
+ */
+export type RequestVerdict = 'approve' | 'decline';
+
+export interface RequestManageCapable {
+    /** Returns the request as it stands afterwards, so the caller can report
+     *  what it became rather than what it asked for. */
+    respondToRequest(id: string, verdict: RequestVerdict): Promise<MediaRequest>;
+    deleteRequest(id: string): Promise<void>;
+    /**
+     * Resolves a human title for a request.
+     *
+     * Needed because Seerr's `/api/v1/request` payload carries **no title at
+     * all** — its `media` object is ids and service metadata only, confirmed
+     * against a live Seerr 3.4.1 and against the recorded fixture. So
+     * `MediaRequest.title` is undefined for every real request, and a write
+     * preview built from it alone says "request 19", which is not something
+     * anyone can meaningfully approve.
+     *
+     * Resolves undefined rather than throwing: a title lookup that fails must
+     * not block a user from deleting a request.
+     */
+    describeRequestMedia(request: MediaRequest): Promise<{ title: string; year?: number } | undefined>;
+}
+
+export const hasRequestManage = (a: ServiceAdapter): a is ServiceAdapter & RequestManageCapable =>
+    typeof (a as Partial<RequestManageCapable>).respondToRequest === 'function';
+
+/**
  * A whole-library read, shaped for the identity resolver rather than for a
  * tool. Phase 3 joins three of these into one index; nothing else consumes it.
  */

--- a/src/tools/manageRequests.ts
+++ b/src/tools/manageRequests.ts
@@ -1,0 +1,187 @@
+import type { McpServer } from '@modelcontextprotocol/server';
+import * as z from 'zod/v4';
+import { ServiceError } from '../core/errors.ts';
+import {
+    hasRequestManage,
+    hasRequests,
+    type MediaRequest,
+    type RequestManageCapable,
+    type ServiceAdapter
+} from '../services/types.ts';
+import { registerWriteTool, type WriteContext, type WritePlan } from './write.ts';
+
+/**
+ * Seerr request management, as **two** tools rather than one with an `action`
+ * of three values.
+ *
+ * The split is the permission tier. Approving and declining move a request
+ * between states it can be moved back out of — including by this same tool —
+ * so they are `safe`. Deleting destroys the record, so it is `destructive`.
+ * A single tool spanning both would have to derive its tier from an argument,
+ * which means the tier stops being a statically reviewable property of the
+ * tool and becomes something you have to trace an enum to work out. The tier
+ * boundary is the tool boundary.
+ */
+
+const seerrAdapter = (adapters: readonly ServiceAdapter[]): ServiceAdapter & RequestManageCapable => {
+    const adapter = adapters.find(a => a.id === 'seerr');
+    if (adapter === undefined) {
+        throw new ServiceError('NotFound', 'seerr', 'seerr is not configured', {
+            remedy: 'Add a services.seerr block to config.yaml and restart. Requests live in Seerr, not in Radarr or Sonarr.'
+        });
+    }
+    if (!hasRequestManage(adapter)) {
+        throw new ServiceError('NotFound', 'seerr', 'this seerr adapter cannot manage requests');
+    }
+    return adapter;
+};
+
+/**
+ * Requests are read back by id from the live list rather than trusted from the
+ * argument, for the same reason every other write tool reads first: so the
+ * preview names a film and a person, and so a stale id fails here rather than
+ * as a bare 404.
+ */
+async function findRequest(adapters: readonly ServiceAdapter[], id: string): Promise<MediaRequest> {
+    const adapter = adapters.find(a => a.id === 'seerr');
+    if (adapter === undefined || !hasRequests(adapter)) {
+        throw new ServiceError('NotFound', 'seerr', 'seerr is not configured', {
+            remedy: 'Add a services.seerr block to config.yaml and restart.'
+        });
+    }
+
+    const found = (await adapter.getRequests({})).find(r => String(r.id) === id);
+    if (found === undefined) {
+        throw new ServiceError('NotFound', 'seerr', `no Seerr request has id "${id}"`, {
+            remedy: 'It may already have been deleted. Call get_requests for a current list.'
+        });
+    }
+    return found;
+}
+
+/**
+ * Seerr's request payload carries no title (see `describeRequestMedia`), so
+ * naming the media takes a second lookup. Worth it here and nowhere else: this
+ * string is what someone approves or refuses, and "request 19, requested by
+ * Sam" does not tell them whether they are about to delete a request for a
+ * children's film or a box set.
+ *
+ * Falls back to the id when the lookup cannot answer, and says so, rather than
+ * quietly presenting a bare id as though that were the whole story.
+ */
+async function describe(adapters: readonly ServiceAdapter[], request: MediaRequest): Promise<string> {
+    const adapter = adapters.find(a => a.id === 'seerr');
+    const media =
+        adapter !== undefined && hasRequestManage(adapter)
+            ? await adapter.describeRequestMedia(request)
+            : undefined;
+
+    if (media === undefined) {
+        const kind = request.mediaType === 'unknown' ? 'media' : request.mediaType;
+        return `request ${request.id} (${kind}, title unavailable), requested by ${request.requestedBy}`;
+    }
+    return `${media.title}${media.year === undefined ? '' : ` (${media.year})`}, requested by ${request.requestedBy}`;
+}
+
+export function registerRespondToRequest(
+    server: McpServer,
+    context: WriteContext,
+    adapters: readonly ServiceAdapter[]
+): void {
+    registerWriteTool(server, context, {
+        name: 'respond_to_request',
+        description:
+            'Approves or declines a pending Seerr request. Approving hands it to Radarr or Sonarr, which will search for it and download it — so it costs disk space and bandwidth even though the decision itself is reversible. Take `id` from get_requests. Previews by default — call again with the returned `confirm` token to actually apply the verdict.',
+        inputSchema: z.object({
+            id: z.string().min(1).describe('The Seerr request id, as get_requests reported it.'),
+            verdict: z.enum(['approve', 'decline']).describe('approve or decline.')
+        }),
+        service: 'seerr',
+        operation: 'respond_to_request',
+        tier: 'safe',
+
+        async plan({ id, verdict }): Promise<WritePlan> {
+            const request = await findRequest(adapters, id);
+            const label = await describe(adapters, request);
+            const target = verdict === 'approve' ? 'approved' : 'declined';
+
+            // Re-approving an approved request is not an error, but it is not
+            // an action either — and asking someone to confirm a no-op teaches
+            // them to confirm without reading.
+            if (request.status === target) {
+                return {
+                    target: `seerr:${id}`,
+                    summary: `${label} is already ${target}.`,
+                    effects: [],
+                    noop: true
+                };
+            }
+
+            const effects =
+                verdict === 'approve'
+                    ? [
+                          'Hands the request to Radarr or Sonarr, which will search for it and start downloading — this uses disk space and bandwidth.',
+                          `Marks the request approved. ${request.requestedBy} will see it as accepted.`
+                      ]
+                    : [
+                          `Marks the request declined. ${request.requestedBy} will see it as rejected.`,
+                          'Downloads nothing. Anything already downloaded for it is left alone.'
+                      ];
+
+            return {
+                target: `seerr:${id}`,
+                summary: `${verdict === 'approve' ? 'Approve' : 'Decline'} ${label} (currently ${request.status}).`,
+                effects,
+                args: { id, verdict }
+            };
+        },
+
+        async apply(_plan, { id, verdict }) {
+            // Reports what the request *became*, read back from Seerr's own
+            // response, rather than echoing what was asked for.
+            const updated = await seerrAdapter(adapters).respondToRequest(id, verdict);
+            return { id: updated.id, status: updated.status };
+        }
+    });
+}
+
+export function registerDeleteRequest(
+    server: McpServer,
+    context: WriteContext,
+    adapters: readonly ServiceAdapter[]
+): void {
+    registerWriteTool(server, context, {
+        name: 'delete_request',
+        description:
+            'Deletes a Seerr request record entirely. This removes the request, not the media — anything already downloaded stays on disk and in Radarr or Sonarr. Use respond_to_request with `decline` to refuse a request while keeping the record. Take `id` from get_requests. Previews by default — call again with the returned `confirm` token to actually delete it.',
+        inputSchema: z.object({
+            id: z.string().min(1).describe('The Seerr request id, as get_requests reported it.')
+        }),
+        service: 'seerr',
+        operation: 'delete_request',
+        tier: 'destructive',
+
+        async plan({ id }): Promise<WritePlan> {
+            const request = await findRequest(adapters, id);
+            const label = await describe(adapters, request);
+
+            return {
+                target: `seerr:${id}`,
+                summary: `Delete the Seerr request for ${label} (currently ${request.status}).`,
+                effects: [
+                    'Removes the request record from Seerr. This cannot be undone — the request would have to be made again.',
+                    // The distinction people get wrong, stated before they act
+                    // rather than discovered after: this is not delete_media.
+                    'Does NOT delete any media. Anything already downloaded stays on disk and in Radarr or Sonarr — use delete_media for that.',
+                    `${request.requestedBy} will no longer see this request at all.`
+                ],
+                args: { id }
+            };
+        },
+
+        async apply(_plan, { id }) {
+            await seerrAdapter(adapters).deleteRequest(id);
+            return { deleted: `seerr:${id}` };
+        }
+    });
+}

--- a/src/tools/register.ts
+++ b/src/tools/register.ts
@@ -20,6 +20,7 @@ import { registerGetRequests } from './getRequests.ts';
 import { registerGetSubtitles } from './getSubtitles.ts';
 import { LibraryLoader } from './library.ts';
 import { registerLookupMedia } from './lookupMedia.ts';
+import { registerDeleteRequest, registerRespondToRequest } from './manageRequests.ts';
 import { registerRemoveQueueItem } from './removeQueueItem.ts';
 import { registerSearchMedia } from './searchMedia.ts';
 import { registerStackHealth } from './stackHealth.ts';
@@ -116,6 +117,8 @@ export function registerAllTools(server: McpServer, context: ToolContext): void 
     registerTriggerSearch(server, write, adapters);
     registerRemoveQueueItem(server, write, adapters);
     registerDeleteMedia(server, write, adapters);
+    registerRespondToRequest(server, write, adapters);
+    registerDeleteRequest(server, write, adapters);
 }
 
 /** The tool surface, frozen. §18: renaming one breaks users' saved prompts. */
@@ -135,5 +138,7 @@ export const TOOL_NAMES = [
     'discover_media',
     'trigger_search',
     'remove_queue_item',
-    'delete_media'
+    'delete_media',
+    'respond_to_request',
+    'delete_request'
 ] as const;

--- a/test/manageRequests.test.ts
+++ b/test/manageRequests.test.ts
@@ -1,0 +1,389 @@
+import { describe, expect, it, vi } from 'vitest';
+import * as z from 'zod/v4';
+import type { AnyServiceConfig, MultiUserServiceConfig, ServiceId } from '../src/config/schema.ts';
+import { WriteAudit } from '../src/core/audit.ts';
+import { ConfirmTokens } from '../src/core/confirm.ts';
+import { ServiceError } from '../src/core/errors.ts';
+import { permissionSourceFrom } from '../src/core/permissions.ts';
+import { SeerrAdapter } from '../src/services/seerr.ts';
+import type { ServiceAdapter } from '../src/services/types.ts';
+import type { LibraryLoader } from '../src/tools/library.ts';
+import { registerDeleteRequest, registerRespondToRequest } from '../src/tools/manageRequests.ts';
+import type { WriteToolResult } from '../src/tools/write.ts';
+import { jsonResponse } from './helpers/serve.ts';
+
+const seerrConfig: MultiUserServiceConfig = {
+    url: 'http://192.0.2.10:5055',
+    api_key: 'k',
+    timeout_ms: 10_000,
+    allow_other_users: false,
+    permissions: { safe_write: false, destructive: false }
+};
+
+const tiered = (safe_write: boolean, destructive: boolean): AnyServiceConfig =>
+    ({ ...seerrConfig, permissions: { safe_write, destructive } }) as AnyServiceConfig;
+
+/**
+ * Shaped like the *recorded* response, which is the point: real Seerr sends
+ * **no title** on a request — `media` is ids and service metadata only. An
+ * earlier version of this file invented `media.title`, and every assertion
+ * against it passed while the live stack printed "request 19, requested by
+ * Bardesss". A fixture that is kinder than reality tests nothing.
+ */
+const PENDING = {
+    id: 31,
+    status: 1,
+    createdAt: '2026-08-01T10:00:00.000Z',
+    media: { tmdbId: 603, tvdbId: null, mediaType: 'movie' },
+    requestedBy: { id: 2, displayName: 'Sam' }
+};
+const APPROVED = { ...PENDING, status: 2 };
+
+/** What `/api/v1/movie/{tmdbId}` answers — where the title actually lives. */
+const MOVIE_DETAILS = { title: 'The Matrix', releaseDate: '1999-03-30' };
+
+function recordingFetch(handlers: {
+    requests?: unknown;
+    onWrite?: (path: string, method: string) => Response;
+    titleLookupFails?: boolean;
+}) {
+    const sent: { path: string; method: string; body: unknown }[] = [];
+    const impl = (async (input: string | URL | Request, init?: RequestInit) => {
+        const url = new URL(input instanceof Request ? input.url : String(input));
+        const method = init?.method ?? 'GET';
+        sent.push({
+            path: url.pathname,
+            method,
+            body: typeof init?.body === 'string' ? JSON.parse(init.body) : undefined
+        });
+
+        if (method !== 'GET') {
+            return handlers.onWrite?.(url.pathname, method) ?? new Response('', { status: 200 });
+        }
+        if (url.pathname === '/api/v1/request') {
+            return jsonResponse(handlers.requests ?? { results: [PENDING] });
+        }
+        if (url.pathname.startsWith('/api/v1/movie/')) {
+            return handlers.titleLookupFails === true
+                ? jsonResponse({ message: 'not found' }, 404)
+                : jsonResponse(MOVIE_DETAILS);
+        }
+        return jsonResponse({ message: 'not found' }, 404);
+    }) as unknown as typeof fetch;
+
+    return { impl, sent };
+}
+
+type Call = (args: Record<string, unknown>) => Promise<{
+    content: { type: 'text'; text: string }[];
+    structuredContent: WriteToolResult;
+}>;
+
+function harness(
+    register: typeof registerRespondToRequest,
+    opts: {
+        permissions?: Partial<Record<ServiceId, AnyServiceConfig>>;
+        requests?: unknown;
+        onWrite?: (path: string, method: string) => Response;
+        titleLookupFails?: boolean;
+        adapters?: ServiceAdapter[];
+    } = {}
+) {
+    const fetchImpl = recordingFetch({
+        ...(opts.requests === undefined ? {} : { requests: opts.requests }),
+        ...(opts.onWrite === undefined ? {} : { onWrite: opts.onWrite }),
+        ...(opts.titleLookupFails === undefined ? {} : { titleLookupFails: opts.titleLookupFails })
+    });
+    const adapters = opts.adapters ?? [new SeerrAdapter(seerrConfig, fetchImpl.impl)];
+
+    let call: Call = () => Promise.reject(new Error('not registered'));
+    const server = {
+        registerTool(_n: string, config: { inputSchema: z.ZodObject }, handler: Call) {
+            call = args => handler(config.inputSchema.parse(args) as Record<string, unknown>);
+        }
+    };
+
+    const invalidate = vi.fn();
+    const audit = WriteAudit.ephemeral();
+    register(
+        server as never,
+        {
+            permissions: permissionSourceFrom(opts.permissions ?? { seerr: tiered(false, true) }),
+            confirm: new ConfirmTokens(),
+            audit,
+            library: { invalidate } as unknown as LibraryLoader
+        },
+        adapters
+    );
+
+    return { call: (a: Record<string, unknown>) => call(a), fetchImpl, audit, invalidate };
+}
+
+// --- adapter -------------------------------------------------------------
+
+describe('SeerrAdapter request writes', () => {
+    it('posts to the verdict endpoint and reports what the request became', async () => {
+        const { impl, sent } = recordingFetch({ onWrite: () => jsonResponse(APPROVED) });
+        const updated = await new SeerrAdapter(seerrConfig, impl).respondToRequest('31', 'approve');
+
+        const post = sent.find(s => s.method === 'POST');
+        expect(post?.path).toBe('/api/v1/request/31/approve');
+        expect(updated.status).toBe('approved');
+    });
+
+    it('resolves a title from the media endpoint, since the request has none', async () => {
+        const { impl, sent } = recordingFetch({});
+        const adapter = new SeerrAdapter(seerrConfig, impl);
+        const [request] = await adapter.getRequests({});
+
+        // The gap this exists to close: nothing on the request itself.
+        expect(request?.title).toBeUndefined();
+
+        const described = await adapter.describeRequestMedia(request!);
+        // Fenced at the adapter boundary like every other free-text field, so
+        // the assertion is on the content, not on an unfenced string.
+        expect(described?.title).toContain('The Matrix');
+        expect(described?.title).toContain('untrusted');
+        expect(described?.year).toBe(1999);
+        expect(sent.some(s => s.path === '/api/v1/movie/603')).toBe(true);
+    });
+
+    it('looks up a series on the tv path, where the title is called name', async () => {
+        const seen: string[] = [];
+        const impl = (async (input: string | URL | Request) => {
+            const path = new URL(input instanceof Request ? input.url : String(input)).pathname;
+            seen.push(path);
+            if (path.startsWith('/api/v1/tv/')) {
+                return jsonResponse({ name: 'Alien: Earth', firstAirDate: '2025-08-12' });
+            }
+            return jsonResponse({ results: [{ ...PENDING, media: { tmdbId: 157239, mediaType: 'tv' } }] });
+        }) as unknown as typeof fetch;
+
+        const adapter = new SeerrAdapter(seerrConfig, impl);
+        const [request] = await adapter.getRequests({});
+        const described = await adapter.describeRequestMedia(request!);
+
+        expect(described?.title).toContain('Alien: Earth');
+        expect(described?.year).toBe(2025);
+        expect(seen).toContain('/api/v1/tv/157239');
+    });
+
+    // The live-stack regression: Seerr sends an empty releaseDate for anything
+    // TMDB has no date for, and Number(''.slice(0,4)) is 0, not NaN — so the
+    // preview read "The Origin of Hide and Seek (0)".
+    it('omits the year rather than reporting 0 when the date is empty', async () => {
+        const impl = (async (input: string | URL | Request) => {
+            const path = new URL(input instanceof Request ? input.url : String(input)).pathname;
+            if (path.startsWith('/api/v1/movie/')) return jsonResponse({ title: 'Undated Film', releaseDate: '' });
+            return jsonResponse({ results: [PENDING] });
+        }) as unknown as typeof fetch;
+
+        const adapter = new SeerrAdapter(seerrConfig, impl);
+        const [request] = await adapter.getRequests({});
+        const described = await adapter.describeRequestMedia(request!);
+
+        expect(described?.title).toContain('Undated Film');
+        expect(described).not.toHaveProperty('year');
+    });
+
+    it('rejects an implausible year rather than passing it through', async () => {
+        const impl = (async (input: string | URL | Request) => {
+            const path = new URL(input instanceof Request ? input.url : String(input)).pathname;
+            if (path.startsWith('/api/v1/movie/')) return jsonResponse({ title: 'Bad Date', releaseDate: '0000-01-01' });
+            return jsonResponse({ results: [PENDING] });
+        }) as unknown as typeof fetch;
+
+        const adapter = new SeerrAdapter(seerrConfig, impl);
+        const [request] = await adapter.getRequests({});
+        expect(await adapter.describeRequestMedia(request!)).not.toHaveProperty('year');
+    });
+
+    // A title lookup that fails must not stop someone deleting a request.
+    it('resolves undefined rather than throwing when the lookup fails', async () => {
+        const { impl } = recordingFetch({ titleLookupFails: true });
+        const adapter = new SeerrAdapter(seerrConfig, impl);
+        const [request] = await adapter.getRequests({});
+
+        await expect(adapter.describeRequestMedia(request!)).resolves.toBeUndefined();
+    });
+
+    it('uses the decline endpoint for a decline', async () => {
+        const { impl, sent } = recordingFetch({ onWrite: () => jsonResponse({ ...PENDING, status: 3 }) });
+        const updated = await new SeerrAdapter(seerrConfig, impl).respondToRequest('31', 'decline');
+
+        expect(sent.find(s => s.method === 'POST')?.path).toBe('/api/v1/request/31/decline');
+        expect(updated.status).toBe('declined');
+    });
+
+    // Reporting "approved" off the back of a response we could not read would
+    // be a claim we never verified.
+    it('refuses to claim success when the response carries no request', async () => {
+        const { impl } = recordingFetch({ onWrite: () => jsonResponse({}) });
+        await expect(new SeerrAdapter(seerrConfig, impl).respondToRequest('31', 'approve')).rejects.toThrow(
+            /returned no request/
+        );
+    });
+
+    it('deletes by id', async () => {
+        const { impl, sent } = recordingFetch({});
+        await new SeerrAdapter(seerrConfig, impl).deleteRequest('31');
+
+        const del = sent.find(s => s.method === 'DELETE');
+        expect(del?.path).toBe('/api/v1/request/31');
+    });
+
+    it('refuses a non-numeric request id', async () => {
+        const { impl, sent } = recordingFetch({});
+        await expect(new SeerrAdapter(seerrConfig, impl).deleteRequest('matrix')).rejects.toThrow(ServiceError);
+        expect(sent.filter(s => s.method !== 'GET')).toHaveLength(0);
+    });
+});
+
+// --- respond_to_request --------------------------------------------------
+
+describe('respond_to_request', () => {
+    it('names the film and who asked for it', async () => {
+        const h = harness(registerRespondToRequest, { permissions: { seerr: tiered(true, false) } });
+        const { structuredContent } = await h.call({ id: '31', verdict: 'approve', dry_run: true });
+
+        expect(structuredContent.summary).toContain('The Matrix');
+        expect(structuredContent.summary).toContain('1999');
+        expect(structuredContent.summary).toContain('Sam');
+        expect(structuredContent.tier).toBe('safe');
+    });
+
+    // The live-stack regression: with no title lookup this read "request 31,
+    // requested by Sam", which is not something anyone can approve.
+    it('never presents a bare id as though that were the whole story', async () => {
+        const h = harness(registerRespondToRequest, {
+            permissions: { seerr: tiered(true, false) },
+            titleLookupFails: true
+        });
+        const { structuredContent } = await h.call({ id: '31', verdict: 'approve', dry_run: true });
+
+        expect(structuredContent.summary).toContain('title unavailable');
+        expect(structuredContent.summary).toContain('movie');
+    });
+
+    // "Approve" reads much cheaper than it is.
+    it('warns that approving starts a download', async () => {
+        const h = harness(registerRespondToRequest, { permissions: { seerr: tiered(true, false) } });
+        const { structuredContent } = await h.call({ id: '31', verdict: 'approve', dry_run: true });
+        expect(structuredContent.effects.join(' ')).toContain('disk space and bandwidth');
+    });
+
+    it('says a decline downloads nothing', async () => {
+        const h = harness(registerRespondToRequest, { permissions: { seerr: tiered(true, false) } });
+        const { structuredContent } = await h.call({ id: '31', verdict: 'decline', dry_run: true });
+        expect(structuredContent.effects.join(' ')).toContain('Downloads nothing');
+    });
+
+    it('applies once confirmed and reports the resulting status', async () => {
+        const h = harness(registerRespondToRequest, {
+            permissions: { seerr: tiered(true, false) },
+            onWrite: () => jsonResponse(APPROVED)
+        });
+
+        const first = await h.call({ id: '31', verdict: 'approve' });
+        const second = await h.call({ id: '31', verdict: 'approve', confirm: first.structuredContent.confirm_token });
+
+        expect(second.structuredContent.applied).toBe(true);
+        expect(second.structuredContent.result).toEqual({ id: 31, status: 'approved' });
+    });
+
+    // Asking someone to confirm a no-op teaches them to confirm without reading.
+    it('short-circuits when the request is already in that state', async () => {
+        const h = harness(registerRespondToRequest, {
+            permissions: { seerr: tiered(true, false) },
+            requests: { results: [APPROVED] }
+        });
+
+        const { structuredContent } = await h.call({ id: '31', verdict: 'approve' });
+        expect(structuredContent.noop).toBe(true);
+        expect(structuredContent.confirm_token).toBeUndefined();
+        expect(h.fetchImpl.sent.filter(s => s.method === 'POST')).toHaveLength(0);
+    });
+
+    it('still acts when the verdict differs from the current state', async () => {
+        const h = harness(registerRespondToRequest, {
+            permissions: { seerr: tiered(true, false) },
+            requests: { results: [APPROVED] },
+            onWrite: () => jsonResponse({ ...PENDING, status: 3 })
+        });
+
+        const first = await h.call({ id: '31', verdict: 'decline' });
+        expect(first.structuredContent.noop).toBe(false);
+        expect(first.structuredContent.confirm_token).toBeTypeOf('string');
+    });
+
+    it('is reachable on safe_write alone', async () => {
+        const h = harness(registerRespondToRequest, { permissions: { seerr: tiered(true, false) } });
+        const first = await h.call({ id: '31', verdict: 'approve' });
+        expect(first.structuredContent.confirm_token).toBeTypeOf('string');
+    });
+
+    it('fails legibly on an id that is not in the request list', async () => {
+        const h = harness(registerRespondToRequest, { permissions: { seerr: tiered(true, false) } });
+        await expect(h.call({ id: '999', verdict: 'approve', dry_run: true })).rejects.toThrow(
+            /no Seerr request has id/
+        );
+    });
+
+    it('refuses when Seerr is not configured, pointing at where requests live', async () => {
+        const h = harness(registerRespondToRequest, { adapters: [], permissions: {} });
+        await expect(h.call({ id: '31', verdict: 'approve', dry_run: true })).rejects.toThrow(/not configured/);
+    });
+
+    // The token binds the verdict, so a preview of one cannot apply the other.
+    it('will not let an approve token be used to decline', async () => {
+        const h = harness(registerRespondToRequest, { permissions: { seerr: tiered(true, false) } });
+        const approve = await h.call({ id: '31', verdict: 'approve' });
+
+        const swapped = await h.call({
+            id: '31',
+            verdict: 'decline',
+            confirm: approve.structuredContent.confirm_token
+        });
+
+        expect(swapped.structuredContent.applied).toBe(false);
+        expect(h.fetchImpl.sent.filter(s => s.method === 'POST')).toHaveLength(0);
+    });
+});
+
+// --- delete_request ------------------------------------------------------
+
+describe('delete_request', () => {
+    it('is destructive tier, so safe_write alone will not reach it', async () => {
+        const h = harness(registerDeleteRequest, { permissions: { seerr: tiered(true, false) } });
+        await expect(h.call({ id: '31' })).rejects.toThrow(/services\.seerr\.permissions\.destructive: true/);
+    });
+
+    // The distinction people get wrong, stated before they act.
+    it('says plainly that it does not delete the media', async () => {
+        const h = harness(registerDeleteRequest);
+        const { structuredContent } = await h.call({ id: '31', dry_run: true });
+
+        const effects = structuredContent.effects.join(' ');
+        expect(effects).toContain('Does NOT delete any media');
+        expect(effects).toContain('delete_media');
+    });
+
+    it('deletes only once confirmed', async () => {
+        const h = harness(registerDeleteRequest);
+        const first = await h.call({ id: '31' });
+        expect(h.fetchImpl.sent.filter(s => s.method === 'DELETE')).toHaveLength(0);
+
+        const second = await h.call({ id: '31', confirm: first.structuredContent.confirm_token });
+        expect(second.structuredContent.applied).toBe(true);
+        expect(h.fetchImpl.sent.find(s => s.method === 'DELETE')?.path).toBe('/api/v1/request/31');
+    });
+
+    it('records the deletion in the audit trail', async () => {
+        const h = harness(registerDeleteRequest);
+        const first = await h.call({ id: '31' });
+        await h.call({ id: '31', confirm: first.structuredContent.confirm_token });
+
+        const rows = h.audit.recent() as { outcome: string; operation: string; target: string }[];
+        expect(rows[0]).toMatchObject({ outcome: 'applied', operation: 'delete_request', target: 'seerr:31' });
+    });
+});


### PR DESCRIPTION
Adds `respond_to_request` (safe) and `delete_request` (destructive) on the Phase 4 harness. Follows #45 and #47.

## Two tools, not one with a three-valued `action`

The split is the permission tier. Approve and decline move a request between states it can be moved back out of — including by this same tool — so they're `safe`. Deleting destroys the record, so it's `destructive`.

A single tool spanning both would have to derive its tier from an argument, which means the tier stops being a statically reviewable property of the tool and becomes something you trace an enum to work out. **The tier boundary is the tool boundary.**

`delete_request` removes the *request*, never the media. Anything already downloaded stays on disk and in Radarr/Sonarr — the preview says so in as many words, before you confirm rather than after, because it's the distinction people get wrong.

## Two bugs the suite could not have found

**Seerr's `/api/v1/request` payload carries no title.** Its `media` object is ids and service metadata only — 24 fields in the recorded fixture, none of them a title. So `MediaRequest.title` has been `undefined` for every real request since 0.3, and the first live preview read:

> Nothing to do — request 19, requested by Bardesss is already approved.

Which is not something anyone can meaningfully approve, and is the entire argument for reading before writing. Titles now resolve from `/movie/{tmdbId}` or `/tv/{tmdbId}` — films call it `title`, series call it `name`, hence two paths. That lookup runs **in the write previews only, never in `getRequests`**: one request is worth an extra call, five hundred are not. It degrades to `"title unavailable"` rather than throwing, since a failed title lookup must not stop someone deleting a request.

Worth calling out: **the test fixture had invented `media.title`.** Every assertion passed against fiction while the live stack printed a bare id. Corrected to match the recorded response, with a comment saying why, because a fixture kinder than reality tests nothing.

**Then the fix printed `The Origin of Hide and Seek (0)`.** Seerr returns an empty `releaseDate` for anything TMDB has no date for, and `Number(''.slice(0, 4))` is `0`, not `NaN` — so a `Number.isFinite` guard waves it straight through. Now a shared `yearOf` requiring four leading digits and a plausible value.

That second one is a **pre-existing bug beyond this PR's scope**: the identical pattern was already in `#toHit`, so `search_media` and `discover_media` have been reporting `year: 0` for undated Seerr titles since 0.3. Fixed there too, since it's two lines and the same helper.

## Verification

- 834 tests / 42 files; typecheck, lint and build clean.
- **26/26 integration calls against a live eight-service stack**, with both fixes confirmed in the real output.
- Both new tools are dry-run only from the integration script, like the other destructive ones — approving a request really does start a download.

## Phase 4 after this

Remaining: `add_media` (Radarr/Sonarr add, which needs quality-profile and root-folder lookups — a chunkier slice than any of these). Everything else the roadmap listed for 0.5 is in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
