### PR TITLE
feat: add add_media, the last of Phase 4's writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ Jellyfin. arr-mcp correlates them and gives you the causal chain.
 >
 > **On `main`, ahead of the 0.4 tag:** writes, as described under
 > [Writes](#writes) — permission tiers, `dry_run`, confirmation tokens and the
-> audit trail, with five write tools covering searches, the download queue,
-> media and Seerr requests. Released images tagged `0.4` are still read-only.
+> audit trail, with six write tools covering searches, the download queue,
+> adding and removing media, and Seerr requests. Released images tagged `0.4`
+> are still read-only.
 
 ## Services
 
@@ -58,6 +59,7 @@ All eight are supported as of 0.3.
 | `delete_media` | Remove this film or series, optionally from disk |
 | `respond_to_request` | Approve or decline what someone asked for |
 | `delete_request` | Drop a request record entirely |
+| `add_media` | Add this film or series and start looking for it |
 
 Every tool but `diagnose` takes `detail` (`minimal`/`standard`/`full`) and
 `limit`, and reports `{ total, returned, truncated }` — a truncated answer
@@ -72,7 +74,7 @@ only — a series has no series-level quality, and Sonarr carries one flat
 TVDB rating rather than per-source scores. Asking either of series returns a
 refusal explaining why, not an empty list.
 
-The first thirteen are reads. The last five write, and are gated as described
+The first thirteen are reads. The last six write, and are gated as described
 under [Writes](#writes) — off by default, previewed before they act, recorded
 either way.
 
@@ -121,6 +123,7 @@ a film but refuses to re-monitor it.
 | --- | --- | --- |
 | `trigger_search` | safe | `safe_write` |
 | `respond_to_request` | safe | `safe_write` |
+| `add_media` | safe | `safe_write` |
 | `remove_queue_item` | destructive | `destructive` |
 | `delete_media` | destructive | `destructive` |
 | `delete_request` | destructive | `destructive` |
@@ -185,7 +188,16 @@ rather than proceeding unrecorded; reads are unaffected.
 Write tools take `service` and `id`, never a title. Titles are resolved fuzzily,
 which is fine when the cost of being wrong is a wrong answer and not fine when
 it is an action against the wrong film — use `get_media_details` or
-`get_library` to get an id first.
+`get_library` to get an id first. `add_media` takes an external id instead:
+TMDB for Radarr, TVDB for Sonarr, both returned by `lookup_media` under `ids`.
+
+`add_media` also needs a quality profile and a root folder. If your service has
+exactly one of each, it uses them without asking. If it has several and you name
+none, **it refuses and lists them** rather than picking:
+
+> radarr has several quality profiles and none was named — Name one —
+> available: Any (id 1); HD-1080p (id 4); HD-2160p (id 5); … Not guessing,
+> because the wrong one is not obvious until the download finishes.
 
 ## Quick start
 

--- a/scripts/integration.ts
+++ b/scripts/integration.ts
@@ -108,7 +108,8 @@ const DYNAMIC_TOOLS: ToolName[] = [
     'remove_queue_item',
     'delete_media',
     'respond_to_request',
-    'delete_request'
+    'delete_request',
+    'add_media'
 ];
 
 const missing = TOOL_NAMES.filter(
@@ -191,6 +192,46 @@ async function run(tool: string, args: Record<string, unknown>, note?: string): 
     }
 }
 
+/**
+ * Runs a case whose *correct* outcome is a refusal, and passes only when the
+ * refusal is the expected one.
+ *
+ * Some behaviour is only worth confirming as a failure — a tool that declines
+ * to guess between nine quality profiles is working, and asserting that with
+ * `run` would paint a green stack red. Asserting on the message, not merely on
+ * "it errored", is what keeps this from passing for the wrong reason: an
+ * unreachable service also errors.
+ */
+async function expectError(
+    tool: string,
+    args: Record<string, unknown>,
+    expected: RegExp,
+    note: string
+): Promise<void> {
+    const label = `${tool} ${JSON.stringify(args)} — ${note}`;
+    const started = performance.now();
+
+    try {
+        const result = await callTool(tool, args);
+        const ms = Math.round(performance.now() - started);
+        const text = redactHosts(result.content?.[0]?.text ?? '', hosts);
+
+        if (result.isError === true && expected.test(text)) {
+            console.log(`PASS ${label} (${ms}ms) — refused as expected: ${text}`);
+            passes += 1;
+            return;
+        }
+        console.error(
+            `FAIL ${label} (${ms}ms) — ${result.isError === true ? `wrong refusal: ${text}` : `expected a refusal, got: ${text}`}`
+        );
+        failures += 1;
+    } catch (err) {
+        const ms = Math.round(performance.now() - started);
+        console.error(`FAIL ${label} (${ms}ms) — ${redactHosts((err as Error).message, hosts)}`);
+        failures += 1;
+    }
+}
+
 let libraryResult: ToolCallResult | undefined;
 let searchResult: ToolCallResult | undefined;
 let queueResult: ToolCallResult | undefined;
@@ -212,7 +253,7 @@ for (const { tool, args } of CASES) {
  * looks wrong), and — when the library actually has one — an item present on
  * one side and not the other, which is the case diagnose exists to explain.
  */
-type LibraryItemLike = { title?: unknown; presence?: unknown };
+type LibraryItemLike = { title?: unknown; presence?: unknown; kind?: unknown; ids?: { tmdb?: number } };
 type SearchHitLike = { service?: unknown; id?: unknown };
 
 const libraryItems = ((libraryResult?.structuredContent as { items?: unknown[] } | undefined)?.items ??
@@ -341,6 +382,29 @@ if (request?.id !== undefined) {
 } else {
     console.log('SKIP respond_to_request and delete_request — get_requests returned nothing to preview against.');
 }
+
+/**
+ * add_media, dry run only — it would otherwise add a film to a maintainer's
+ * Radarr and start downloading it on every run.
+ *
+ * A **fixed, known-good** TMDB id rather than one taken from the library. The
+ * first version of this case used a library item's own tmdbId and failed,
+ * because a film in the library had been removed from TMDB upstream — Radarr
+ * answers `[]` for it, correctly, and the case went red for a real-world data
+ * condition rather than a defect. 603 is The Matrix, which is not going
+ * anywhere.
+ *
+ * No quality profile is named on purpose, so this exercises the refusal path:
+ * a real stack has nine profiles, and the tool declining to guess between them
+ * — while listing them — is the behaviour most worth confirming against live
+ * data. `expectError` is what makes that a pass rather than a red line.
+ */
+await expectError(
+    'add_media',
+    { service: 'radarr', external_id: '603', dry_run: true },
+    /several quality profiles|Name one/,
+    'DRY RUN ONLY — expects the refuse-to-guess path, with the profiles listed'
+);
 
 console.log(`\n${passes}/${passes + failures} calls succeeded.`);
 if (missing.length > 0) {

--- a/src/services/arrAdd.ts
+++ b/src/services/arrAdd.ts
@@ -1,0 +1,186 @@
+import type { ServiceId } from '../config/schema.ts';
+import { ServiceError } from '../core/errors.ts';
+import { fenceText } from '../core/fence.ts';
+import type { ServiceHttp } from '../core/http.ts';
+import type { AddCandidate, AddMediaOptions, QualityProfile, RootFolder } from './types.ts';
+
+/**
+ * Adding to Radarr and Sonarr, shared for the same reason the queue read is:
+ * the two differ only in which noun and which external id they use. The
+ * differences are the four values in `ArrAddShape`; everything else — the
+ * profile and root-folder lookups, the "is it already there" check, the
+ * argument validation — is identical, and writing it twice is how the two
+ * drift into disagreeing about what adding means.
+ */
+
+export type ArrAddShape = {
+    /** `movie` or `series` — the REST noun. */
+    resource: 'movie' | 'series';
+    /** `tmdbId` or `tvdbId` — the field the add posts back. */
+    idField: 'tmdbId' | 'tvdbId';
+    /** For error prose: which provider's id this service speaks. */
+    idLabel: 'tmdb' | 'tvdb';
+    lookupPath: (id: number) => string;
+    /**
+     * Radarr's by-id lookup answers a single object; Sonarr's term search
+     * answers an array. Not cosmetic — reading one as the other yields
+     * undefined and reports a real film as "matched nothing".
+     */
+    lookupReturnsArray: boolean;
+    /** Radarr searches for a movie, Sonarr for missing episodes. */
+    searchOption: 'searchForMovie' | 'searchForMissingEpisodes';
+};
+
+/**
+ * Both services use the term search, and Radarr's dedicated
+ * `/movie/lookup/tmdb?tmdbId=` is deliberately **not** used, despite existing
+ * and being the more obvious choice.
+ *
+ * Probed against a live Radarr 6.3.0:
+ *
+ *   /movie/lookup/tmdb?tmdbId=603        200, one MovieResource
+ *   /movie/lookup/tmdb?tmdbId=999999999  500, MovieNotFoundException
+ *   /movie/lookup?term=tmdb:603          200, a one-element array
+ *   /movie/lookup?term=tmdb:999999999    200, []
+ *
+ * An unknown id is a **500** on the dedicated endpoint, which `classifyHttpStatus`
+ * turns into `UpstreamError` — telling the user Radarr is broken when in fact
+ * their id is wrong. The term form answers an empty array, which becomes a
+ * clean `NotFound` naming the id. Symmetry with Sonarr, which has no by-id
+ * endpoint at all, is a bonus rather than the reason.
+ */
+export const RADARR_ADD: ArrAddShape = {
+    resource: 'movie',
+    idField: 'tmdbId',
+    idLabel: 'tmdb',
+    lookupPath: id => `/api/v3/movie/lookup?term=tmdb:${id}`,
+    lookupReturnsArray: true,
+    searchOption: 'searchForMovie'
+};
+
+export const SONARR_ADD: ArrAddShape = {
+    resource: 'series',
+    idField: 'tvdbId',
+    idLabel: 'tvdb',
+    lookupPath: id => `/api/v3/series/lookup?term=tvdb:${id}`,
+    lookupReturnsArray: true,
+    searchOption: 'searchForMissingEpisodes'
+};
+
+type RawProfile = { id?: number; name?: string };
+type RawRootFolder = { path?: string; freeSpace?: number };
+type RawLookup = { id?: number; title?: string; year?: number };
+
+export async function readQualityProfiles(http: ServiceHttp, service: ServiceId): Promise<QualityProfile[]> {
+    const rows = await http.get<RawProfile[]>('/api/v3/qualityprofile');
+    return rows
+        .filter((p): p is RawProfile & { id: number } => typeof p.id === 'number')
+        .map(p => ({ id: p.id, name: fenceText(p.name ?? `profile ${p.id}`, { service, field: 'name' }) }));
+}
+
+export async function readRootFolders(http: ServiceHttp, service: ServiceId): Promise<RootFolder[]> {
+    const rows = await http.get<RawRootFolder[]>('/api/v3/rootfolder');
+    return rows
+        .filter((r): r is RawRootFolder & { path: string } => typeof r.path === 'string' && r.path !== '')
+        .map(r => ({
+            // Raw, because this is what gets posted back as a directory.
+            path: r.path,
+            // Fenced, because this is what reaches model context as prose.
+            display: fenceText(r.path, { service, field: 'path' }),
+            ...(typeof r.freeSpace === 'number' ? { freeSpaceBytes: r.freeSpace } : {})
+        }));
+}
+
+/**
+ * The single lookup both the preview and the write are built from. Returns the
+ * service's own raw payload alongside the fenced summary, because the add has
+ * to post the former back and the preview has to show the latter — and doing
+ * the lookup twice to get both would be two chances for them to disagree about
+ * what is being added.
+ */
+async function lookupRaw(
+    http: ServiceHttp,
+    service: ServiceId,
+    shape: ArrAddShape,
+    externalId: string
+): Promise<{ raw: RawLookup; candidate: AddCandidate }> {
+    const numeric = Number(externalId);
+    if (!Number.isInteger(numeric) || numeric <= 0) {
+        throw new ServiceError('NotFound', service, `"${externalId}" is not a ${shape.idLabel} id`, {
+            remedy: `${service} adds by ${shape.idLabel} id, which is a positive integer. lookup_media returns one under \`ids.${shape.idLabel}\`.`
+        });
+    }
+
+    const notFound = new ServiceError('NotFound', service, `${shape.idLabel} id ${numeric} matched nothing`, {
+        remedy: `Check the id with lookup_media. ${service} resolves this against its own metadata provider, so an id that is right for the other service will not match here — Radarr takes TMDB, Sonarr takes TVDB.`
+    });
+
+    const payload = await http.get<RawLookup | RawLookup[]>(shape.lookupPath(numeric));
+    const first = shape.lookupReturnsArray ? (payload as RawLookup[])[0] : (payload as RawLookup);
+    if (first === undefined || first.title === undefined) throw notFound;
+
+    return {
+        raw: first,
+        candidate: {
+            title: fenceText(first.title, { service, field: 'title' }),
+            ...(first.year === undefined || first.year === 0 ? {} : { year: first.year }),
+            // Both services return `id: 0` for something not in the library, so
+            // a real id here means it is already added — a no-op, not an error.
+            ...(typeof first.id === 'number' && first.id > 0 ? { existingId: first.id } : {})
+        }
+    };
+}
+
+export async function lookupArrForAdd(
+    http: ServiceHttp,
+    service: ServiceId,
+    shape: ArrAddShape,
+    externalId: string
+): Promise<AddCandidate> {
+    return (await lookupRaw(http, service, shape, externalId)).candidate;
+}
+
+export async function addArrMedia(
+    http: ServiceHttp,
+    service: ServiceId,
+    shape: ArrAddShape,
+    opts: AddMediaOptions
+): Promise<{ id: number; title: string }> {
+    const { raw, candidate } = await lookupRaw(http, service, shape, opts.externalId);
+
+    if (candidate.existingId !== undefined) {
+        // Reached only when something was added between the preview and the
+        // confirmation. Posting anyway creates a duplicate entry, so it fails.
+        throw new ServiceError('UpstreamError', service, `that ${shape.resource} is already in ${service}`, {
+            remedy: 'It was added between the preview and the confirmation, so nothing was changed here.'
+        });
+    }
+
+    // Built from the service's own raw lookup payload, not from the fenced
+    // candidate: the fence exists for model context, and a title carrying
+    // escaped angle brackets is not what anyone wants stored in their library.
+    const body: Record<string, unknown> = {
+        ...raw,
+        [shape.idField]: Number(opts.externalId),
+        qualityProfileId: opts.qualityProfileId,
+        rootFolderPath: opts.rootFolderPath,
+        monitored: opts.monitored,
+        addOptions: { [shape.searchOption]: opts.searchNow }
+    };
+
+    // Sonarr stores each series in its own folder by default, and omitting
+    // this drops every episode of every series into the root together.
+    if (shape.resource === 'series') body.seasonFolder = true;
+    // Radarr's own UI defaults to "Released", which is what stops a brand-new
+    // film grabbing a cinema recording the day it is announced.
+    if (shape.resource === 'movie') body.minimumAvailability = 'released';
+
+    const created = await http.post<RawLookup>(`/api/v3/${shape.resource}`, body);
+    if (typeof created.id !== 'number' || created.id <= 0) {
+        throw new ServiceError('UpstreamError', service, `${service} returned no id for the added ${shape.resource}`, {
+            remedy: 'It may still have been added — check with get_media_details before trying again.'
+        });
+    }
+
+    return { id: created.id, title: fenceText(created.title ?? '', { service, field: 'title' }) };
+}

--- a/src/services/radarr.ts
+++ b/src/services/radarr.ts
@@ -4,6 +4,7 @@ import { ServiceError } from '../core/errors.ts';
 import { ServiceHttp } from '../core/http.ts';
 import { fenceText } from '../core/fence.ts';
 import type { IndexInput } from '../core/resolver.ts';
+import { addArrMedia, lookupArrForAdd, RADARR_ADD, readQualityProfiles, readRootFolders } from './arrAdd.ts';
 import { calendarPath, deleteArrMedia, readArrQueue, readRadarrCalendar, removeArrQueueItem } from './arrQueue.ts';
 import { flattenRatings, toMergedRatings, type RawRating } from './arrRatings.ts';
 import {
@@ -22,10 +23,15 @@ import {
     type QueueItem,
     type ScanState,
     type ScanStateCapable,
+    type AddCandidate,
+    type AddMediaOptions,
     type CommandHandle,
     type DeleteMediaOptions,
+    type MediaAddCapable,
     type MediaDeleteCapable,
+    type QualityProfile,
     type QueueRemoveCapable,
+    type RootFolder,
     type RemoveQueueOptions,
     type SearchCapable,
     type SearchHit,
@@ -88,7 +94,8 @@ export class RadarrAdapter
         LibraryCapable,
         SearchTriggerCapable,
         QueueRemoveCapable,
-        MediaDeleteCapable
+        MediaDeleteCapable,
+        MediaAddCapable
 {
     readonly id: ServiceId = 'radarr';
     readonly #http: ServiceHttp;
@@ -155,6 +162,23 @@ export class RadarrAdapter
 
     async deleteMedia(id: string, opts: DeleteMediaOptions): Promise<void> {
         return deleteArrMedia(this.#http, this.id, 'movie', id, opts);
+    }
+
+    async listQualityProfiles(): Promise<QualityProfile[]> {
+        return readQualityProfiles(this.#http, this.id);
+    }
+
+    async listRootFolders(): Promise<RootFolder[]> {
+        return readRootFolders(this.#http, this.id);
+    }
+
+    /** Radarr resolves by TMDB id; a TVDB id will simply match nothing. */
+    async lookupForAdd(externalId: string): Promise<AddCandidate> {
+        return lookupArrForAdd(this.#http, this.id, RADARR_ADD, externalId);
+    }
+
+    async addMedia(opts: AddMediaOptions): Promise<{ id: number; title: string }> {
+        return addArrMedia(this.#http, this.id, RADARR_ADD, opts);
     }
 
     async getCalendar(range: { start: Date; end: Date }): Promise<CalendarEntry[]> {

--- a/src/services/sonarr.ts
+++ b/src/services/sonarr.ts
@@ -5,6 +5,7 @@ import { ServiceHttp } from '../core/http.ts';
 import { fenceText } from '../core/fence.ts';
 import { applyLimit } from '../core/shape.ts';
 import type { IndexInput } from '../core/resolver.ts';
+import { addArrMedia, lookupArrForAdd, readQualityProfiles, readRootFolders, SONARR_ADD } from './arrAdd.ts';
 import { deleteArrMedia, readArrQueue, readSonarrCalendar, removeArrQueueItem, sonarrCalendarPath } from './arrQueue.ts';
 import { flattenSeriesRating, type RawRating } from './arrRatings.ts';
 import type { components } from './generated/sonarr.ts';
@@ -24,10 +25,15 @@ import {
     type QueueItem,
     type ScanState,
     type ScanStateCapable,
+    type AddCandidate,
+    type AddMediaOptions,
     type CommandHandle,
     type DeleteMediaOptions,
+    type MediaAddCapable,
     type MediaDeleteCapable,
+    type QualityProfile,
     type QueueRemoveCapable,
+    type RootFolder,
     type RemoveQueueOptions,
     type SearchCapable,
     type SearchHit,
@@ -92,7 +98,8 @@ export class SonarrAdapter
         LibraryCapable,
         SearchTriggerCapable,
         QueueRemoveCapable,
-        MediaDeleteCapable
+        MediaDeleteCapable,
+        MediaAddCapable
 {
     readonly id: ServiceId = 'sonarr';
     readonly #http: ServiceHttp;
@@ -154,6 +161,23 @@ export class SonarrAdapter
      *  which is why `delete_media` refuses to pretend otherwise. */
     async deleteMedia(id: string, opts: DeleteMediaOptions): Promise<void> {
         return deleteArrMedia(this.#http, this.id, 'series', id, opts);
+    }
+
+    async listQualityProfiles(): Promise<QualityProfile[]> {
+        return readQualityProfiles(this.#http, this.id);
+    }
+
+    async listRootFolders(): Promise<RootFolder[]> {
+        return readRootFolders(this.#http, this.id);
+    }
+
+    /** Sonarr resolves by TVDB id, not TMDB — Radarr's id will match nothing. */
+    async lookupForAdd(externalId: string): Promise<AddCandidate> {
+        return lookupArrForAdd(this.#http, this.id, SONARR_ADD, externalId);
+    }
+
+    async addMedia(opts: AddMediaOptions): Promise<{ id: number; title: string }> {
+        return addArrMedia(this.#http, this.id, SONARR_ADD, opts);
     }
 
     async getCalendar(range: { start: Date; end: Date }): Promise<CalendarEntry[]> {

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -333,6 +333,49 @@ export interface QueueRemoveCapable {
 export const hasQueueRemove = (a: ServiceAdapter): a is ServiceAdapter & QueueRemoveCapable =>
     typeof (a as Partial<QueueRemoveCapable>).removeQueueItem === 'function';
 
+export type QualityProfile = { id: number; name: string };
+
+/**
+ * Two forms of the same string, deliberately.
+ *
+ * `path` is exactly what the service reported and is what gets posted back —
+ * a fenced string is not a directory, and sending one would create a library
+ * folder literally named `<<untrusted:radarr.path>>/movies<</untrusted>>`.
+ * `display` is the fenced form for prose that reaches model context. Keeping
+ * both is what stops anyone having to un-fence a value, which `fenceText` is
+ * deliberately not reversible for.
+ */
+export type RootFolder = { path: string; display: string; freeSpaceBytes?: number };
+
+/** What an external id resolves to, and whether the service already has it. */
+export type AddCandidate = {
+    title: string;
+    year?: number;
+    /** The service's own id when it is already in the library. Radarr and
+     *  Sonarr both report `id: 0` on a lookup for something not yet added,
+     *  which is how "already there" is told apart from "new". */
+    existingId?: number;
+};
+
+export type AddMediaOptions = {
+    externalId: string;
+    qualityProfileId: number;
+    rootFolderPath: string;
+    monitored: boolean;
+    searchNow: boolean;
+};
+
+export interface MediaAddCapable {
+    listQualityProfiles(): Promise<QualityProfile[]>;
+    listRootFolders(): Promise<RootFolder[]>;
+    /** Resolves the external id — TMDB for Radarr, TVDB for Sonarr. */
+    lookupForAdd(externalId: string): Promise<AddCandidate>;
+    addMedia(opts: AddMediaOptions): Promise<{ id: number; title: string }>;
+}
+
+export const hasMediaAdd = (a: ServiceAdapter): a is ServiceAdapter & MediaAddCapable =>
+    typeof (a as Partial<MediaAddCapable>).addMedia === 'function';
+
 /**
  * The two reversible verdicts on a request. Deliberately not including
  * "delete": approving and declining move a request between states it can be

--- a/src/tools/addMedia.ts
+++ b/src/tools/addMedia.ts
@@ -1,0 +1,218 @@
+import type { McpServer } from '@modelcontextprotocol/server';
+import * as z from 'zod/v4';
+import { ServiceIdSchema, type ServiceId } from '../config/schema.ts';
+import { ServiceError } from '../core/errors.ts';
+import {
+    hasMediaAdd,
+    type MediaAddCapable,
+    type QualityProfile,
+    type RootFolder,
+    type ServiceAdapter
+} from '../services/types.ts';
+import { registerWriteTool, type WriteContext, type WritePlan } from './write.ts';
+
+/**
+ * The last of Phase 4's writes, and the only one that has to *choose*
+ * something on the user's behalf.
+ *
+ * Adding needs a quality profile and a root folder, and neither has a
+ * defensible default this code could invent. So the rule is: if there is
+ * exactly one, use it silently — there was no choice to make. If there are
+ * several and the caller named none, **refuse and list them**. Picking the
+ * first of four quality profiles would be a guess presented as a decision, and
+ * the user would discover it as a 4K film filling a disk they meant to keep
+ * for 1080p.
+ *
+ * Safe tier: an added item can be removed again with `delete_media`. It still
+ * says in the preview that it will start downloading, because "add" reads
+ * cheaper than it is.
+ */
+
+const findAdapter = (adapters: readonly ServiceAdapter[], service: ServiceId): ServiceAdapter & MediaAddCapable => {
+    const adapter = adapters.find(a => a.id === service);
+    if (adapter === undefined) {
+        throw new ServiceError('NotFound', service, `${service} is not configured`, {
+            remedy: `Add a services.${service} block to config.yaml and restart, or name a configured service.`
+        });
+    }
+    if (!hasMediaAdd(adapter)) {
+        throw new ServiceError('NotFound', service, `${service} cannot add media`, {
+            remedy: 'Only radarr (films, by TMDB id) and sonarr (series, by TVDB id) can.'
+        });
+    }
+    return adapter;
+};
+
+/**
+ * Resolves one of several options, or refuses in a way that can be acted on.
+ *
+ * The refusal lists what is available. A model told only "ambiguous" has to
+ * guess or give up; a model handed the four profile names can ask the user
+ * which, or pick the one they already mentioned.
+ */
+function chooseOne<T>(
+    options: readonly T[],
+    requested: string | undefined,
+    matches: (option: T, requested: string) => boolean,
+    describe: (option: T) => string,
+    what: string,
+    service: ServiceId
+): T {
+    if (options.length === 0) {
+        throw new ServiceError('NotFound', service, `${service} has no ${what} configured`, {
+            remedy: `Add one in ${service}'s own settings first — nothing can be added without it.`
+        });
+    }
+
+    if (requested !== undefined) {
+        const found = options.find(o => matches(o, requested));
+        if (found === undefined) {
+            throw new ServiceError('NotFound', service, `no ${what} on ${service} matches "${requested}"`, {
+                remedy: `Available: ${options.map(describe).join('; ')}.`
+            });
+        }
+        return found;
+    }
+
+    // Exactly one is not a choice, so making it silently is not a guess.
+    if (options.length === 1) return options[0]!;
+
+    throw new ServiceError('NotFound', service, `${service} has several ${what}s and none was named`, {
+        remedy: `Name one — available: ${options.map(describe).join('; ')}. Not guessing, because the wrong one is not obvious until the download finishes.`
+    });
+}
+
+const GIB = 1024 ** 3;
+const freeSpace = (folder: RootFolder): string =>
+    folder.freeSpaceBytes === undefined ? 'free space unknown' : `${(folder.freeSpaceBytes / GIB).toFixed(0)} GB free`;
+
+const profileMatches = (p: QualityProfile, requested: string): boolean =>
+    String(p.id) === requested || p.name.toLowerCase().includes(requested.toLowerCase());
+
+export function registerAddMedia(server: McpServer, context: WriteContext, adapters: readonly ServiceAdapter[]): void {
+    registerWriteTool(server, context, {
+        name: 'add_media',
+        description:
+            'Adds a film to Radarr or a series to Sonarr and, by default, starts searching for it. Radarr takes a TMDB id, Sonarr takes a TVDB id — get the right one from lookup_media, which returns both under `ids`. If the service has more than one quality profile or root folder you must name which, because guessing wrong is only discovered once the download finishes. Previews by default — call again with the returned `confirm` token to actually add it.',
+        inputSchema: z.object({
+            service: ServiceIdSchema.describe('radarr for a film, sonarr for a series.'),
+            external_id: z
+                .string()
+                .min(1)
+                .describe('TMDB id for radarr, TVDB id for sonarr, as an integer string. From lookup_media.'),
+            quality_profile: z
+                .string()
+                .optional()
+                .describe('Profile name or id. Optional only when the service has exactly one.'),
+            root_folder: z
+                .string()
+                .optional()
+                .describe('Root folder path, or any distinctive part of it. Optional only when the service has exactly one.'),
+            monitored: z.boolean().default(true).describe('Monitor it for downloads. Defaults to true.'),
+            search_now: z
+                .boolean()
+                .default(true)
+                .describe('Start searching immediately. Defaults to true — set false to add without downloading yet.')
+        }),
+        service: ({ service }) => service,
+        operation: 'add_media',
+        tier: 'safe',
+
+        async plan({ service, external_id, quality_profile, root_folder, monitored, search_now }): Promise<WritePlan> {
+            const adapter = findAdapter(adapters, service);
+
+            // All three reads together: they are independent, and a preview
+            // that takes three sequential round trips on a LAN service is
+            // needlessly slow.
+            const [candidate, profiles, folders] = await Promise.all([
+                adapter.lookupForAdd(external_id),
+                adapter.listQualityProfiles(),
+                adapter.listRootFolders()
+            ]);
+
+            const label = `${candidate.title}${candidate.year === undefined ? '' : ` (${candidate.year})`}`;
+
+            // Already there is a no-op, not a failure — and adding again would
+            // be a duplicate entry rather than a second copy of the film.
+            if (candidate.existingId !== undefined) {
+                return {
+                    target: `${service}:${external_id}`,
+                    summary: `${label} is already in ${service} (id ${candidate.existingId}).`,
+                    effects: [],
+                    noop: true
+                };
+            }
+
+            const profile = chooseOne(
+                profiles,
+                quality_profile,
+                profileMatches,
+                p => `${p.name} (id ${p.id})`,
+                'quality profile',
+                service
+            );
+
+            const folder = chooseOne(
+                folders,
+                root_folder,
+                (f, requested) => f.path.toLowerCase().includes(requested.toLowerCase()),
+                f => `${f.display} (${freeSpace(f)})`,
+                'root folder',
+                service
+            );
+
+            const effects = [
+                `Adds ${label} to ${service} under ${folder.display} (${freeSpace(folder)}), quality profile ${profile.name}.`,
+                monitored
+                    ? 'Monitors it, so it will be grabbed when a matching release appears.'
+                    : 'Adds it unmonitored, so nothing will be grabbed until you monitor it.'
+            ];
+
+            effects.push(
+                search_now
+                    ? 'Starts searching immediately — this may begin a download, using disk space and bandwidth.'
+                    : 'Does not search yet. Use trigger_search when you want it to look.'
+            );
+
+            return {
+                target: `${service}:${external_id}`,
+                summary: `Add ${label} to ${service}.`,
+                effects,
+                // The resolved profile and folder, not the strings asked for:
+                // the token must commit to what will actually happen, so a
+                // preview showing "1080p into /movies" cannot be confirmed
+                // into "4K into /media2".
+                args: {
+                    service,
+                    externalId: external_id,
+                    qualityProfileId: profile.id,
+                    rootFolderPath: folder.path,
+                    monitored,
+                    searchNow: search_now
+                }
+            };
+        },
+
+        async apply(plan, { service }) {
+            const a = plan.args as {
+                externalId: string;
+                qualityProfileId: number;
+                rootFolderPath: string;
+                monitored: boolean;
+                searchNow: boolean;
+            };
+
+            // Taken from the plan rather than re-resolved from the arguments:
+            // re-running `chooseOne` here could land on a different profile if
+            // one was added in between, and the token guaranteed the one that
+            // was previewed.
+            return findAdapter(adapters, service).addMedia({
+                externalId: a.externalId,
+                qualityProfileId: a.qualityProfileId,
+                rootFolderPath: a.rootFolderPath,
+                monitored: a.monitored,
+                searchNow: a.searchNow
+            });
+        }
+    });
+}

--- a/src/tools/register.ts
+++ b/src/tools/register.ts
@@ -7,6 +7,7 @@ import { permissionSourceFrom } from '../core/permissions.ts';
 import { JellyfinAdapter } from '../services/jellyfin.ts';
 import { SeerrAdapter } from '../services/seerr.ts';
 import { hasIndexers, hasSubtitles, type ServiceAdapter } from '../services/types.ts';
+import { registerAddMedia } from './addMedia.ts';
 import { registerDeleteMedia } from './deleteMedia.ts';
 import { registerDiagnose } from './diagnose/index.ts';
 import { registerDiscoverMedia } from './discoverMedia.ts';
@@ -119,6 +120,7 @@ export function registerAllTools(server: McpServer, context: ToolContext): void 
     registerDeleteMedia(server, write, adapters);
     registerRespondToRequest(server, write, adapters);
     registerDeleteRequest(server, write, adapters);
+    registerAddMedia(server, write, adapters);
 }
 
 /** The tool surface, frozen. §18: renaming one breaks users' saved prompts. */
@@ -140,5 +142,6 @@ export const TOOL_NAMES = [
     'remove_queue_item',
     'delete_media',
     'respond_to_request',
-    'delete_request'
+    'delete_request',
+    'add_media'
 ] as const;

--- a/test/addMedia.test.ts
+++ b/test/addMedia.test.ts
@@ -1,0 +1,420 @@
+import { describe, expect, it, vi } from 'vitest';
+import * as z from 'zod/v4';
+import type { AnyServiceConfig, KeyedServiceConfig, ServiceId } from '../src/config/schema.ts';
+import { WriteAudit } from '../src/core/audit.ts';
+import { ConfirmTokens } from '../src/core/confirm.ts';
+import { permissionSourceFrom } from '../src/core/permissions.ts';
+import { RadarrAdapter } from '../src/services/radarr.ts';
+import { SonarrAdapter } from '../src/services/sonarr.ts';
+import type { ServiceAdapter } from '../src/services/types.ts';
+import { registerAddMedia } from '../src/tools/addMedia.ts';
+import type { LibraryLoader } from '../src/tools/library.ts';
+import type { WriteToolResult } from '../src/tools/write.ts';
+import { jsonResponse } from './helpers/serve.ts';
+
+const keyed = (port: number): KeyedServiceConfig => ({
+    url: `http://192.0.2.10:${port}`,
+    api_key: 'k',
+    timeout_ms: 10_000,
+    permissions: { safe_write: false, destructive: false }
+});
+
+const tiered = (safe_write: boolean, destructive = false): AnyServiceConfig =>
+    ({ ...keyed(7878), permissions: { safe_write, destructive } }) as AnyServiceConfig;
+
+const ONE_PROFILE = [{ id: 4, name: 'HD-1080p' }];
+const MANY_PROFILES = [
+    { id: 4, name: 'HD-1080p' },
+    { id: 5, name: 'Ultra-HD' }
+];
+const ONE_FOLDER = [{ path: '/movies', freeSpace: 2_000_000_000_000 }];
+const MANY_FOLDERS = [
+    { path: '/movies', freeSpace: 2_000_000_000_000 },
+    { path: '/movies-4k', freeSpace: 500_000_000_000 }
+];
+
+/** `id: 0` is what both services report for something not in the library. */
+const NEW_MOVIE = [{ id: 0, title: 'The Matrix', year: 1999, tmdbId: 603 }];
+const EXISTING_MOVIE = [{ id: 88, title: 'The Matrix', year: 1999, tmdbId: 603 }];
+
+function stack(
+    opts: {
+        profiles?: unknown;
+        folders?: unknown;
+        lookup?: unknown;
+        created?: unknown;
+        resource?: 'movie' | 'series';
+    } = {}
+) {
+    const sent: { path: string; search: string; method: string; body: Record<string, unknown> | undefined }[] = [];
+    const resource = opts.resource ?? 'movie';
+
+    const impl = (async (input: string | URL | Request, init?: RequestInit) => {
+        const url = new URL(input instanceof Request ? input.url : String(input));
+        const method = init?.method ?? 'GET';
+        sent.push({
+            path: url.pathname,
+            search: url.search,
+            method,
+            body: typeof init?.body === 'string' ? (JSON.parse(init.body) as Record<string, unknown>) : undefined
+        });
+
+        if (url.pathname === '/api/v3/qualityprofile') return jsonResponse(opts.profiles ?? ONE_PROFILE);
+        if (url.pathname === '/api/v3/rootfolder') return jsonResponse(opts.folders ?? ONE_FOLDER);
+
+        // Both services answer the term search with an array — including an
+        // empty one for an id that resolves to nothing, which is exactly why
+        // the term form is preferred over Radarr's by-id endpoint (that one
+        // answers 500). Verified against a live Radarr 6.3.0.
+        if (url.pathname === `/api/v3/${resource}/lookup`) return jsonResponse(opts.lookup ?? NEW_MOVIE);
+        if (url.pathname === '/api/v3/movie/lookup/tmdb') {
+            throw new Error('the dedicated by-id endpoint must not be used — it 500s on an unknown id');
+        }
+        if (url.pathname === `/api/v3/${resource}` && method === 'POST') {
+            return jsonResponse(opts.created ?? { id: 91, title: 'The Matrix' });
+        }
+        return jsonResponse({ message: 'not found' }, 404);
+    }) as unknown as typeof fetch;
+
+    return { impl, sent };
+}
+
+type Call = (args: Record<string, unknown>) => Promise<{
+    content: { type: 'text'; text: string }[];
+    structuredContent: WriteToolResult;
+}>;
+
+function harness(
+    opts: Parameters<typeof stack>[0] & {
+        permissions?: Partial<Record<ServiceId, AnyServiceConfig>>;
+        adapters?: ServiceAdapter[];
+    } = {}
+) {
+    const s = stack(opts);
+    const adapters = opts.adapters ?? [new RadarrAdapter(keyed(7878), s.impl)];
+
+    let call: Call = () => Promise.reject(new Error('not registered'));
+    const server = {
+        registerTool(_n: string, config: { inputSchema: z.ZodObject }, handler: Call) {
+            call = args => handler(config.inputSchema.parse(args) as Record<string, unknown>);
+        }
+    };
+
+    const invalidate = vi.fn();
+    const audit = WriteAudit.ephemeral();
+    registerAddMedia(
+        server as never,
+        {
+            permissions: permissionSourceFrom(opts.permissions ?? { radarr: tiered(true), sonarr: tiered(true) }),
+            confirm: new ConfirmTokens(),
+            audit,
+            library: { invalidate } as unknown as LibraryLoader
+        },
+        adapters
+    );
+
+    return { call: (a: Record<string, unknown>) => call(a), sent: s.sent, audit, invalidate };
+}
+
+const posted = (h: ReturnType<typeof harness>) => h.sent.find(x => x.method === 'POST')?.body;
+
+describe('add_media previews', () => {
+    it('names the film, the folder and the profile', async () => {
+        const h = harness();
+        const { structuredContent } = await h.call({ service: 'radarr', external_id: '603', dry_run: true });
+
+        expect(structuredContent.summary).toContain('The Matrix');
+        expect(structuredContent.summary).toContain('1999');
+        expect(structuredContent.effects.join(' ')).toContain('HD-1080p');
+        expect(structuredContent.effects.join(' ')).toContain('/movies');
+    });
+
+    it('reports free space, because that is what a bad root folder costs', async () => {
+        const h = harness();
+        const { structuredContent } = await h.call({ service: 'radarr', external_id: '603', dry_run: true });
+        expect(structuredContent.effects.join(' ')).toContain('GB free');
+    });
+
+    // "Add" reads much cheaper than it is.
+    it('says a search will start', async () => {
+        const h = harness();
+        const { structuredContent } = await h.call({ service: 'radarr', external_id: '603', dry_run: true });
+        expect(structuredContent.effects.join(' ')).toContain('disk space and bandwidth');
+    });
+
+    it('says nothing will download when search_now is false', async () => {
+        const h = harness();
+        const { structuredContent } = await h.call({
+            service: 'radarr',
+            external_id: '603',
+            search_now: false,
+            dry_run: true
+        });
+        expect(structuredContent.effects.join(' ')).toContain('Does not search yet');
+    });
+
+    it('adds nothing on a dry run', async () => {
+        const h = harness();
+        await h.call({ service: 'radarr', external_id: '603', dry_run: true });
+        expect(h.sent.filter(s => s.method === 'POST')).toHaveLength(0);
+    });
+});
+
+describe('add_media choosing a profile and folder', () => {
+    it('uses the only profile and folder without asking', async () => {
+        const h = harness();
+        const { structuredContent } = await h.call({ service: 'radarr', external_id: '603', dry_run: true });
+        expect(structuredContent.effects.join(' ')).toContain('HD-1080p');
+    });
+
+    // Picking the first of several would be a guess presented as a decision.
+    it('refuses to guess between several profiles, and lists them', async () => {
+        const h = harness({ profiles: MANY_PROFILES });
+        await expect(h.call({ service: 'radarr', external_id: '603', dry_run: true })).rejects.toThrow(
+            /HD-1080p.*Ultra-HD|Ultra-HD.*HD-1080p/
+        );
+    });
+
+    it('refuses to guess between several root folders, and lists them', async () => {
+        const h = harness({ folders: MANY_FOLDERS });
+        await expect(h.call({ service: 'radarr', external_id: '603', dry_run: true })).rejects.toThrow(
+            /movies-4k/
+        );
+    });
+
+    it('accepts a profile by name, case-insensitively', async () => {
+        const h = harness({ profiles: MANY_PROFILES });
+        const { structuredContent } = await h.call({
+            service: 'radarr',
+            external_id: '603',
+            quality_profile: 'ultra-hd',
+            root_folder: '/movies',
+            dry_run: true
+        });
+        expect(structuredContent.effects.join(' ')).toContain('Ultra-HD');
+    });
+
+    it('accepts a profile by id', async () => {
+        const h = harness({ profiles: MANY_PROFILES });
+        const { structuredContent } = await h.call({
+            service: 'radarr',
+            external_id: '603',
+            quality_profile: '5',
+            root_folder: '/movies',
+            dry_run: true
+        });
+        expect(structuredContent.effects.join(' ')).toContain('Ultra-HD');
+    });
+
+    it('lists the options when the named profile does not exist', async () => {
+        const h = harness({ profiles: MANY_PROFILES });
+        await expect(
+            h.call({ service: 'radarr', external_id: '603', quality_profile: 'SD', dry_run: true })
+        ).rejects.toThrow(/Available:/);
+    });
+
+    it('says so when the service has no profiles at all', async () => {
+        const h = harness({ profiles: [] });
+        await expect(h.call({ service: 'radarr', external_id: '603', dry_run: true })).rejects.toThrow(
+            /no quality profile configured/
+        );
+    });
+});
+
+describe('add_media applying', () => {
+    it('adds nothing until confirmed, then posts', async () => {
+        const h = harness();
+        const first = await h.call({ service: 'radarr', external_id: '603' });
+        expect(h.sent.filter(s => s.method === 'POST')).toHaveLength(0);
+
+        const second = await h.call({
+            service: 'radarr',
+            external_id: '603',
+            confirm: first.structuredContent.confirm_token
+        });
+
+        expect(second.structuredContent.applied).toBe(true);
+        expect(second.structuredContent.result).toEqual({ id: 91, title: expect.stringContaining('The Matrix') });
+        expect(h.invalidate).toHaveBeenCalledTimes(1);
+    });
+
+    it('posts the resolved profile, folder and search flag', async () => {
+        const h = harness();
+        const first = await h.call({ service: 'radarr', external_id: '603' });
+        await h.call({ service: 'radarr', external_id: '603', confirm: first.structuredContent.confirm_token });
+
+        const body = posted(h);
+        expect(body).toMatchObject({
+            tmdbId: 603,
+            qualityProfileId: 4,
+            rootFolderPath: '/movies',
+            monitored: true,
+            addOptions: { searchForMovie: true }
+        });
+    });
+
+    // A fenced path is not a directory.
+    it('posts the raw root folder path, never the fenced display form', async () => {
+        const h = harness();
+        const first = await h.call({ service: 'radarr', external_id: '603' });
+        await h.call({ service: 'radarr', external_id: '603', confirm: first.structuredContent.confirm_token });
+
+        expect(posted(h)?.rootFolderPath).toBe('/movies');
+        expect(JSON.stringify(posted(h))).not.toContain('untrusted');
+    });
+
+    it('sets minimumAvailability so a new film does not grab a cinema recording', async () => {
+        const h = harness();
+        const first = await h.call({ service: 'radarr', external_id: '603' });
+        await h.call({ service: 'radarr', external_id: '603', confirm: first.structuredContent.confirm_token });
+        expect(posted(h)?.minimumAvailability).toBe('released');
+    });
+
+    // The token commits to the resolved choices, not the requested strings.
+    it('will not let a token previewed for one profile add with another', async () => {
+        const h = harness({ profiles: MANY_PROFILES, folders: MANY_FOLDERS });
+        const preview = await h.call({
+            service: 'radarr',
+            external_id: '603',
+            quality_profile: 'HD-1080p',
+            root_folder: '/movies'
+        });
+
+        const swapped = await h.call({
+            service: 'radarr',
+            external_id: '603',
+            quality_profile: 'Ultra-HD',
+            root_folder: '/movies-4k',
+            confirm: preview.structuredContent.confirm_token
+        });
+
+        expect(swapped.structuredContent.applied).toBe(false);
+        expect(h.sent.filter(s => s.method === 'POST')).toHaveLength(0);
+    });
+
+    it('is refused without safe_write', async () => {
+        const h = harness({ permissions: { radarr: tiered(false) } });
+        await expect(h.call({ service: 'radarr', external_id: '603' })).rejects.toThrow(
+            /services\.radarr\.permissions\.safe_write: true/
+        );
+    });
+});
+
+describe('add_media when it is already there', () => {
+    it('short-circuits rather than creating a duplicate', async () => {
+        const h = harness({ lookup: EXISTING_MOVIE });
+        const { structuredContent, content } = await h.call({ service: 'radarr', external_id: '603' });
+
+        expect(structuredContent.noop).toBe(true);
+        expect(structuredContent.confirm_token).toBeUndefined();
+        expect(content[0]?.text).toContain('already in radarr');
+        expect(h.sent.filter(s => s.method === 'POST')).toHaveLength(0);
+    });
+
+    /**
+     * The race: added between the preview and the confirmation.
+     *
+     * The harness re-runs `plan` on the confirming call, so this is caught
+     * there and comes back as the same "already there" no-op rather than as an
+     * error — which is the better outcome, and the reason `plan` is not
+     * skipped once a token exists. The adapter's own guard (asserted below)
+     * remains the backstop for a change landing inside a single call.
+     */
+    it('reports it as already there rather than duplicating, when it appears in between', async () => {
+        let lookups = 0;
+        const impl = (async (input: string | URL | Request, init?: RequestInit) => {
+            const url = new URL(input instanceof Request ? input.url : String(input));
+            if (url.pathname === '/api/v3/qualityprofile') return jsonResponse(ONE_PROFILE);
+            if (url.pathname === '/api/v3/rootfolder') return jsonResponse(ONE_FOLDER);
+            if (url.pathname === '/api/v3/movie/lookup') {
+                lookups += 1;
+                return jsonResponse(lookups === 1 ? NEW_MOVIE : EXISTING_MOVIE);
+            }
+            if ((init?.method ?? 'GET') === 'POST') return jsonResponse({ id: 91, title: 'The Matrix' });
+            return jsonResponse({ message: 'not found' }, 404);
+        }) as unknown as typeof fetch;
+
+        const h = harness({ adapters: [new RadarrAdapter(keyed(7878), impl)] });
+        const first = await h.call({ service: 'radarr', external_id: '603' });
+
+        const second = await h.call({
+            service: 'radarr',
+            external_id: '603',
+            confirm: first.structuredContent.confirm_token
+        });
+
+        expect(second.structuredContent.noop).toBe(true);
+        expect(second.structuredContent.applied).toBe(false);
+        expect(h.sent.filter(s => s.method === 'POST')).toHaveLength(0);
+    });
+
+    // The backstop, exercised directly: reachable only if the state changes
+    // inside a single call, which the tool level cannot reproduce.
+    it('the adapter itself refuses to post a duplicate', async () => {
+        const s = stack({ lookup: EXISTING_MOVIE });
+        const adapter = new RadarrAdapter(keyed(7878), s.impl);
+
+        await expect(
+            adapter.addMedia({
+                externalId: '603',
+                qualityProfileId: 4,
+                rootFolderPath: '/movies',
+                monitored: true,
+                searchNow: true
+            })
+        ).rejects.toThrow(/already in radarr/);
+        expect(s.sent.filter(x => x.method === 'POST')).toHaveLength(0);
+    });
+});
+
+describe('add_media on Sonarr', () => {
+    it('looks up and posts by tvdb id, with season folders', async () => {
+        const s = stack({
+            resource: 'series',
+            lookup: [{ id: 0, title: 'Alien: Earth', year: 2025, tvdbId: 424207 }],
+            created: { id: 12, title: 'Alien: Earth' }
+        });
+        const h = harness({ adapters: [new SonarrAdapter(keyed(8989), s.impl)] });
+
+        const first = await h.call({ service: 'sonarr', external_id: '424207' });
+        await h.call({ service: 'sonarr', external_id: '424207', confirm: first.structuredContent.confirm_token });
+
+        const lookup = s.sent.find(x => x.path === '/api/v3/series/lookup');
+        expect(lookup?.search).toContain('tvdb:424207');
+
+        const body = s.sent.find(x => x.method === 'POST')?.body;
+        expect(body).toMatchObject({
+            tvdbId: 424207,
+            seasonFolder: true,
+            addOptions: { searchForMissingEpisodes: true }
+        });
+    });
+
+    /**
+     * Radarr's dedicated `/movie/lookup/tmdb` answers an unknown id with a
+     * **500**, which would surface as "radarr upstream error" — blaming the
+     * service for what is really a wrong id. The term form answers `[]`.
+     * Probed against a live Radarr 6.3.0; the fake throws if the by-id
+     * endpoint is ever called, so a future refactor cannot quietly switch back.
+     */
+    it('looks Radarr up by term, not via the by-id endpoint that 500s', async () => {
+        const h = harness();
+        await h.call({ service: 'radarr', external_id: '603', dry_run: true });
+
+        expect(h.sent.some(x => x.path === '/api/v3/movie/lookup' && x.search.includes('tmdb:603'))).toBe(true);
+    });
+
+    it('rejects a non-numeric external id before calling anything', async () => {
+        const h = harness();
+        await expect(h.call({ service: 'radarr', external_id: 'matrix', dry_run: true })).rejects.toThrow(
+            /is not a tmdb id/
+        );
+    });
+
+    it('explains the id mix-up when the lookup matches nothing', async () => {
+        const h = harness({ lookup: [] });
+        await expect(h.call({ service: 'radarr', external_id: '999999999', dry_run: true })).rejects.toThrow(
+            /Radarr takes TMDB, Sonarr takes TVDB/
+        );
+    });
+});

--- a/test/encoding.test.ts
+++ b/test/encoding.test.ts
@@ -57,25 +57,40 @@ async function sourceFiles(dir: string, out: string[] = []): Promise<string[]> {
     return out;
 }
 
+/**
+ * Every source file, read once and concurrently, shared by both scans below.
+ *
+ * It used to be a serial `await readFile` inside a loop, run twice — once per
+ * scan. That is ~180 sequential round trips, which was comfortable at Phase 3
+ * and started intermittently blowing vitest's 5s default timeout once Phase 4
+ * added enough files, but *only* under the full suite, where every other test
+ * file is competing for the same disk. A gate that fails on a busy machine
+ * rather than on a real BOM is a gate people learn to re-run rather than read.
+ */
+let cached: Promise<{ file: string; text: string }[]> | undefined;
+
+const allSources = async (): Promise<{ file: string; text: string }[]> => {
+    cached ??= (async () => {
+        const files = (await Promise.all(['src', 'test', 'scripts'].map(d => sourceFiles(join(ROOT, d))))).flat();
+        return Promise.all(files.map(async file => ({ file, text: await readFile(file, 'utf8') })));
+    })();
+    return cached;
+};
+
 describe('source file encoding', () => {
     it('has no byte order mark in any source file', async () => {
-        const offenders: string[] = [];
-        for (const dir of ['src', 'test', 'scripts']) {
-            for (const file of await sourceFiles(join(ROOT, dir))) {
-                if ((await readFile(file, 'utf8')).startsWith(BOM)) offenders.push(file);
-            }
-        }
+        const offenders = (await allSources()).filter(s => s.text.startsWith(BOM)).map(s => s.file);
         expect(offenders).toEqual([]);
     });
 
     it('has no mojibake from a tool that guessed the encoding', async () => {
-        const offenders: string[] = [];
-        for (const dir of ['src', 'test', 'scripts']) {
-            for (const file of await sourceFiles(join(ROOT, dir))) {
-                if (MOJIBAKE.test(await readFile(file, 'utf8'))) offenders.push(file);
-            }
-        }
+        const offenders = (await allSources()).filter(s => MOJIBAKE.test(s.text)).map(s => s.file);
         expect(offenders).toEqual([]);
+    });
+
+    // The scans above are only meaningful if they actually saw the tree.
+    it('scanned a plausible number of source files', async () => {
+        expect((await allSources()).length).toBeGreaterThan(50);
     });
 
     it('detects the corruption it is looking for', () => {


### PR DESCRIPTION
The last of Phase 4's writes. Adds a film to Radarr or a series to Sonarr, safe tier, on the harness from #45. Stacks after #48 (merge that first).

## The one write that has to choose something

Adding needs a quality profile and a root folder, and neither has a defensible default this code could invent. So the rule is explicit:

- **Exactly one** → use it silently. There was no choice to make.
- **Several, none named** → refuse, and list them.

Picking the first of nine would be a guess presented as a decision, and the user would meet it as a 4K film filling a disk they meant to keep for 1080p. The live stack turned out to have **nine profiles and one root folder**, which makes the refusal the normal path rather than an exotic one:

> radarr has several quality profiles and none was named — Name one — available: Any (id 1); HD-1080p (id 4); HD-2160p (id 5); … Not guessing, because the wrong one is not obvious until the download finishes.

The token binds the **resolved** profile and folder, not the strings asked for, so a preview showing "HD-1080p into /movies" can't be confirmed into "Ultra-HD into /movies-4k". `apply` reads them back from the plan rather than re-resolving.

`RootFolder` now carries both `path` and `display`. The raw path is what gets posted back — a fenced string is not a directory, and posting one would create a library folder literally named `<<untrusted:radarr.path>>…`. Keeping both is what stops anyone needing to un-fence a value, which `fenceText` is deliberately not reversible for.

## Two things the live stack corrected after the suite was green

**The by-id lookup was wrong twice over.** A library-derived id matched nothing, and switching to Radarr's dedicated `/movie/lookup/tmdb` looked like the obvious fix. Probing the live service showed the opposite:

```
/movie/lookup/tmdb?tmdbId=603        200, one MovieResource
/movie/lookup/tmdb?tmdbId=999999999  500, MovieNotFoundException
/movie/lookup?term=tmdb:603          200, one-element array
/movie/lookup?term=tmdb:999999999    200, []
```

An unknown id is a **500** on the dedicated endpoint, which `classifyHttpStatus` turns into "radarr upstream error" — blaming the service for what is really a wrong id. The term form answers cleanly. Both services use the term search, with the probe results recorded in the code and a test fake that throws if anyone switches back.

And the original failure was never the endpoint: **a film in the library had been removed from TMDB upstream**, so Radarr correctly answered `[]` and the integration case was asserting against a real-world data condition. It now uses a fixed known-good id.

**The encoding test started failing on timing, not on a BOM.** Two scans each walked ~90 files serially — ~180 sequential reads — which crossed vitest's 5s default only under the full suite, where every other test file competes for the same disk. My files tipped it over. Now read once, concurrently, with a count assertion so the scan can't silently cover nothing. A gate that fails on a busy machine rather than on a real BOM is one people learn to re-run instead of read.

## Also

`scripts/integration.ts` gains `expectError`, for cases whose *correct* outcome is a refusal. It asserts on the message rather than merely on "it errored" — an unreachable service also errors, and that would pass for the wrong reason.

## Verification

- 860 tests / 43 files; typecheck, lint and build clean.
- **27/27 integration calls against a live eight-service stack**, `add_media` dry-run only.

## Phase 4 is complete after this

All of 0.5's roadmap scope is in: permission tiers, `dry_run`, the audit trail, per-call confirmation, and six write tools. The one thing still untested anywhere is the **apply** path — every live run has been a dry run by design, so no real write has executed yet. Worth doing one deliberate `delete_files: false` add-or-delete against something you don't mind losing before cutting 0.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
