### PR TITLE
fix: stop add_media picking a quality profile nobody asked for

### DIFF
--- a/src/services/arrAdd.ts
+++ b/src/services/arrAdd.ts
@@ -75,7 +75,11 @@ export async function readQualityProfiles(http: ServiceHttp, service: ServiceId)
     const rows = await http.get<RawProfile[]>('/api/v3/qualityprofile');
     return rows
         .filter((p): p is RawProfile & { id: number } => typeof p.id === 'number')
-        .map(p => ({ id: p.id, name: fenceText(p.name ?? `profile ${p.id}`, { service, field: 'name' }) }));
+        .map(p => {
+            const name = p.name ?? `profile ${p.id}`;
+            // Raw for matching, fenced for prose — see QualityProfile.
+            return { id: p.id, name, display: fenceText(name, { service, field: 'name' }) };
+        });
 }
 
 export async function readRootFolders(http: ServiceHttp, service: ServiceId): Promise<RootFolder[]> {

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -333,7 +333,15 @@ export interface QueueRemoveCapable {
 export const hasQueueRemove = (a: ServiceAdapter): a is ServiceAdapter & QueueRemoveCapable =>
     typeof (a as Partial<QueueRemoveCapable>).removeQueueItem === 'function';
 
-export type QualityProfile = { id: number; name: string };
+/**
+ * `name` raw and `display` fenced, for the same reason `RootFolder` splits its
+ * path — and discovered the same way, by a match that could never succeed.
+ * `add_media` matches a requested profile against `name`; comparing against
+ * the fenced form meant an exact-name match was structurally impossible, so
+ * every name request fell through to substring matching, which is ambiguous
+ * exactly where precision matters most.
+ */
+export type QualityProfile = { id: number; name: string; display: string };
 
 /**
  * Two forms of the same string, deliberately.

--- a/src/tools/addMedia.ts
+++ b/src/tools/addMedia.ts
@@ -46,14 +46,25 @@ const findAdapter = (adapters: readonly ServiceAdapter[], service: ServiceId): S
 /**
  * Resolves one of several options, or refuses in a way that can be acted on.
  *
- * The refusal lists what is available. A model told only "ambiguous" has to
- * guess or give up; a model handed the four profile names can ask the user
- * which, or pick the one they already mentioned.
+ * Exact matches are tried first and, crucially, a **loose match that is
+ * ambiguous is a refusal, not a coin toss**. Two live failures shaped this:
+ *
+ * - Asking for quality profile `8` selected `HD-1080p` (id 4), because the
+ *   old single predicate `id === requested || name.includes(requested)` let
+ *   the *name* branch fire on the digit: "hd-1080p" contains "8". A film was
+ *   added and a 1080p release grabbed against an explicit request for 2160p.
+ *   A numeric request now only ever matches an id.
+ * - `2160p Balanced` is a prefix of `2160p Balanced NL`, so a substring match
+ *   silently picked whichever came first.
+ *
+ * Both are the same failure the "several, none named" refusal below exists to
+ * prevent — a guess presented as a decision — and both are worse for arriving
+ * while looking like the tool had understood.
  */
 function chooseOne<T>(
     options: readonly T[],
     requested: string | undefined,
-    matches: (option: T, requested: string) => boolean,
+    match: { exact: (option: T, requested: string) => boolean; loose: (option: T, requested: string) => boolean },
     describe: (option: T) => string,
     what: string,
     service: ServiceId
@@ -65,13 +76,23 @@ function chooseOne<T>(
     }
 
     if (requested !== undefined) {
-        const found = options.find(o => matches(o, requested));
-        if (found === undefined) {
+        const exact = options.filter(o => match.exact(o, requested));
+        if (exact.length === 1) return exact[0]!;
+
+        // Only consulted when nothing matched exactly, so an exact name can
+        // never be beaten by another option that merely contains it.
+        const loose = exact.length === 0 ? options.filter(o => match.loose(o, requested)) : exact;
+        if (loose.length === 1) return loose[0]!;
+
+        if (loose.length === 0) {
             throw new ServiceError('NotFound', service, `no ${what} on ${service} matches "${requested}"`, {
                 remedy: `Available: ${options.map(describe).join('; ')}.`
             });
         }
-        return found;
+
+        throw new ServiceError('NotFound', service, `"${requested}" matches more than one ${what} on ${service}`, {
+            remedy: `Be exact — it matches: ${loose.map(describe).join('; ')}. Naming the id is unambiguous.`
+        });
     }
 
     // Exactly one is not a choice, so making it silently is not a guess.
@@ -82,12 +103,26 @@ function chooseOne<T>(
     });
 }
 
+/** A request made entirely of digits is an id and nothing else. Without this,
+ *  "8" matches the *name* "HD-1080p". */
+const isNumeric = (value: string) => /^\d+$/.test(value);
+
 const GIB = 1024 ** 3;
 const freeSpace = (folder: RootFolder): string =>
     folder.freeSpaceBytes === undefined ? 'free space unknown' : `${(folder.freeSpaceBytes / GIB).toFixed(0)} GB free`;
 
-const profileMatches = (p: QualityProfile, requested: string): boolean =>
-    String(p.id) === requested || p.name.toLowerCase().includes(requested.toLowerCase());
+const PROFILE_MATCH = {
+    exact: (p: QualityProfile, requested: string): boolean =>
+        String(p.id) === requested || p.name.toLowerCase() === requested.toLowerCase(),
+    // A numeric request is an id, full stop — never a substring of a name.
+    loose: (p: QualityProfile, requested: string): boolean =>
+        !isNumeric(requested) && p.name.toLowerCase().includes(requested.toLowerCase())
+};
+
+const FOLDER_MATCH = {
+    exact: (f: RootFolder, requested: string): boolean => f.path.toLowerCase() === requested.toLowerCase(),
+    loose: (f: RootFolder, requested: string): boolean => f.path.toLowerCase().includes(requested.toLowerCase())
+};
 
 export function registerAddMedia(server: McpServer, context: WriteContext, adapters: readonly ServiceAdapter[]): void {
     registerWriteTool(server, context, {
@@ -146,8 +181,8 @@ export function registerAddMedia(server: McpServer, context: WriteContext, adapt
             const profile = chooseOne(
                 profiles,
                 quality_profile,
-                profileMatches,
-                p => `${p.name} (id ${p.id})`,
+                PROFILE_MATCH,
+                p => `${p.display} (id ${p.id})`,
                 'quality profile',
                 service
             );
@@ -155,14 +190,14 @@ export function registerAddMedia(server: McpServer, context: WriteContext, adapt
             const folder = chooseOne(
                 folders,
                 root_folder,
-                (f, requested) => f.path.toLowerCase().includes(requested.toLowerCase()),
+                FOLDER_MATCH,
                 f => `${f.display} (${freeSpace(f)})`,
                 'root folder',
                 service
             );
 
             const effects = [
-                `Adds ${label} to ${service} under ${folder.display} (${freeSpace(folder)}), quality profile ${profile.name}.`,
+                `Adds ${label} to ${service} under ${folder.display} (${freeSpace(folder)}), quality profile ${profile.display} (id ${profile.id}).`,
                 monitored
                     ? 'Monitors it, so it will be grabbed when a matching release appears.'
                     : 'Adds it unmonitored, so nothing will be grabbed until you monitor it.'

--- a/test/addMedia.test.ts
+++ b/test/addMedia.test.ts
@@ -194,6 +194,68 @@ describe('add_media choosing a profile and folder', () => {
         expect(structuredContent.effects.join(' ')).toContain('Ultra-HD');
     });
 
+    /**
+     * The live regression, and the most expensive bug in this phase.
+     *
+     * Asking for profile id 8 selected HD-1080p (id 4), because the old
+     * predicate let the name branch fire on a digit — "hd-1080p" contains "8".
+     * A real film was added and a 1080p release grabbed against an explicit
+     * request for 2160p, with the preview stating the wrong profile in prose
+     * that read entirely plausible.
+     */
+    it('treats a numeric request as an id only, never as part of a name', async () => {
+        const h = harness({
+            profiles: [
+                { id: 4, name: 'HD-1080p' },
+                { id: 8, name: '2160p Balanced' }
+            ]
+        });
+
+        const { structuredContent } = await h.call({
+            service: 'radarr',
+            external_id: '603',
+            quality_profile: '8',
+            dry_run: true
+        });
+
+        expect(structuredContent.effects.join(' ')).toContain('2160p Balanced');
+        expect(structuredContent.effects.join(' ')).not.toContain('HD-1080p');
+    });
+
+    // "2160p Balanced" is a prefix of "2160p Balanced NL".
+    it('refuses an ambiguous name rather than taking whichever comes first', async () => {
+        const h = harness({
+            profiles: [
+                { id: 8, name: '2160p Balanced' },
+                { id: 12, name: '2160p Balanced NL' }
+            ]
+        });
+
+        await expect(
+            h.call({ service: 'radarr', external_id: '603', quality_profile: 'Balanced', dry_run: true })
+        ).rejects.toThrow(/matches more than one/);
+    });
+
+    it('lets an exact name win over an option that merely contains it', async () => {
+        const h = harness({
+            profiles: [
+                { id: 8, name: '2160p Balanced' },
+                { id: 12, name: '2160p Balanced NL' }
+            ]
+        });
+
+        const { structuredContent } = await h.call({
+            service: 'radarr',
+            external_id: '603',
+            quality_profile: '2160p Balanced',
+            dry_run: true
+        });
+
+        const effects = structuredContent.effects.join(' ');
+        expect(effects).toContain('2160p Balanced');
+        expect(effects).not.toContain('NL');
+    });
+
     it('accepts a profile by id', async () => {
         const h = harness({ profiles: MANY_PROFILES });
         const { structuredContent } = await h.call({


### PR DESCRIPTION
**Ships in 0.5.0. Found by the first real write against a live stack, minutes after the release merged.**

Asking for quality profile `8` added the film under **HD-1080p (id 4)**, and Radarr grabbed a 1080p release against an explicit request for 2160p.

This is the exact failure the "several profiles, none named" refusal exists to prevent — a guess presented as a decision — and it is worse than a plain failure, because the preview stated the wrong profile in prose that read entirely plausible, and the confirmation was given against it.

## Two defects, same line

**1. A numeric request could match a name.** The predicate was:

```js
String(p.id) === requested || p.name.toLowerCase().includes(requested.toLowerCase())
```

With `requested = '8'`, iteration reaches `HD-1080p` (id 4) before id 8 — and `"hd-1080p".includes("8")` is **true**, because the name contains the digit. A numeric request is now an id and nothing else.

**2. An exact name match was structurally impossible.** Profile names are fenced, so `p.name` is `<<untrusted:radarr.name>>2160p Balanced<</untrusted>>` and `p.name === requested` can never hold. Every name request therefore fell through to substring matching — which is ambiguous exactly where precision matters: `2160p Balanced` is a prefix of `2160p Balanced NL`.

`QualityProfile` now carries `name` (raw, for matching) and `display` (fenced, for prose) — the same split `RootFolder` already needed, discovered the same way.

## What changed

- Matching is **exact-first**; loose matching is consulted only when nothing matched exactly, so an exact name can't be beaten by an option containing it.
- A loose match hitting **more than one** option is a refusal listing the candidates, not whichever came first.
- The preview now names the profile **id** alongside the name, so the confirmation prompt states the thing that actually determines what gets downloaded.

## Verification

- 863 tests / 43 files; typecheck, lint clean. Three new regression tests, including the numeric-request case and the prefix-ambiguity case.
- **Confirmed against the live stack**: the same `quality_profile: "8"` request that misfired now resolves to `2160p Balanced (id 8)`.

## Note on the release

0.5.0 merged (#46) before this fix existed, so **0.5.0 contains the bug**. This is a `fix:` commit, so release-please will queue it as 0.5.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
