### PR TITLE
ci: let release PRs run their own checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,20 @@ jobs:
       - uses: googleapis/release-please-action@v5
         id: rp
         with:
+          # Without this, the action falls back to GITHUB_TOKEN and opens the
+          # release PR as `app/github-actions`. CI *does* trigger for that PR —
+          # but the runs land in `action_required` (queued, 0s, never started),
+          # so the `check` and `docker` required status checks never report and
+          # the PR sits at mergeStateStatus BLOCKED forever. With
+          # enforce_admins: true on main there is no bypass, so every release
+          # needed someone to press "Approve and run" in the Actions tab. That
+          # is what happened to 0.4.0 and 0.5.0.
+          #
+          # A PAT is a real account, so its PRs are not bot-gated and CI runs
+          # immediately. The `||` fallback keeps releases working before the
+          # secret exists: an unset secret is the empty string, which is falsy.
+          # Needs contents:write and pull-requests:write on this repo only.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,6 +18,44 @@ bleeding edge. Nothing else. The release workflow fails the job when a release
 computes no version tag — a release that publishes only `latest` is a silent
 policy violation, and it has happened once.
 
+## If the release PR is BLOCKED with nothing failing
+
+`main` requires the `check` and `docker` status checks, with `enforce_admins:
+true` — so nobody merges without them, including you. If the release PR shows
+`mergeable: MERGEABLE` but `mergeStateStatus: BLOCKED`, and its checks section
+is **empty rather than red**, the runs are waiting for approval:
+
+```bash
+gh run list --branch release-please--branches--main--components--arr-mcp
+```
+
+A column of `action_required` runs at `0s` confirms it — queued, never started.
+Approve the newest one in the Actions tab, or:
+
+```bash
+gh api repos/bardesss/arr-mcp/actions/runs/<id>/approve --method POST
+```
+
+Approve it **after** the last feature PR merges. Every merge makes
+release-please push again, which supersedes the run you just approved.
+
+This is what gated 0.4.0 and 0.5.0. The cause was `release.yml` calling
+release-please without a `token:`, so it fell back to `GITHUB_TOKEN` and opened
+the PR as `app/github-actions`, whose workflow runs are approval-gated.
+
+**The permanent fix is a `RELEASE_PLEASE_TOKEN` secret**, which the workflow now
+prefers. Until it exists the workflow still works — it falls back to
+`GITHUB_TOKEN` — and every release keeps needing that manual approval. To set it
+up: create a fine-grained PAT scoped to this repository with **Contents:
+read/write** and **Pull requests: read/write**, then
+
+```bash
+gh secret set RELEASE_PLEASE_TOKEN --repo bardesss/arr-mcp   # paste at the prompt
+```
+
+Set it interactively, never as a shell argument — an argument lands in shell
+history.
+
 ## Check `main` contains what you think it does
 
 **Before merging the release PR.** A release PR describes the commits on `main`


### PR DESCRIPTION
Every release PR has sat `BLOCKED` until someone pressed **"Approve and run"** in the Actions tab. That gated 0.4.0 and 0.5.0.

It reads like a mystery rather than a pending approval: the PR shows `mergeable: MERGEABLE`, `mergeStateStatus: BLOCKED`, and an **empty** checks section rather than a red one.

## Cause

`release.yml` called `googleapis/release-please-action` with no `token:`, so it fell back to `GITHUB_TOKEN` and opened the release PR as `app/github-actions`.

CI *does* trigger for that PR — but the runs land in `action_required`:

```
completed  action_required  chore(main): release 0.5.0  CI  pull_request  0s
completed  action_required  chore(main): release 0.5.0  CI  pull_request  0s
completed  action_required  chore(main): release 0.5.0  CI  pull_request  0s
completed  success          chore(main): release 0.4.0  CI  pull_request  47s   ← manually approved
```

Queued, never started. So the `check` and `docker` required status checks never report, and with `enforce_admins: true` on `main` there is no bypass — not even for the repo owner. The one 0.4.0 run that shows `success` is the one somebody approved by hand, which is why that release could merge at all.

## Fix

```yaml
token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
```

A PAT is a real account, so its PRs aren't bot-gated and CI runs immediately.

**This PR changes nothing on its own.** The `||` fallback keeps releases working before the secret exists — an unset secret is the empty string, which is falsy — so merging this is safe and inert. The manual approval stops being needed the moment `RELEASE_PLEASE_TOKEN` exists.

## To finish it (needs you — I can't mint a PAT)

1. Create a **fine-grained PAT** scoped to `bardesss/arr-mcp` only, with **Contents: read/write** and **Pull requests: read/write**.
2. ```bash
   gh secret set RELEASE_PLEASE_TOKEN --repo bardesss/arr-mcp
   ```
   Set it interactively at the prompt — passing it as a shell argument puts it in your history.

The next release PR after that should arrive with checks already running.

`RELEASING.md` gains the symptom, the one-command diagnosis (`gh run list --branch release-please--…`), and these setup steps, so the next person recognises it immediately instead of working backwards from branch protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
