### PR TITLE
feat: add the config UI, with hot reload

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,6 +154,37 @@ data: files on disk, a request's history, a blocklist entry. When unsure, it is
 `destructive`; the cost of over-classifying is one config flag, and the cost of
 under-classifying is someone's library.
 
+## Working on the config UI
+
+Server rendered from `src/web/`, no build step and no framework. `tsc` does not
+emit non-TypeScript files, so **assets live in modules, not in a `public/`
+directory** — a static file would work in development and be silently missing
+from the Docker image.
+
+Three rules, each of which exists because breaking it is quiet rather than
+loud:
+
+- **Every interpolation goes through `html`/`esc`.** Release names from public
+  indexers reach the log table and the audit view, and they are the most
+  attacker-controllable strings in the system (§11). `raw()` is the only escape
+  hatch and has to be written on purpose.
+- **The live log stream is JSON, and the client builds rows with
+  `textContent`.** Not `innerHTML`. Everything else on the page is
+  server-rendered through the escaping template, which is sound — but that one
+  surface carries indexer text on a timer, and building nodes makes an XSS
+  impossible rather than merely unlikely.
+- **A secret is never rendered back.** API keys, the Transmission password and
+  the UI password all render as empty fields meaning *unchanged*. That is also
+  why an empty field can never mean "clear this" — clearing is expressed by
+  switching the service off.
+
+Anything a config change can invalidate belongs in `core/runtime.ts`, behind
+the snapshot swap, and is read **per request** rather than captured when the
+app is built. Capturing it is what made a restart necessary before. Two things
+deliberately live outside the snapshot and survive a reload: confirmation
+tokens, because a write handshake spans two calls, and sessions, because a
+config edit must not log you out of the page you are editing from.
+
 ## Vendored API specs
 
 `specs/*.json` are upstream OpenAPI documents, refreshed by `npm run specs:fetch`

--- a/README.md
+++ b/README.md
@@ -16,20 +16,21 @@ Jellyfin. arr-mcp correlates them and gives you the causal chain.
 - **Writes are opt-in, previewed, and recorded.** Every write is off until you
   turn it on per service, shows you exactly what it would do before it does it,
   and lands in an audit trail either way.
+- **A config page that diagnoses.** Add services from a browser, see what is
+  broken and what to do about it, and read the logs and the write audit — no
+  hand-edited YAML, no restart.
 
-> ### Status: 0.4 — correlation across the stack
+> ### Status: 0.5 — writes, opt-in and previewed
 >
-> `get_library` joins Radarr, Sonarr and Jellyfin into one record per title, on
-> shared external ids — presence, ratings and watch state answered together
-> instead of service by service. `diagnose` walks the whole chain from request
-> to playable and names the first thing that explains a gap, even with
-> services down. See [the roadmap](#roadmap).
+> Six write tools behind per-service permission tiers, each previewing exactly
+> what it would do before it does it, and recording every attempt — applied,
+> refused or failed — in an audit trail. `get_library` and `diagnose` from 0.4
+> still do the correlation work. See [the roadmap](#roadmap).
 >
-> **On `main`, ahead of the 0.4 tag:** writes, as described under
-> [Writes](#writes) — permission tiers, `dry_run`, confirmation tokens and the
-> audit trail, with six write tools covering searches, the download queue,
-> adding and removing media, and Seerr requests. Released images tagged `0.4`
-> are still read-only.
+> **On `main`, ahead of the 0.5 tag:** the [config UI](#config-ui) — a
+> dashboard, connection tests that diagnose rather than pass or fail, log
+> streams, the write audit, and configuration editing that applies without a
+> restart. Released images tagged `0.5` still need hand-edited YAML.
 
 ## Services
 
@@ -204,7 +205,7 @@ none, **it refuses and lists them** rather than picking:
 ```yaml
 services:
   arr-mcp:
-    image: ghcr.io/bardesss/arr-mcp:0.4
+    image: ghcr.io/bardesss/arr-mcp:0.5
     ports: ['6060:6060']
     volumes: ['./config:/config']
     environment:
@@ -217,9 +218,17 @@ services:
 Tags are `X.Y.Z`, `X.Y`, `X` and `latest` for releases, plus `main` for
 bleeding edge. Pin a minor while the tool surface is still moving.
 
-On first start, `config/config.yaml` is created and **the bearer token for the
-MCP endpoint is printed to the container log** — `docker logs arr-mcp`. Add
-your services to that file:
+On first start, `config/config.yaml` is created and **the config UI password
+and the MCP bearer token are printed once to the container log** —
+`docker logs arr-mcp`. The password is not stored anywhere and will not be
+shown again; only a hash of it is kept.
+
+Then open **`http://<host>:6060/ui`**, sign in, and add your services from the
+Configuration page. Saving applies immediately — no restart. The bearer token
+your MCP client needs is on the dashboard, so you only need the log once.
+
+Everything the UI does is still just `config.yaml`, and editing it by hand
+remains supported:
 
 ```yaml
 services:
@@ -254,8 +263,41 @@ from Radarr/Sonarr alone.
 A misspelled key, an unknown service, or an `api_key` on Transmission fails at
 startup with the offending field named, rather than being silently ignored.
 
-Until the config UI arrives in 0.6, edit the file by hand and **restart the
-container** to pick up changes.
+Changes saved from the config UI take effect immediately. A change you make by
+hand-editing the file still needs a restart, because nothing is watching the
+file — the UI reloads because it knows it just wrote.
+
+## Config UI
+
+`http://<host>:6060/ui`
+
+| Page | What it is for |
+| --- | --- |
+| Dashboard | Every service tested live, with the bearer token for your MCP client |
+| Configuration | Add, edit and remove services; change credentials |
+| Logs | The last few thousand lines, filtered by level and by service |
+| Write audit | Every write attempt — applied, previewed, refused or failed |
+
+**Connection tests diagnose rather than pass or fail.** A service that is down
+says what is wrong and what to do about it — the same `kind`, `detail` and
+`remedy` the MCP tools return — instead of showing a red cross you then have to
+investigate.
+
+**Secrets never come back out.** API keys, the Transmission password and the UI
+password all render as empty fields meaning *unchanged*, so a saved page or a
+screenshot cannot carry them. The bearer token is the deliberate exception —
+handing it to your MCP client is the point — and it is masked until you ask.
+
+**Logs are a ring buffer**, kept beside your config and capped, so a chatty
+service cannot fill the disk. Full history stays in `docker logs`.
+
+Sign-in is a username and password, generated on first run alongside the bearer
+token. If you lose the password, delete the `password_hash` line from
+`config.yaml` and restart — a new one is generated and printed.
+
+The UI is served over plain http on your LAN, like the services it manages.
+Put it behind a reverse proxy with TLS if it needs to leave the LAN, and pin
+`allowed_hosts` if you do.
 
 ## Roadmap
 
@@ -264,8 +306,8 @@ container** to pick up changes.
 | 0.1 / 0.2 | Walking skeleton: stateless MCP transport, bearer auth, Radarr, `stack_health` |
 | 0.3 | The remaining seven service adapters and ten read tools |
 | 0.4 | Cross-service correlation: identity resolver, three-way library join, `diagnose` |
-| 0.5 | Writes: permission tiers, `dry_run`, write audit, per-call confirmation — on `main`, unreleased |
-| 0.6 | Web config page: dashboard, diagnosing connection tests, log streams |
+| 0.5 | Writes: permission tiers, `dry_run`, write audit, per-call confirmation |
+| 0.6 | Web config page: dashboard, diagnosing connection tests, log streams, config editing with hot reload — on `main`, unreleased |
 | 0.7 → 1.0 | Metadata providers, MCP resources and prompts |
 
 Each version is a self-contained, shippable slice — the goal is that 0.4 already

--- a/scripts/capture-fixtures.ts
+++ b/scripts/capture-fixtures.ts
@@ -361,7 +361,9 @@ function redact(node: unknown, secrets: string[], hosts: string[]): unknown {
 }
 
 const configDir = process.env.ARR_MCP_CAPTURE_CONFIG ?? './config';
-const { config } = await loadConfig(configDir);
+// `persist: false` — capturing fixtures reads the user's config; it must never
+// write to the file holding their credentials.
+const { config } = await loadConfig(configDir, { persist: false });
 const secrets = secretsOf(config);
 const hosts = hostsOf(config);
 

--- a/scripts/integration.ts
+++ b/scripts/integration.ts
@@ -32,9 +32,10 @@
  * line — pass or fail — is passed through `redactHosts` first.
  */
 import { loadConfig } from '../src/config/load.ts';
-import { buildAdapters } from '../src/services/registry.ts';
 import { buildApp } from '../src/app.ts';
 import { WriteAudit } from '../src/core/audit.ts';
+import { LogStore } from '../src/core/logs.ts';
+import { Runtime } from '../src/core/runtime.ts';
 import { TOOL_NAMES } from '../src/tools/register.ts';
 import { hostsOf, redactHosts } from './lib/redact.ts';
 
@@ -88,12 +89,18 @@ const CASES: Case[] = [
 // root). `./config` matches capture-fixtures.ts's own local-checkout
 // default, under its own env var, for the same reason.
 const CONFIG_DIR = process.env.ARR_MCP_CONFIG_DIR ?? './config';
-const { config } = await loadConfig(CONFIG_DIR);
+// `persist: false` — a smoke run reads the user's config; it must never write
+// to the file holding their credentials.
+const { config } = await loadConfig(CONFIG_DIR, { persist: false });
 
-const adapters = buildAdapters(config);
 // Ephemeral on purpose: this script is a maintainer smoke run, and its dry-run
-// probes are not events the user's own audit trail should be cluttered with.
-const app = buildApp({ config, adapters, audit: WriteAudit.ephemeral() });
+// probes are not events the user's own audit trail — or log ring buffer —
+// should be cluttered with.
+const app = buildApp({
+    runtime: Runtime.fromConfig(config, WriteAudit.ephemeral(), { configDir: CONFIG_DIR }),
+    audit: WriteAudit.ephemeral(),
+    logs: LogStore.ephemeral()
+});
 const hosts = hostsOf(config);
 
 /**

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,11 +2,12 @@ import { createMcpHonoApp } from '@modelcontextprotocol/hono';
 import { McpServer, createMcpHandler } from '@modelcontextprotocol/server';
 import type { Context } from 'hono';
 import { timingSafeEqual } from 'node:crypto';
-import type { Config } from './config/schema.ts';
 import type { WriteAudit } from './core/audit.ts';
 import { logger } from './core/logger.ts';
-import type { ServiceAdapter } from './services/types.ts';
-import { buildToolContext, registerAllTools } from './tools/register.ts';
+import type { LogStore } from './core/logs.ts';
+import type { Runtime } from './core/runtime.ts';
+import { registerAllTools } from './tools/register.ts';
+import { registerWebRoutes } from './web/routes.ts';
 
 const NAME = 'arr-mcp';
 const VERSION = process.env.ARR_MCP_VERSION ?? '0.0.0-dev';
@@ -24,22 +25,21 @@ function tokenMatches(presented: string, expected: string): boolean {
     return timingSafeEqual(a, b);
 }
 
-export function buildApp(opts: { config: Config; adapters: readonly ServiceAdapter[]; audit: WriteAudit }) {
-    const { config, adapters, audit } = opts;
-
-    // Built once, outside the per-request factory: the identity resolvers cache
-    // each service's user directory, and rebuilding them per request would
-    // refetch it on every tool call. The write context has a second, harder
-    // reason — its confirmation tokens must outlive a single request or the
-    // preview/confirm handshake could never complete.
-    const toolContext = buildToolContext(adapters, config, audit);
+export function buildApp(opts: { runtime: Runtime; audit: WriteAudit; logs: LogStore }) {
+    const { runtime, audit, logs } = opts;
 
     // The factory runs once per request, so every call gets a fresh McpServer.
     // This is what keeps the transport stateless (design spec §5) — do not
     // hoist the server out of the closure.
+    //
+    // `runtime.current` is read here, per request, rather than captured when
+    // the app is built: that is what lets a config change take effect without
+    // a restart. Reading it once into `snapshot` also means a call that starts
+    // before a reload finishes against the configuration it began with.
     const handler = createMcpHandler(() => {
+        const snapshot = runtime.current;
         const server = new McpServer({ name: NAME, version: VERSION });
-        registerAllTools(server, toolContext);
+        registerAllTools(server, snapshot.tools);
         return server;
     });
 
@@ -52,7 +52,12 @@ export function buildApp(opts: { config: Config; adapters: readonly ServiceAdapt
     // empty allow-list and rejects *every* request with 403. Authentication is
     // what protects us here; Host pinning is an extra a reverse-proxy user can
     // opt into.
-    const allowedHosts = config.auth.allowed_hosts;
+    //
+    // Read once, at build time, unlike everything else: the Hono adapter
+    // installs this middleware when the app is constructed, so a reload cannot
+    // change it. Pinning hostnames therefore still needs a restart, which is
+    // documented — it is a transport concern, not a service one.
+    const allowedHosts = runtime.config.auth.allowed_hosts;
     const app = createMcpHonoApp({
         host: '0.0.0.0',
         ...(allowedHosts.length > 0 ? { allowedHosts } : {})
@@ -60,11 +65,15 @@ export function buildApp(opts: { config: Config; adapters: readonly ServiceAdapt
 
     app.get('/healthz', c => c.json({ status: 'ok', name: NAME, version: VERSION }));
 
+    registerWebRoutes(app, { runtime, audit, logs, name: NAME, version: VERSION });
+
     app.all('/mcp', async (c: Context) => {
         const header = c.req.header('Authorization') ?? '';
         const [scheme, presented] = header.split(' ');
 
-        if (scheme !== 'Bearer' || !presented || !tokenMatches(presented, config.auth.bearer_token)) {
+        // From the runtime, not a captured value, so rotating the token in the
+        // config UI takes effect on the very next request.
+        if (scheme !== 'Bearer' || !presented || !tokenMatches(presented, runtime.config.auth.bearer_token)) {
             logger.warn(
                 { path: '/mcp', ip: c.req.header('x-forwarded-for') ?? 'unknown' },
                 'rejected unauthenticated MCP request'

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -4,15 +4,31 @@ import { join } from 'node:path';
 import { parse, stringify } from 'yaml';
 import * as z from 'zod/v4';
 import { logger } from '../core/logger.ts';
+import { generatePassword, hashPassword } from '../core/session.ts';
 import { ConfigSchema, type Config } from './schema.ts';
 
 const FILENAME = 'config.yaml';
 
 const generateToken = (): string => randomBytes(32).toString('hex');
 
+/**
+ * Credentials created on a run, returned so `index.ts` can print them once.
+ *
+ * The password is deliberately not stored anywhere — only its hash reaches
+ * `config.yaml` — so this is the only moment it exists in a form anyone can
+ * read. That is why it travels back out of `loadConfig` rather than being
+ * logged from in here: the loader should not decide what gets printed.
+ */
+export type GeneratedCredentials = { bearerToken?: string; password?: string; username?: string };
+
 /** Written on first run so the knobs are discoverable without reading docs. */
-const seedConfig = () => ({
-    auth: { bearer_token: generateToken(), allowed_hosts: [] as string[] },
+const seedConfig = (password: string) => ({
+    auth: {
+        bearer_token: generateToken(),
+        username: 'admin',
+        password_hash: hashPassword(password),
+        allowed_hosts: [] as string[]
+    },
     services: {}
 });
 
@@ -21,9 +37,24 @@ const seedConfig = () => ({
  * first run. The file is the source of truth; environment variables seed
  * first-run defaults only (design spec §13).
  */
-export async function loadConfig(configDir: string): Promise<{ config: Config; created: boolean }> {
+/**
+ * `persist: false` reads without ever writing.
+ *
+ * The maintainer scripts load this file only to reach the services it names,
+ * and a read must not have side effects on the user's credentials. Before this
+ * existed, running `npm run integration` against a config predating the config
+ * UI silently backfilled a `password_hash` into it — generating a password
+ * that the script never printed, so nobody could ever know it. Missing
+ * credentials are still synthesised in memory, because the schema requires
+ * them and a script has no business failing over a field it does not use.
+ */
+export async function loadConfig(
+    configDir: string,
+    opts: { persist?: boolean } = {}
+): Promise<{ config: Config; created: boolean; generated: GeneratedCredentials }> {
+    const persist = opts.persist ?? true;
     const path = join(configDir, FILENAME);
-    await mkdir(configDir, { recursive: true });
+    if (persist) await mkdir(configDir, { recursive: true });
 
     let raw: string | undefined;
     try {
@@ -33,11 +64,21 @@ export async function loadConfig(configDir: string): Promise<{ config: Config; c
     }
 
     if (raw === undefined) {
-        const seeded = seedConfig();
+        if (!persist) {
+            throw new Error(
+                `no config.yaml in ${configDir} — start arr-mcp once to create one, or point ARR_MCP_CONFIG_DIR at an existing config directory.`
+            );
+        }
+        const password = generatePassword();
+        const seeded = seedConfig(password);
         // 0o600: the file holds the bearer token and every service API key.
         await writeFile(path, stringify(seeded), { mode: 0o600 });
-        logger.info({ path }, 'created config.yaml with a generated bearer token');
-        return { config: ConfigSchema.parse(seeded), created: true };
+        logger.info({ path }, 'created config.yaml with generated credentials');
+        return {
+            config: ConfigSchema.parse(seeded),
+            created: true,
+            generated: { bearerToken: seeded.auth.bearer_token, password, username: 'admin' }
+        };
     }
 
     let parsed: unknown;
@@ -52,19 +93,37 @@ export async function loadConfig(configDir: string): Promise<{ config: Config; c
     }
 
     const obj = parsed as Record<string, unknown>;
-    const auth = obj.auth as { bearer_token?: string } | undefined;
-    if (!auth?.bearer_token) {
-        // Backfill rather than refuse to start: a user who deleted the token,
-        // or hand-wrote a config without one, should get a working server and
-        // a warning telling them where the new token came from.
-        obj.auth = { ...(auth ?? {}), bearer_token: generateToken() };
-        await writeFile(path, stringify(obj), { mode: 0o600 });
-        logger.warn({ path }, 'config.yaml had no bearer token; generated one');
+    const auth = (obj.auth ?? {}) as { bearer_token?: string; password_hash?: string; username?: string };
+    const generated: GeneratedCredentials = {};
+
+    // Backfill rather than refuse to start: someone who deleted a credential,
+    // or hand-wrote a config without one, should get a working server and be
+    // told where the replacement came from. Deleting `password_hash` is also
+    // the documented way to ask for a new password when you have lost it, so
+    // this path is a feature, not only a repair.
+    if (!auth.bearer_token) {
+        auth.bearer_token = generateToken();
+        generated.bearerToken = auth.bearer_token;
+    }
+    if (!auth.password_hash) {
+        const password = generatePassword();
+        auth.password_hash = hashPassword(password);
+        auth.username ??= 'admin';
+        generated.password = password;
+        generated.username = auth.username;
+    }
+
+    if (generated.bearerToken !== undefined || generated.password !== undefined) {
+        obj.auth = auth;
+        if (persist) {
+            await writeFile(path, stringify(obj), { mode: 0o600 });
+            logger.warn({ path }, 'config.yaml was missing a credential; generated one');
+        }
     }
 
     const result = ConfigSchema.safeParse(obj);
     if (!result.success) {
         throw new Error(`config.yaml is invalid:\n${z.prettifyError(result.error)}`);
     }
-    return { config: result.data, created: false };
+    return { config: result.data, created: false, generated };
 }

--- a/src/config/save.ts
+++ b/src/config/save.ts
@@ -1,0 +1,52 @@
+import { readFile, rename, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { parseDocument } from 'yaml';
+import * as z from 'zod/v4';
+import { ConfigSchema, type Config } from './schema.ts';
+
+const FILENAME = 'config.yaml';
+
+/**
+ * Writes config.yaml from the config UI.
+ *
+ * Three properties, each learned the hard way somewhere in this project:
+ *
+ * 1. **Comments survive.** A plain `stringify` round trip silently deletes
+ *    every comment and reflows the file. People hand-edit this file — the
+ *    README told them to for five releases — so their annotations are theirs,
+ *    not ours to discard. `parseDocument` keeps them.
+ * 2. **It validates before it writes.** The same schema the loader uses, so a
+ *    form post cannot produce a file that will not start the process.
+ * 3. **It replaces atomically.** Written to a temp file and renamed, so a
+ *    crash mid-write cannot leave a truncated config holding every API key —
+ *    which would lock the user out of the UI that could fix it.
+ */
+export async function saveConfig(configDir: string, next: Config): Promise<void> {
+    // Validated first: the caller assembles `next` from form fields, and a
+    // typo there must fail before anything touches the file.
+    const parsed = ConfigSchema.safeParse(next);
+    if (!parsed.success) {
+        throw new Error(`that configuration is not valid:\n${z.prettifyError(parsed.error)}`);
+    }
+    const value = parsed.data;
+
+    const path = join(configDir, FILENAME);
+    const doc = parseDocument(await readFile(path, 'utf8'));
+
+    doc.setIn(['auth', 'bearer_token'], value.auth.bearer_token);
+    doc.setIn(['auth', 'username'], value.auth.username);
+    doc.setIn(['auth', 'password_hash'], value.auth.password_hash);
+    doc.setIn(['auth', 'allowed_hosts'], value.auth.allowed_hosts);
+
+    // Services are replaced wholesale rather than merged key by key: a service
+    // the user switched off has to disappear, and a field they cleared has to
+    // clear. Merging would leave orphans behind that the strict schema would
+    // then reject on the next start.
+    doc.setIn(['services'], value.services);
+
+    const tmp = `${path}.tmp`;
+    // 0o600 on the temp file too — it holds the same secrets for the moment it
+    // exists, and a default-umask temp file is a readable one.
+    await writeFile(tmp, doc.toString(), { mode: 0o600 });
+    await rename(tmp, path);
+}

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -108,6 +108,21 @@ export const ConfigSchema = z.object({
     auth: z.object({
         /** Generated on first run by loadConfig; 32 random bytes, hex. */
         bearer_token: z.string().length(64),
+        /** Who logs into the config UI. Defaulted rather than generated —
+         *  a random username helps nobody and is one more thing to look up. */
+        username: z.string().min(1).default('admin'),
+        /**
+         * scrypt hash of the UI password, `scrypt$salt$hash`. Required for the
+         * same reason `bearer_token` is: loadConfig always injects one before
+         * parsing, so the only way it is missing is a hand-edited file that
+         * deleted it — which must fail loudly rather than default to something
+         * that lets anyone in.
+         *
+         * The password itself is never stored. It is printed once, on the run
+         * that generates it, and cannot be recovered afterwards — deleting
+         * this line is how you ask for a new one.
+         */
+        password_hash: z.string().min(1),
         /**
          * Hostnames the MCP endpoint may be reached on, for the SDK's DNS
          * rebinding protection. Empty means "accept any Host", which is the

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -1,27 +1,65 @@
 import pino from 'pino';
+import type { LogStore } from './logs.ts';
 
 /**
- * Process-wide logger. Writes to stdout; the SQLite ring-buffer sink arrives
- * in Phase 5 alongside the config UI's three log streams.
+ * The ring-buffer sink, attached late.
+ *
+ * `logger` is imported at module load by nearly every file, but the store
+ * needs the config directory, which only `index.ts` knows. So the destination
+ * is a stable object that forwards to a store once one exists and drops
+ * otherwise — rather than a second logger built later, which would silently
+ * lose every line emitted during startup.
  */
-export const logger = pino({
-    level: process.env.LOG_LEVEL ?? 'info',
-    // `app`, not `service`: `service` belongs to the media service a log line
-    // is about (radarr, sonarr, …), which is what the config UI's per-service
-    // log stream filters on in Phase 5. Binding both to `service` emits a
-    // duplicate JSON key and silently loses one of them.
-    base: { app: 'arr-mcp' },
-    serializers: {
-        // pino's default `err` serializer spreads every own enumerable
-        // property, and `ServiceError.message` embeds `.remedy` (see
-        // core/errors.ts) — without this, `remedy` would appear twice in
-        // every logged error: once inline in `message`, once as its own
-        // field. `kind`/`service`/`detail` stay, since those are structured
-        // fields the config UI's log streams can filter on and are not
-        // themselves duplicated prose.
-        err: err => {
-            const { remedy: _remedy, ...rest } = pino.stdSerializers.err(err);
-            return rest;
-        }
+let sink: LogStore | undefined;
+
+export function attachLogStore(store: LogStore): void {
+    sink = store;
+}
+
+/** Tests attach an ephemeral store; this puts it back. */
+export function detachLogStore(): void {
+    sink = undefined;
+}
+
+/**
+ * Writes to stdout **and** the ring buffer.
+ *
+ * stdout first and unconditionally: `docker logs` is the only way in before
+ * anyone has reached the UI, and a failing store must not cost a line there.
+ * `LogStore.write` swallows its own errors for the same reason.
+ */
+const destination = {
+    write(line: string): void {
+        process.stdout.write(line);
+        sink?.write(line);
     }
-});
+};
+
+/**
+ * Process-wide logger. Writes to stdout, and to the SQLite ring buffer behind
+ * the config UI's log streams once `attachLogStore` has been called.
+ */
+export const logger = pino(
+    {
+        level: process.env.LOG_LEVEL ?? 'info',
+        // `app`, not `service`: `service` belongs to the media service a log
+        // line is about (radarr, sonarr, …), which is what the config UI's
+        // per-service log stream filters on. Binding both to `service` emits a
+        // duplicate JSON key and silently loses one of them.
+        base: { app: 'arr-mcp' },
+        serializers: {
+            // pino's default `err` serializer spreads every own enumerable
+            // property, and `ServiceError.message` embeds `.remedy` (see
+            // core/errors.ts) — without this, `remedy` would appear twice in
+            // every logged error: once inline in `message`, once as its own
+            // field. `kind`/`service`/`detail` stay, since those are structured
+            // fields the config UI's log streams can filter on and are not
+            // themselves duplicated prose.
+            err: err => {
+                const { remedy: _remedy, ...rest } = pino.stdSerializers.err(err);
+                return rest;
+            }
+        }
+    },
+    destination
+);

--- a/src/core/logs.ts
+++ b/src/core/logs.ts
@@ -1,0 +1,195 @@
+import Database from 'better-sqlite3';
+import type { Database as Db } from 'better-sqlite3';
+import { join } from 'node:path';
+import type { ServiceId } from '../config/schema.ts';
+
+/**
+ * The SQLite ring buffer `logger.ts` has been pointing at since Phase 1, and
+ * the store behind the config UI's log streams.
+ *
+ * A ring buffer, not an audit trail — the opposite of `audit.ts`, and kept in
+ * its own file for exactly that reason. Write records must survive forever;
+ * log lines must not, or a chatty service fills a home server's disk. Sharing
+ * one database would mean one retention policy for two things that need
+ * different ones.
+ *
+ * stdout stays the primary sink. This is additive: `docker logs` keeps working
+ * unchanged, and losing this store loses nothing that was not already printed.
+ */
+
+export const LOG_FILENAME = 'logs.db';
+
+/** Roughly a day of a busy stack, and a few MB on disk. */
+export const LOG_RING_SIZE = 5000;
+
+/** Counting rows on every insert costs more than the occasional overshoot. */
+const PRUNE_EVERY = 100;
+
+/** pino's numeric levels, which are what actually appear in the JSON. */
+export const LEVELS = { trace: 10, debug: 20, info: 30, warn: 40, error: 50, fatal: 60 } as const;
+export type LevelName = keyof typeof LEVELS;
+
+const LEVEL_NAME = new Map<number, LevelName>(
+    Object.entries(LEVELS).map(([name, value]) => [value, name as LevelName])
+);
+
+export type LogRow = {
+    id: number;
+    at: string;
+    level: number;
+    levelName: string;
+    service: string | undefined;
+    msg: string;
+    /** Everything pino emitted that is not already a column, as JSON. */
+    fields: string;
+};
+
+export type LogQuery = {
+    limit?: number;
+    /** Inclusive floor, so `warn` returns warnings, errors and fatals. */
+    minLevel?: number;
+    /** The media service a line is *about* — `service`, never `app` (see logger.ts). */
+    service?: ServiceId | undefined;
+    /** For polling: only rows newer than one already seen. */
+    afterId?: number;
+};
+
+const SCHEMA = `
+CREATE TABLE IF NOT EXISTS log (
+    id      INTEGER PRIMARY KEY AUTOINCREMENT,
+    at      TEXT    NOT NULL,
+    level   INTEGER NOT NULL,
+    service TEXT,
+    msg     TEXT    NOT NULL,
+    fields  TEXT    NOT NULL
+);
+CREATE INDEX IF NOT EXISTS log_level ON log (level, id DESC);
+CREATE INDEX IF NOT EXISTS log_service ON log (service, id DESC);
+`;
+
+/** Columns of their own; everything else is folded into `fields`. */
+const PROMOTED = new Set(['time', 'level', 'msg', 'service', 'app', 'hostname', 'pid']);
+
+export class LogStore {
+    readonly #db: Db;
+    #sincePrune = 0;
+
+    private constructor(db: Db) {
+        this.#db = db;
+        db.exec(SCHEMA);
+    }
+
+    static open(configDir: string): LogStore {
+        const db = new Database(join(configDir, LOG_FILENAME));
+        db.pragma('journal_mode = WAL');
+        // NORMAL, not FULL: unlike the audit trail, a log line lost to a power
+        // cut costs nothing — it was already on stdout — and fsyncing every
+        // line would make logging the slowest thing the process does.
+        db.pragma('synchronous = NORMAL');
+        return new LogStore(db);
+    }
+
+    /** In-memory, for tests. */
+    static ephemeral(): LogStore {
+        return new LogStore(new Database(':memory:'));
+    }
+
+    /**
+     * Takes one pino JSON line. Never throws: logging must not be able to
+     * break the thing it is logging about, and a malformed line is worth
+     * dropping rather than crashing a tool call. That also means this cannot
+     * report its own failures through `logger` — doing so would recurse.
+     */
+    write(line: string): void {
+        try {
+            const parsed = JSON.parse(line) as Record<string, unknown>;
+            const level = typeof parsed.level === 'number' ? parsed.level : LEVELS.info;
+            const at = typeof parsed.time === 'number' ? new Date(parsed.time).toISOString() : new Date().toISOString();
+
+            const extra: Record<string, unknown> = {};
+            for (const [key, value] of Object.entries(parsed)) {
+                if (!PROMOTED.has(key)) extra[key] = value;
+            }
+
+            this.#db
+                .prepare(`INSERT INTO log (at, level, service, msg, fields) VALUES (?, ?, ?, ?, ?)`)
+                .run(
+                    at,
+                    level,
+                    typeof parsed.service === 'string' ? parsed.service : null,
+                    typeof parsed.msg === 'string' ? parsed.msg : '',
+                    JSON.stringify(extra)
+                );
+
+            this.#sincePrune += 1;
+            if (this.#sincePrune >= PRUNE_EVERY) {
+                this.#sincePrune = 0;
+                this.#prune();
+            }
+        } catch {
+            // Deliberately silent — see the doc comment.
+        }
+    }
+
+    recent(query: LogQuery = {}): LogRow[] {
+        const where: string[] = [];
+        const params: unknown[] = [];
+
+        if (query.minLevel !== undefined) {
+            where.push('level >= ?');
+            params.push(query.minLevel);
+        }
+        if (query.service !== undefined) {
+            where.push('service = ?');
+            params.push(query.service);
+        }
+        if (query.afterId !== undefined) {
+            where.push('id > ?');
+            params.push(query.afterId);
+        }
+
+        const clause = where.length === 0 ? '' : `WHERE ${where.join(' AND ')}`;
+        const limit = Math.min(Math.max(Math.trunc(query.limit ?? 200), 1), LOG_RING_SIZE);
+        params.push(limit);
+
+        const rows = this.#db
+            .prepare(`SELECT * FROM log ${clause} ORDER BY id DESC LIMIT ?`)
+            .all(...params) as Omit<LogRow, 'levelName'>[];
+
+        return rows.map(r => ({ ...r, levelName: LEVEL_NAME.get(r.level) ?? String(r.level) }));
+    }
+
+    /** Which services have actually logged, so the UI's filter offers only
+     *  those rather than all eight regardless. */
+    services(): string[] {
+        return (
+            this.#db.prepare(`SELECT DISTINCT service FROM log WHERE service IS NOT NULL ORDER BY service`).all() as {
+                service: string;
+            }[]
+        ).map(r => r.service);
+    }
+
+    count(): number {
+        return (this.#db.prepare(`SELECT COUNT(*) AS n FROM log`).get() as { n: number }).n;
+    }
+
+    /** Keeps the newest LOG_RING_SIZE rows. Exposed for tests; called
+     *  automatically every PRUNE_EVERY writes. */
+    prune(): void {
+        this.#prune();
+    }
+
+    close(): void {
+        this.#db.close();
+    }
+
+    #prune(): void {
+        this.#db
+            .prepare(
+                `DELETE FROM log WHERE id <= (
+                     SELECT id FROM log ORDER BY id DESC LIMIT 1 OFFSET ?
+                 )`
+            )
+            .run(LOG_RING_SIZE - 1);
+    }
+}

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -1,0 +1,140 @@
+import { loadConfig } from '../config/load.ts';
+import type { Config } from '../config/schema.ts';
+import { buildAdapters } from '../services/registry.ts';
+import type { ServiceAdapter } from '../services/types.ts';
+import { buildToolContext, type ToolContext } from '../tools/register.ts';
+import type { WriteAudit } from './audit.ts';
+import { ConfirmTokens } from './confirm.ts';
+import { logger } from './logger.ts';
+import { Sessions } from './session.ts';
+
+/**
+ * Everything a request needs that a config change can invalidate, behind one
+ * swap.
+ *
+ * Before the config UI, `index.ts` read the config once, built the adapters
+ * once, and handed both to `buildApp`, which closed over them — so changing a
+ * service meant restarting the container. Editing config from a web page and
+ * then telling the user to restart it would be a worse experience than the
+ * hand-edited YAML it replaces.
+ *
+ * The swap is one assignment of an immutable snapshot, not a mutation of a
+ * live object. A request that started before a reload finishes against the
+ * snapshot it began with, rather than seeing half of each — which is what
+ * makes "reload while a tool call is in flight" safe without any locking.
+ */
+
+export type RuntimeSnapshot = {
+    config: Config;
+    adapters: readonly ServiceAdapter[];
+    tools: ToolContext;
+};
+
+export class Runtime {
+    #snapshot: RuntimeSnapshot;
+    readonly #configDir: string;
+    readonly #audit: WriteAudit;
+
+    /**
+     * Deliberately outside the snapshot, and so **not** rebuilt on reload.
+     *
+     * Confirmation tokens span two calls by construction, and sessions span
+     * many. Rebuilding either on every config change would mean a config edit
+     * silently invalidated an in-flight write confirmation, or logged the
+     * person making the edit out of the page they were editing from. Neither
+     * is a safety property: the permission check runs again at confirm time
+     * against the *new* config, so a revoked permission is still enforced.
+     */
+    readonly confirm: ConfirmTokens;
+    readonly sessions: Sessions;
+
+    private constructor(configDir: string, audit: WriteAudit, config: Config) {
+        this.#configDir = configDir;
+        this.#audit = audit;
+        this.confirm = new ConfirmTokens();
+        this.sessions = new Sessions();
+        this.#snapshot = buildSnapshot(config, audit, this.confirm);
+    }
+
+    static async start(configDir: string, audit: WriteAudit): Promise<{ runtime: Runtime; created: boolean }> {
+        const { config, created, generated } = await loadConfig(configDir);
+        const runtime = new Runtime(configDir, audit, config);
+        runtime.printCredentials(generated);
+        return { runtime, created };
+    }
+
+    /**
+     * A runtime around a config already in hand, without reading the disk.
+     *
+     * `adapters` overrides what would be built from the config, which is the
+     * same seam every adapter already offers with its injectable `fetch`: it
+     * lets a test drive real tool code against a fake service. A reload
+     * rebuilds from config as normal, so the override is a starting state, not
+     * a permanent replacement.
+     *
+     * `reload()` works if `configDir` names a real directory; with the default
+     * it will fail, which is correct — a runtime that never read a file has
+     * nothing to re-read.
+     */
+    static fromConfig(
+        config: Config,
+        audit: WriteAudit,
+        opts: { configDir?: string; adapters?: readonly ServiceAdapter[] } = {}
+    ): Runtime {
+        const runtime = new Runtime(opts.configDir ?? '', audit, config);
+        if (opts.adapters !== undefined) {
+            runtime.#snapshot = {
+                config,
+                adapters: opts.adapters,
+                tools: buildToolContext(opts.adapters, config, audit, runtime.confirm)
+            };
+        }
+        return runtime;
+    }
+
+    get current(): RuntimeSnapshot {
+        return this.#snapshot;
+    }
+
+    get config(): Config {
+        return this.#snapshot.config;
+    }
+
+    /** Where config.yaml lives, so the config UI writes to the same directory
+     *  this runtime reloads from rather than deriving it a second time. */
+    get configDir(): string {
+        return this.#configDir;
+    }
+
+    /**
+     * Re-reads config.yaml and rebuilds everything derived from it.
+     *
+     * Throws rather than half-applying: `loadConfig` validates, so a config
+     * that would not start the process does not replace one that is working.
+     * The caller reports the error to whoever tried to save it.
+     */
+    async reload(): Promise<void> {
+        const { config } = await loadConfig(this.#configDir);
+        this.#snapshot = buildSnapshot(config, this.#audit, this.confirm);
+        logger.info({ services: this.#snapshot.adapters.map(a => a.id) }, 'configuration reloaded');
+    }
+
+    /** Printed once, on the run that generates them — the password cannot be
+     *  recovered afterwards, only replaced. */
+    printCredentials(generated: { bearerToken?: string; password?: string; username?: string }): void {
+        if (generated.password !== undefined) {
+            logger.info(
+                { username: generated.username ?? 'admin', password: generated.password },
+                'config UI credentials — this password is not stored and will not be shown again'
+            );
+        }
+        if (generated.bearerToken !== undefined) {
+            logger.info({ token: generated.bearerToken }, 'bearer token for /mcp — also shown in the config UI');
+        }
+    }
+}
+
+function buildSnapshot(config: Config, audit: WriteAudit, confirm: ConfirmTokens): RuntimeSnapshot {
+    const adapters = buildAdapters(config);
+    return { config, adapters, tools: buildToolContext(adapters, config, audit, confirm) };
+}

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -1,0 +1,184 @@
+import { createHmac, randomBytes, scryptSync, timingSafeEqual } from 'node:crypto';
+
+/**
+ * Password storage and browser sessions for the config UI.
+ *
+ * The UI is a bigger target than the MCP endpoint: it shows every service's API
+ * key and can change them. So the password is never stored — only a scrypt
+ * hash — and the session cookie is a signed, expiring token rather than an
+ * identifier looked up in a table, which keeps the transport as stateless as
+ * §5 asks while still expiring properly.
+ */
+
+/** scrypt parameters. N=16384 is the Node default and costs ~50ms here, which
+ *  is the point: it makes a stolen hash expensive to attack, and a login form
+ *  is not a hot path. */
+const SCRYPT_N = 16_384;
+const KEY_LENGTH = 64;
+
+export const SESSION_COOKIE = 'arr_mcp_session';
+
+/** Long enough not to interrupt a config edit; short enough that a forgotten
+ *  browser on a shared machine stops mattering the same day. */
+export const SESSION_TTL_MS = 12 * 60 * 60 * 1000;
+
+/** `scrypt$<saltHex>$<hashHex>`, so the format names its own algorithm and a
+ *  future change can be detected rather than guessed. */
+export function hashPassword(password: string): string {
+    const salt = randomBytes(16);
+    const hash = scryptSync(password, salt, KEY_LENGTH, { N: SCRYPT_N });
+    return `scrypt$${salt.toString('hex')}$${hash.toString('hex')}`;
+}
+
+export function verifyPassword(password: string, stored: string): boolean {
+    const [scheme, saltHex, hashHex] = stored.split('$');
+    if (scheme !== 'scrypt' || saltHex === undefined || hashHex === undefined) return false;
+
+    let expected: Buffer;
+    try {
+        expected = Buffer.from(hashHex, 'hex');
+    } catch {
+        return false;
+    }
+    if (expected.length !== KEY_LENGTH) return false;
+
+    const actual = scryptSync(password, Buffer.from(saltHex, 'hex'), KEY_LENGTH, { N: SCRYPT_N });
+    return timingSafeEqual(actual, expected);
+}
+
+/** A readable password someone can retype from a terminal without misreading
+ *  it. No `l`, `1`, `O` or `0`; length carries the entropy instead (~93 bits). */
+const ALPHABET = 'abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+
+/** 32 random bytes as hex — the 64 characters `ConfigSchema` requires, and the
+ *  same shape `loadConfig` generates on first run. */
+export const generateBearerToken = (): string => randomBytes(32).toString('hex');
+
+export function generatePassword(length = 18): string {
+    const bytes = randomBytes(length);
+    let out = '';
+    for (const byte of bytes) out += ALPHABET[byte % ALPHABET.length];
+    return out;
+}
+
+export type SessionVerdict = { valid: true } | { valid: false; reason: 'malformed' | 'expired' | 'bad-signature' };
+
+/**
+ * Signed cookies over a server-side session table, deliberately.
+ *
+ * A table would have to live somewhere — memory, which loses every session on
+ * the restart a config change already causes, or SQLite, which is a third
+ * database for something with no audit value. A signed token needs neither,
+ * and the key being per-process means a restart invalidates outstanding
+ * sessions, which is the correct behaviour after the credentials may have
+ * changed.
+ */
+export class Sessions {
+    readonly #key: Buffer;
+    readonly #ttlMs: number;
+    readonly #now: () => number;
+
+    constructor(opts: { ttlMs?: number; now?: () => number; key?: Buffer } = {}) {
+        this.#key = opts.key ?? randomBytes(32);
+        this.#ttlMs = opts.ttlMs ?? SESSION_TTL_MS;
+        this.#now = opts.now ?? Date.now;
+    }
+
+    /**
+     * `<expiresAt base36>.<nonce>.<hmac>` — the expiry is in the clear because
+     * it is signed, so editing it invalidates the token rather than extending
+     * it.
+     *
+     * The nonce is what makes each session distinct. Without it the token is a
+     * pure function of its expiry, so every sign-in within the same
+     * millisecond produces the *same* token — which a test caught. That is not
+     * an authentication hole on its own (any valid token grants access, and
+     * there are no per-user identities here), but it makes the CSRF binding
+     * below meaningless between colliding sessions, and it means signing out
+     * of one browser would hand the same string to the next.
+     */
+    issue(): string {
+        const expiresAt = this.#now() + this.#ttlMs;
+        const nonce = randomBytes(12).toString('base64url');
+        return `${expiresAt.toString(36)}.${nonce}.${this.#sign(expiresAt, nonce)}`;
+    }
+
+    verify(token: string | undefined): SessionVerdict {
+        if (token === undefined || token === '') return { valid: false, reason: 'malformed' };
+
+        const parts = token.split('.');
+        if (parts.length !== 3) return { valid: false, reason: 'malformed' };
+
+        const expiresAt = Number.parseInt(parts[0] ?? '', 36);
+        const nonce = parts[1] ?? '';
+        const signature = parts[2] ?? '';
+        if (!Number.isFinite(expiresAt) || nonce === '' || signature === '') {
+            return { valid: false, reason: 'malformed' };
+        }
+
+        // Signature before expiry: an unsigned guess must not learn whether a
+        // given expiry is in range.
+        if (!constantTimeEquals(signature, this.#sign(expiresAt, nonce))) {
+            return { valid: false, reason: 'bad-signature' };
+        }
+        if (this.#now() >= expiresAt) return { valid: false, reason: 'expired' };
+
+        return { valid: true };
+    }
+
+    /**
+     * A CSRF token bound to the session cookie, so a form stolen from one
+     * session cannot be replayed in another. SameSite=Strict already blocks
+     * the common case; this covers the rest, and costs one hidden input.
+     */
+    csrfFor(sessionToken: string): string {
+        return createHmac('sha256', this.#key).update(`csrf\n${sessionToken}`).digest('base64url');
+    }
+
+    csrfValid(sessionToken: string | undefined, presented: string | undefined): boolean {
+        if (sessionToken === undefined || presented === undefined) return false;
+        return constantTimeEquals(presented, this.csrfFor(sessionToken));
+    }
+
+    #sign(expiresAt: number, nonce: string): string {
+        // Newline separated so a nonce cannot be shifted into the expiry to
+        // forge a different pair with the same signature.
+        return createHmac('sha256', this.#key).update(`${expiresAt}\n${nonce}`).digest('base64url');
+    }
+}
+
+/** Tolerates unequal lengths without leaking them by timing. */
+export function constantTimeEquals(a: string, b: string): boolean {
+    const left = Buffer.from(a);
+    const right = Buffer.from(b);
+    if (left.length !== right.length) {
+        timingSafeEqual(right, right);
+        return false;
+    }
+    return timingSafeEqual(left, right);
+}
+
+/** Minimal cookie parser — the UI sets one cookie and reads one cookie, and a
+ *  dependency for that would be a dependency to audit. */
+export function readCookie(header: string | undefined, name: string): string | undefined {
+    if (header === undefined) return undefined;
+    for (const part of header.split(';')) {
+        const index = part.indexOf('=');
+        if (index === -1) continue;
+        if (part.slice(0, index).trim() === name) return decodeURIComponent(part.slice(index + 1).trim());
+    }
+    return undefined;
+}
+
+/**
+ * `Secure` is deliberately absent: this is reached over plain http:// on a LAN
+ * by design (the README tells people to use http on the LAN), and a Secure
+ * cookie would simply never be stored, locking everyone out. HttpOnly and
+ * SameSite=Strict are what actually matter here.
+ */
+export function sessionCookie(token: string, maxAgeSeconds: number): string {
+    return `${SESSION_COOKIE}=${encodeURIComponent(token)}; Path=/; HttpOnly; SameSite=Strict; Max-Age=${maxAgeSeconds}`;
+}
+
+export const clearedSessionCookie = (): string =>
+    `${SESSION_COOKIE}=; Path=/; HttpOnly; SameSite=Strict; Max-Age=0`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,35 +1,41 @@
 import { serve } from '@hono/node-server';
 import { buildApp } from './app.ts';
-import { loadConfig } from './config/load.ts';
 import { WriteAudit } from './core/audit.ts';
+import { attachLogStore } from './core/logger.ts';
 import { logger } from './core/logger.ts';
-import { buildAdapters } from './services/registry.ts';
+import { LogStore } from './core/logs.ts';
+import { Runtime } from './core/runtime.ts';
 
 const CONFIG_DIR = process.env.ARR_MCP_CONFIG_DIR ?? '/config';
 const PORT = Number(process.env.ARR_MCP_PORT ?? 6060);
 
-const { config, created } = await loadConfig(CONFIG_DIR);
-
-if (created) {
-    // The token is the only way in and there is no UI until Phase 5, so it has
-    // to be discoverable from `docker logs` on first start.
-    logger.info({ token: config.auth.bearer_token }, 'first run — use this bearer token for /mcp');
-}
-
-const adapters = buildAdapters(config);
+// Attached before anything else runs, so startup lines — including the
+// generated credentials and any config error — are in the ring buffer the
+// config UI reads, not only on stdout.
+const logs = LogStore.open(CONFIG_DIR);
+attachLogStore(logs);
 
 // Opened at startup, not lazily on the first write: a config volume that
 // cannot hold the audit trail should be a loud failure now, while someone is
 // watching `docker logs`, rather than the first time they ask for a deletion.
 const audit = WriteAudit.open(CONFIG_DIR);
 
-if (adapters.length === 0) {
+const { runtime, created } = await Runtime.start(CONFIG_DIR, audit);
+
+if (created) {
+    logger.info({ config: `${CONFIG_DIR}/config.yaml` }, 'first run — sign in to the config UI to add services');
+}
+
+if (runtime.current.adapters.length === 0) {
     logger.warn(
         { config: `${CONFIG_DIR}/config.yaml` },
-        'no services configured — stack_health will return an empty result until you add one'
+        'no services configured — add them in the config UI, or edit config.yaml'
     );
 }
 
-serve({ fetch: buildApp({ config, adapters, audit }).fetch, port: PORT, hostname: '0.0.0.0' }, info => {
-    logger.info({ port: info.port, adapters: adapters.map(a => a.id) }, 'arr-mcp listening');
+serve({ fetch: buildApp({ runtime, audit, logs }).fetch, port: PORT, hostname: '0.0.0.0' }, info => {
+    logger.info(
+        { port: info.port, adapters: runtime.current.adapters.map(a => a.id) },
+        'arr-mcp listening — config UI at /ui'
+    );
 });

--- a/src/tools/register.ts
+++ b/src/tools/register.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/server';
 import type { Config } from '../config/schema.ts';
 import type { WriteAudit } from '../core/audit.ts';
-import { ConfirmTokens } from '../core/confirm.ts';
+import type { ConfirmTokens } from '../core/confirm.ts';
 import { IdentityResolver } from '../core/identity.ts';
 import { permissionSourceFrom } from '../core/permissions.ts';
 import { JellyfinAdapter } from '../services/jellyfin.ts';
@@ -47,10 +47,16 @@ export type ToolContext = {
     write: WriteContext;
 };
 
+/**
+ * `confirm` is supplied rather than created here: it outlives a config reload
+ * on purpose (see `core/runtime.ts`), because a confirmation handshake spans
+ * two calls and a config edit between them must not silently invalidate it.
+ */
 export function buildToolContext(
     adapters: readonly ServiceAdapter[],
     config: Config,
-    audit: WriteAudit
+    audit: WriteAudit,
+    confirm: ConfirmTokens
 ): ToolContext {
     const jellyfin = adapters.find((a): a is JellyfinAdapter => a instanceof JellyfinAdapter);
     const seerr = adapters.find((a): a is SeerrAdapter => a instanceof SeerrAdapter);
@@ -75,7 +81,7 @@ export function buildToolContext(
             // must answer from the file, so an adapter cannot widen its own
             // permissions by reporting a capability it was never granted.
             permissions: permissionSourceFrom(config.services),
-            confirm: new ConfirmTokens(),
+            confirm,
             audit,
             library
         }

--- a/src/web/assets.ts
+++ b/src/web/assets.ts
@@ -1,0 +1,214 @@
+/**
+ * CSS and JS as exported strings, served from memory.
+ *
+ * Not files on disk: the Dockerfile copies `src` and runs `tsc`, and tsc does
+ * not emit non-TypeScript files — so a `public/` directory would be silently
+ * absent from the image while working perfectly in development. Keeping the
+ * assets in modules means the thing that is tested is the thing that ships.
+ *
+ * There is no build step and no framework, by design. The page is server
+ * rendered; this is the small amount of behaviour that genuinely needs a
+ * client — polling the log stream and copying the token.
+ */
+
+export const CSS = `
+:root {
+  --bg: #12141a; --panel: #1a1d26; --panel-2: #21252f; --line: #2c313d;
+  --text: #e6e8ee; --dim: #9aa2b1; --accent: #6ea8fe;
+  --ok: #4ade80; --warn: #fbbf24; --bad: #f87171;
+  --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+@media (prefers-color-scheme: light) {
+  :root {
+    --bg: #f6f7f9; --panel: #fff; --panel-2: #f0f2f5; --line: #d9dee7;
+    --text: #1a1d26; --dim: #5b6472; --accent: #1a56db;
+  }
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0; background: var(--bg); color: var(--text);
+  font: 15px/1.5 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+}
+a { color: var(--accent); }
+header {
+  display: flex; align-items: center; gap: 1.5rem; flex-wrap: wrap;
+  padding: .9rem 1.25rem; background: var(--panel); border-bottom: 1px solid var(--line);
+}
+header h1 { font-size: 1rem; margin: 0; letter-spacing: .02em; }
+header h1 span { color: var(--dim); font-weight: 400; }
+nav { display: flex; gap: .25rem; flex: 1; flex-wrap: wrap; }
+nav a {
+  padding: .35rem .7rem; border-radius: 6px; text-decoration: none;
+  color: var(--dim); font-size: .9rem;
+}
+nav a:hover { background: var(--panel-2); color: var(--text); }
+nav a.on { background: var(--panel-2); color: var(--text); }
+main { max-width: 1100px; margin: 0 auto; padding: 1.5rem 1.25rem 4rem; }
+h2 { font-size: 1.05rem; margin: 2rem 0 .75rem; }
+h2:first-child { margin-top: 0; }
+p.note { color: var(--dim); font-size: .9rem; margin: .35rem 0 1rem; }
+.panel {
+  background: var(--panel); border: 1px solid var(--line);
+  border-radius: 10px; padding: 1rem 1.1rem; margin-bottom: 1rem;
+}
+.grid { display: grid; gap: .85rem; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); }
+.card { background: var(--panel); border: 1px solid var(--line); border-radius: 10px; padding: .9rem 1rem; }
+.card h3 { margin: 0 0 .4rem; font-size: .95rem; display: flex; align-items: center; gap: .5rem; }
+.card dl { margin: .5rem 0 0; display: grid; grid-template-columns: auto 1fr; gap: .2rem .75rem; font-size: .88rem; }
+.card dt { color: var(--dim); }
+.card dd { margin: 0; word-break: break-word; }
+.dot { width: .6rem; height: .6rem; border-radius: 50%; display: inline-block; flex: none; }
+.dot.ok { background: var(--ok); } .dot.bad { background: var(--bad); } .dot.off { background: var(--dim); }
+.remedy {
+  margin-top: .6rem; padding: .5rem .6rem; border-left: 3px solid var(--warn);
+  background: var(--panel-2); border-radius: 0 6px 6px 0; font-size: .85rem; color: var(--text);
+}
+table { width: 100%; border-collapse: collapse; font-size: .87rem; }
+th, td { text-align: left; padding: .45rem .6rem; border-bottom: 1px solid var(--line); vertical-align: top; }
+th { color: var(--dim); font-weight: 500; position: sticky; top: 0; background: var(--panel); }
+td.mono, .mono { font-family: var(--mono); font-size: .85em; }
+tr.lvl-40 td { color: var(--warn); } tr.lvl-50 td, tr.lvl-60 td { color: var(--bad); }
+.scroll { max-height: 65vh; overflow: auto; border: 1px solid var(--line); border-radius: 10px; background: var(--panel); }
+form.inline { display: flex; gap: .5rem; flex-wrap: wrap; align-items: end; margin-bottom: 1rem; }
+label { display: block; font-size: .85rem; color: var(--dim); margin-bottom: .2rem; }
+input, select, textarea {
+  background: var(--panel-2); color: var(--text); border: 1px solid var(--line);
+  border-radius: 7px; padding: .45rem .6rem; font: inherit; min-width: 0;
+}
+input:focus, select:focus, textarea:focus { outline: 2px solid var(--accent); outline-offset: -1px; }
+input[type=checkbox] { min-width: auto; }
+button {
+  background: var(--accent); color: #fff; border: 0; border-radius: 7px;
+  padding: .5rem .9rem; font: inherit; cursor: pointer;
+}
+button.ghost { background: var(--panel-2); color: var(--text); border: 1px solid var(--line); }
+button:hover { filter: brightness(1.1); }
+.row { display: flex; gap: .5rem; align-items: center; flex-wrap: wrap; }
+.msg { padding: .7rem .9rem; border-radius: 8px; margin-bottom: 1rem; font-size: .9rem; }
+.msg.ok { background: #14351f; color: #b7f7cd; }
+.msg.err { background: #3a1618; color: #ffc9cc; white-space: pre-wrap; }
+@media (prefers-color-scheme: light) {
+  .msg.ok { background: #dcfce7; color: #14532d; }
+  .msg.err { background: #fee2e2; color: #7f1d1d; }
+}
+.login { max-width: 380px; margin: 12vh auto; }
+.login .panel { padding: 1.5rem; }
+.field { margin-bottom: .9rem; }
+.field input { width: 100%; }
+fieldset { border: 1px solid var(--line); border-radius: 10px; padding: .9rem 1rem; margin: 0 0 1rem; }
+legend { padding: 0 .4rem; color: var(--dim); font-size: .85rem; }
+.svc-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: .75rem; }
+.token { display: flex; gap: .5rem; align-items: center; }
+.token input { flex: 1; font-family: var(--mono); font-size: .8rem; }
+`;
+
+/**
+ * Two behaviours, both of which genuinely need a client: copying a secret to
+ * the clipboard, and refreshing the log table without losing scroll position.
+ * Everything else is a form post and a server render.
+ */
+export const JS = `
+document.addEventListener('click', async (e) => {
+  const btn = e.target.closest('[data-copy]');
+  if (!btn) return;
+  const input = document.getElementById(btn.dataset.copy);
+  if (!input) return;
+  try {
+    await navigator.clipboard.writeText(input.value);
+  } catch {
+    // Clipboard API needs a secure context, and this is deliberately served
+    // over http on a LAN — so fall back to selecting the text for the user.
+    input.removeAttribute('readonly');
+    input.select();
+    input.setAttribute('readonly', '');
+  }
+  const original = btn.textContent;
+  btn.textContent = 'Copied';
+  setTimeout(() => { btn.textContent = original; }, 1200);
+});
+
+// Reveal a secret only on request, so a screenshot or a shoulder does not
+// capture every API key on the page by default.
+document.addEventListener('click', (e) => {
+  const btn = e.target.closest('[data-reveal]');
+  if (!btn) return;
+  const input = document.getElementById(btn.dataset.reveal);
+  if (!input) return;
+  const hidden = input.type === 'password';
+  input.type = hidden ? 'text' : 'password';
+  btn.textContent = hidden ? 'Hide' : 'Show';
+});
+
+// The log stream polls JSON and builds rows with textContent — never
+// innerHTML.
+//
+// Every other part of this page is server-rendered through an escaping
+// template, and that is sound. This one is different in kind: log lines carry
+// release names straight from public indexers, which are the most
+// attacker-controllable strings in the whole system (design spec §11). Setting
+// innerHTML here would make one escaping mistake, anywhere in the server-side
+// rendering path, an XSS. Building nodes and assigning textContent makes that
+// impossible rather than merely unlikely.
+const stream = document.getElementById('log-stream');
+if (stream) {
+  const follow = document.getElementById('follow');
+
+  const cell = (text, className) => {
+    const td = document.createElement('td');
+    td.textContent = text == null ? '' : String(text);
+    if (className) td.className = className;
+    return td;
+  };
+
+  const render = (rows) => {
+    const table = document.createElement('table');
+    const head = document.createElement('thead');
+    const hr = document.createElement('tr');
+    for (const label of ['Time', 'Level', 'Service', 'Message']) {
+      const th = document.createElement('th');
+      th.textContent = label;
+      hr.appendChild(th);
+    }
+    head.appendChild(hr);
+    table.appendChild(head);
+
+    const body = document.createElement('tbody');
+    for (const row of rows) {
+      const tr = document.createElement('tr');
+      tr.className = 'lvl-' + row.level;
+      tr.appendChild(cell(row.at, 'mono'));
+      tr.appendChild(cell(row.levelName));
+      tr.appendChild(cell(row.service || '—'));
+      tr.appendChild(cell(row.msg));
+      body.appendChild(tr);
+    }
+    table.appendChild(body);
+
+    if (rows.length === 0) {
+      const empty = document.createElement('p');
+      empty.className = 'note';
+      empty.textContent = 'Nothing logged yet for this filter.';
+      stream.replaceChildren(empty);
+      return;
+    }
+    stream.replaceChildren(table);
+  };
+
+  const tick = async () => {
+    if (follow && !follow.checked) return;
+    try {
+      const res = await fetch(stream.dataset.url, { headers: { accept: 'application/json' } });
+      if (!res.ok) return;
+      const data = await res.json();
+      // Scroll position is restored because the container scrolls, not the
+      // body — otherwise every poll would jump to the top while reading.
+      const top = stream.scrollTop;
+      render(Array.isArray(data.rows) ? data.rows : []);
+      stream.scrollTop = top;
+    } catch { /* a poll that fails is retried on the next tick */ }
+  };
+
+  const timer = setInterval(tick, 4000);
+  window.addEventListener('beforeunload', () => clearInterval(timer));
+}
+`;

--- a/src/web/configPage.ts
+++ b/src/web/configPage.ts
@@ -1,0 +1,204 @@
+import { ServiceIdSchema, type Config, type ServiceId } from '../config/schema.ts';
+import { html, raw, type SafeHtml } from './html.ts';
+import { layout } from './pages.ts';
+
+/**
+ * The configuration form.
+ *
+ * One rule shapes the whole page: **a secret is never rendered back**. API
+ * keys, the Transmission password and the UI password all render as empty
+ * fields that mean "unchanged", so a saved page, a screenshot or a browser's
+ * autofill history cannot carry them. That also means an empty field can never
+ * mean "clear this" — clearing is done by disabling the service, which is
+ * unambiguous.
+ */
+
+export const SERVICE_IDS = ServiceIdSchema.options;
+
+/** Which extra fields each service actually has, so the form matches the
+ *  schema rather than showing eight identical boxes. */
+const MULTI_USER: ReadonlySet<string> = new Set(['jellyfin', 'seerr']);
+const NO_API_KEY: ReadonlySet<string> = new Set(['transmission']);
+
+type AnyService = {
+    url: string;
+    timeout_ms: number;
+    permissions: { safe_write: boolean; destructive: boolean };
+    api_key?: string;
+    default_user?: string;
+    allow_other_users?: boolean;
+    username?: string;
+    password?: string;
+};
+
+const field = (opts: {
+    id: string;
+    name: string;
+    label: string;
+    value?: string | number | undefined;
+    type?: string;
+    placeholder?: string;
+    note?: string;
+}): SafeHtml => html`<div class="field">
+    <label for="${opts.id}">${opts.label}</label>
+    <input
+        id="${opts.id}"
+        name="${opts.name}"
+        type="${opts.type ?? 'text'}"
+        value="${opts.value ?? ''}"
+        placeholder="${opts.placeholder ?? ''}"
+        autocomplete="off"
+    >
+    ${opts.note === undefined ? raw('') : html`<p class="note">${opts.note}</p>`}
+</div>`;
+
+const checkbox = (id: string, name: string, label: string, checked: boolean): SafeHtml =>
+    html`<label class="row" style="margin:.25rem 0">
+        <input type="checkbox" id="${id}" name="${name}" ${checked ? raw('checked') : raw('')}> ${label}
+    </label>`;
+
+function serviceFieldset(id: ServiceId, service: AnyService | undefined): SafeHtml {
+    const on = service !== undefined;
+    const p = `svc.${id}`;
+
+    return html`<fieldset>
+        <legend>${id}</legend>
+        ${checkbox(`${p}.enabled`, `${p}.enabled`, `Configure ${id}`, on)}
+        ${field({
+            id: `${p}.url`,
+            name: `${p}.url`,
+            label: 'URL',
+            value: service?.url ?? '',
+            placeholder: 'http://192.168.1.20:7878'
+        })}
+        ${NO_API_KEY.has(id)
+            ? html`${field({
+                  id: `${p}.username`,
+                  name: `${p}.username`,
+                  label: 'Username (optional)',
+                  value: service?.username ?? ''
+              })}
+              ${field({
+                  id: `${p}.password`,
+                  name: `${p}.password`,
+                  label: 'Password',
+                  type: 'password',
+                  placeholder: on ? 'unchanged' : '',
+                  note: 'Leave blank to keep the current password.'
+              })}`
+            : field({
+                  id: `${p}.api_key`,
+                  name: `${p}.api_key`,
+                  label: 'API key',
+                  type: 'password',
+                  placeholder: on ? 'unchanged' : '',
+                  note: on ? 'Leave blank to keep the current key.' : "From the service's Settings → General page."
+              })}
+        ${MULTI_USER.has(id)
+            ? html`${field({
+                  id: `${p}.default_user`,
+                  name: `${p}.default_user`,
+                  label: 'Default user',
+                  value: service?.default_user ?? '',
+                  note:
+                      id === 'jellyfin'
+                          ? 'Required if Jellyfin is configured — get_library, get_media_details and diagnose all need it.'
+                          : 'Optional.'
+              })}
+              ${checkbox(
+                  `${p}.allow_other_users`,
+                  `${p}.allow_other_users`,
+                  'Allow answering as other users',
+                  service?.allow_other_users ?? false
+              )}`
+            : raw('')}
+        ${field({
+            id: `${p}.timeout_ms`,
+            name: `${p}.timeout_ms`,
+            label: 'Timeout (ms)',
+            type: 'number',
+            value: service?.timeout_ms ?? 10_000
+        })}
+        <p class="note" style="margin-top:.75rem">Writes — both off by default.</p>
+        ${checkbox(
+            `${p}.safe_write`,
+            `${p}.safe_write`,
+            'safe_write — searches, monitoring, request verdicts',
+            service?.permissions.safe_write ?? false
+        )}
+        ${checkbox(
+            `${p}.destructive`,
+            `${p}.destructive`,
+            'destructive — deletes files, queue items and requests (implies safe_write)',
+            service?.permissions.destructive ?? false
+        )}
+    </fieldset>`;
+}
+
+export function configPage(opts: {
+    version: string;
+    config: Config;
+    csrf: string;
+    message?: { kind: 'ok' | 'err'; text: string } | undefined;
+}): string {
+    const services = opts.config.services as Partial<Record<ServiceId, AnyService>>;
+
+    const body = html`<form method="post" action="/ui/config">
+        <input type="hidden" name="csrf" value="${opts.csrf}">
+
+        <h2>Services</h2>
+        <p class="note">
+            Saving applies immediately — no restart. Configure only what you run; anything left off is simply
+            absent, not broken.
+        </p>
+        <div class="svc-grid">${SERVICE_IDS.map(id => serviceFieldset(id, services[id]))}</div>
+
+        <h2>Access</h2>
+        <fieldset>
+            <legend>Config UI</legend>
+            ${field({
+                id: 'auth.username',
+                name: 'auth.username',
+                label: 'Username',
+                value: opts.config.auth.username
+            })}
+            ${field({
+                id: 'auth.password',
+                name: 'auth.password',
+                label: 'New password',
+                type: 'password',
+                placeholder: 'unchanged',
+                note: 'Leave blank to keep the current password. Only a hash is stored — it cannot be read back.'
+            })}
+        </fieldset>
+
+        <fieldset>
+            <legend>MCP endpoint</legend>
+            ${checkbox('auth.rotate_token', 'auth.rotate_token', 'Generate a new bearer token', false)}
+            <p class="note">
+                Rotating invalidates the current token immediately; every MCP client will need the new one,
+                which appears on the dashboard.
+            </p>
+            ${field({
+                id: 'auth.allowed_hosts',
+                name: 'auth.allowed_hosts',
+                label: 'Allowed hosts (comma separated)',
+                value: opts.config.auth.allowed_hosts.join(', '),
+                note: 'Leave empty to accept any Host — right for a LAN container reached by IP. Changing this one needs a restart.'
+            })}
+        </fieldset>
+
+        <div class="row">
+            <button type="submit">Save and apply</button>
+            <a href="/ui" style="margin-left:.5rem">Cancel</a>
+        </div>
+    </form>`;
+
+    return layout({
+        title: 'Configuration',
+        nav: 'config',
+        version: opts.version,
+        body,
+        ...(opts.message === undefined ? {} : { message: opts.message })
+    });
+}

--- a/src/web/html.ts
+++ b/src/web/html.ts
@@ -1,0 +1,92 @@
+/**
+ * The one place untrusted text becomes HTML.
+ *
+ * Design spec §11 treats everything a service returns as data, never
+ * instruction — and the config UI is where that data stops being JSON in a
+ * model's context and becomes markup in a browser. A release name from a
+ * public indexer reaches the log stream; a film title reaches the audit view.
+ * Both are attacker-controllable, and neither may become a `<script>`.
+ *
+ * `fenceText` is not enough here. It escapes angle brackets for values that
+ * pass through the adapters, but log lines carry raw fields that never did,
+ * and an error message can contain anything. So every interpolation into the
+ * page goes through `esc`, and templates are built by `html` rather than by
+ * string concatenation, so forgetting is something you have to do on purpose.
+ */
+
+const ENTITIES: Record<string, string> = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;'
+};
+
+export function esc(value: unknown): string {
+    if (value === null || value === undefined) return '';
+    return String(value).replace(/[&<>"']/g, character => ENTITIES[character] ?? character);
+}
+
+/**
+ * Markup that is already safe, and says so by construction.
+ *
+ * Wrapping is the only way to opt a string out of escaping, so an unescaped
+ * interpolation is visible at the call site as `raw(...)` rather than being
+ * the silent default.
+ */
+export class SafeHtml {
+    // Written out rather than as a constructor parameter property: Node runs
+    // this project's TypeScript in strip-only mode, which rejects those.
+    readonly value: string;
+
+    constructor(value: string) {
+        this.value = value;
+    }
+
+    toString(): string {
+        return this.value;
+    }
+}
+
+export const raw = (value: string): SafeHtml => new SafeHtml(value);
+
+/**
+ * Tagged template that escapes every interpolation except `SafeHtml`.
+ *
+ * Arrays are joined without separators, so a list of rendered rows can be
+ * dropped straight in — the common case, and one that otherwise invites
+ * `.join('')` on already-stringified markup, which loses the safety marker.
+ */
+export function html(strings: TemplateStringsArray, ...values: unknown[]): SafeHtml {
+    let out = strings[0] ?? '';
+    for (let i = 0; i < values.length; i += 1) {
+        out += render(values[i]) + (strings[i + 1] ?? '');
+    }
+    return new SafeHtml(out);
+}
+
+function render(value: unknown): string {
+    if (value instanceof SafeHtml) return value.value;
+    if (Array.isArray(value)) return value.map(render).join('');
+    return esc(value);
+}
+
+/** Bytes as something a person reads, for disk-space displays. */
+export function humanBytes(bytes: number | undefined): string {
+    if (bytes === undefined || !Number.isFinite(bytes)) return '—';
+    const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
+    let value = bytes;
+    let unit = 0;
+    while (value >= 1024 && unit < units.length - 1) {
+        value /= 1024;
+        unit += 1;
+    }
+    // One decimal below 100 in any scaled unit: "24.1 GB" is the difference
+    // between two films and three, and "512 KB" gains nothing from ".0".
+    return `${unit > 0 && value < 100 ? value.toFixed(1) : Math.round(value)} ${units[unit]}`;
+}
+
+/** An ISO timestamp as something scannable in a log table. */
+export function shortTime(iso: string): string {
+    return iso.replace('T', ' ').replace(/\.\d+Z?$/, '').replace('Z', '');
+}

--- a/src/web/pages.ts
+++ b/src/web/pages.ts
@@ -1,0 +1,292 @@
+import type { ServiceId } from '../config/schema.ts';
+import type { LogRow } from '../core/logs.ts';
+import type { ConnectionDiagnosis } from '../services/types.ts';
+import { esc, html, humanBytes, raw, shortTime, type SafeHtml } from './html.ts';
+
+/**
+ * Every page, server rendered. No client framework and no build step — the
+ * only JavaScript is `assets.ts`, and every page here works without it except
+ * the log auto-refresh.
+ */
+
+export type Nav = 'dashboard' | 'config' | 'logs' | 'audit';
+
+const NAV: { key: Nav; href: string; label: string }[] = [
+    { key: 'dashboard', href: '/ui', label: 'Dashboard' },
+    { key: 'config', href: '/ui/config', label: 'Configuration' },
+    { key: 'logs', href: '/ui/logs', label: 'Logs' },
+    { key: 'audit', href: '/ui/audit', label: 'Write audit' }
+];
+
+export function layout(opts: {
+    title: string;
+    nav?: Nav;
+    version: string;
+    body: SafeHtml;
+    message?: { kind: 'ok' | 'err'; text: string } | undefined;
+}): string {
+    const message =
+        opts.message === undefined
+            ? raw('')
+            : html`<div class="msg ${opts.message.kind}">${opts.message.text}</div>`;
+
+    const nav =
+        opts.nav === undefined
+            ? raw('')
+            : html`<nav>
+                  ${NAV.map(
+                      item => html`<a href="${item.href}" class="${item.key === opts.nav ? 'on' : ''}">${item.label}</a>`
+                  )}
+              </nav>
+              <form method="post" action="/ui/logout"><button class="ghost" type="submit">Sign out</button></form>`;
+
+    return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${esc(opts.title)} · arr-mcp</title>
+<link rel="stylesheet" href="/ui/app.css">
+</head>
+<body>
+<header><h1>arr-mcp <span>${esc(opts.version)}</span></h1>${nav}</header>
+<main>${message}${opts.body}</main>
+<script src="/ui/app.js" defer></script>
+</body>
+</html>`;
+}
+
+export function loginPage(opts: { version: string; error?: string | undefined }): string {
+    const body = html`<div class="login">
+        <div class="panel">
+            <h2>Sign in</h2>
+            <p class="note">
+                The password was printed to the container log on first start —
+                <span class="mono">docker logs arr-mcp</span>.
+            </p>
+            <form method="post" action="/ui/login">
+                <div class="field">
+                    <label for="username">Username</label>
+                    <input id="username" name="username" autocomplete="username" autofocus required>
+                </div>
+                <div class="field">
+                    <label for="password">Password</label>
+                    <input id="password" name="password" type="password" autocomplete="current-password" required>
+                </div>
+                <button type="submit">Sign in</button>
+            </form>
+        </div>
+    </div>`;
+
+    return layout({
+        title: 'Sign in',
+        version: opts.version,
+        body,
+        ...(opts.error === undefined ? {} : { message: { kind: 'err' as const, text: opts.error } })
+    });
+}
+
+const statusDot = (d: ConnectionDiagnosis): SafeHtml =>
+    html`<span class="dot ${d.ok ? 'ok' : 'bad'}" title="${d.ok ? 'reachable' : 'unreachable'}"></span>`;
+
+/**
+ * A card per service, showing the *diagnosis* rather than a tick or a cross.
+ *
+ * §6/§14: a connection test that returns true/false tells you nothing about
+ * what to fix. `testConnection` already returns kind, detail and remedy — this
+ * is the first surface that shows all three to a human.
+ */
+export function dashboardPage(opts: {
+    version: string;
+    diagnoses: ConnectionDiagnosis[];
+    configured: ServiceId[];
+    bearerToken: string;
+    writeCounts: { applied: number; denied: number; total: number };
+}): string {
+    const cards =
+        opts.diagnoses.length === 0
+            ? html`<p class="note">
+                  No services configured yet. Add one on the
+                  <a href="/ui/config">Configuration</a> page.
+              </p>`
+            : html`<div class="grid">
+                  ${opts.diagnoses.map(
+                      d => html`<div class="card">
+                          <h3>${statusDot(d)} ${d.service}</h3>
+                          <dl>
+                              <dt>Status</dt>
+                              <dd>${d.ok ? 'Reachable' : (d.error?.kind ?? 'Unreachable')}</dd>
+                              <dt>Latency</dt>
+                              <dd>${d.latency_ms} ms</dd>
+                              ${d.version === undefined ? raw('') : html`<dt>Version</dt><dd>${d.version}</dd>`}
+                          </dl>
+                          ${d.ok || d.error === undefined
+                              ? raw('')
+                              : html`<div class="remedy">
+                                    <strong>${d.error.detail}</strong>
+                                    ${d.error.remedy === undefined ? raw('') : html`<br>${d.error.remedy}`}
+                                </div>`}
+                      </div>`
+                  )}
+              </div>`;
+
+    const body = html`<h2>Services</h2>
+        <p class="note">
+            Tested live, just now. A failure shows what to fix rather than only that it failed.
+        </p>
+        ${cards}
+
+        <h2>MCP endpoint</h2>
+        <div class="panel">
+            <p class="note">
+                Point your MCP client at <span class="mono">/mcp</span> on this host and give it this bearer
+                token. It is the same token printed on first start.
+            </p>
+            <div class="token">
+                <input id="bearer" type="password" value="${opts.bearerToken}" readonly>
+                <button class="ghost" type="button" data-reveal="bearer">Show</button>
+                <button class="ghost" type="button" data-copy="bearer">Copy</button>
+            </div>
+        </div>
+
+        <h2>Writes</h2>
+        <div class="panel">
+            <p class="note">
+                Every write attempt is recorded, including the ones that were refused.
+                <a href="/ui/audit">See the full trail</a>.
+            </p>
+            <div class="row">
+                <span><strong>${opts.writeCounts.applied}</strong> applied</span>
+                <span><strong>${opts.writeCounts.denied}</strong> refused</span>
+                <span><strong>${opts.writeCounts.total}</strong> recorded in total</span>
+            </div>
+        </div>`;
+
+    return layout({ title: 'Dashboard', nav: 'dashboard', version: opts.version, body });
+}
+
+export function logsPage(opts: {
+    version: string;
+    services: string[];
+    selectedService: string;
+    minLevel: number;
+    streamUrl: string;
+    rows: LogRow[];
+}): string {
+    const levels: [number, string][] = [
+        [10, 'Everything'],
+        [30, 'Info and above'],
+        [40, 'Warnings and errors'],
+        [50, 'Errors only']
+    ];
+
+    const body = html`<h2>Logs</h2>
+        <p class="note">
+            The last few thousand lines, kept in a ring buffer beside your config. Full history stays in
+            <span class="mono">docker logs</span>.
+        </p>
+
+        <form class="inline" method="get" action="/ui/logs">
+            <div>
+                <label for="level">Level</label>
+                <select id="level" name="level">
+                    ${levels.map(
+                        ([value, label]) =>
+                            html`<option value="${value}" ${value === opts.minLevel ? raw('selected') : raw('')}>
+                                ${label}
+                            </option>`
+                    )}
+                </select>
+            </div>
+            <div>
+                <label for="service">Service</label>
+                <select id="service" name="service">
+                    <option value="">All services</option>
+                    ${opts.services.map(
+                        s =>
+                            html`<option value="${s}" ${s === opts.selectedService ? raw('selected') : raw('')}>
+                                ${s}
+                            </option>`
+                    )}
+                </select>
+            </div>
+            <button type="submit">Apply</button>
+            <label class="row" style="margin:0"><input type="checkbox" id="follow" checked> Auto-refresh</label>
+        </form>
+
+        <div class="scroll" id="log-stream" data-url="${opts.streamUrl}">${logTable(opts.rows)}</div>`;
+
+    return layout({ title: 'Logs', nav: 'logs', version: opts.version, body });
+}
+
+/** The no-JavaScript rendering. The live one is rebuilt client-side from JSON
+ *  with textContent — see assets.ts for why that one is not HTML. */
+export function logTable(rows: LogRow[]): SafeHtml {
+    if (rows.length === 0) return html`<p class="note">Nothing logged yet for this filter.</p>`;
+
+    return html`<table>
+        <thead>
+            <tr><th>Time</th><th>Level</th><th>Service</th><th>Message</th></tr>
+        </thead>
+        <tbody>
+            ${rows.map(
+                r => html`<tr class="lvl-${r.level}">
+                    <td class="mono">${shortTime(r.at)}</td>
+                    <td>${r.levelName}</td>
+                    <td>${r.service ?? '—'}</td>
+                    <td>${r.msg}</td>
+                </tr>`
+            )}
+        </tbody>
+    </table>`;
+}
+
+export type AuditRow = {
+    at: string;
+    tool: string;
+    service: string;
+    operation: string;
+    tier: string;
+    target: string;
+    args: string;
+    outcome: string;
+    detail: string | null;
+};
+
+export function auditPage(opts: { version: string; rows: AuditRow[] }): string {
+    const body = html`<h2>Write audit</h2>
+        <p class="note">
+            Every write attempt, including previews and refusals. A row still reading
+            <span class="mono">attempted</span> means arr-mcp stopped mid-write.
+        </p>
+
+        ${opts.rows.length === 0
+            ? html`<p class="note">Nothing has tried to write yet.</p>`
+            : html`<div class="scroll">
+                  <table>
+                      <thead>
+                          <tr>
+                              <th>Time</th><th>Outcome</th><th>Tool</th><th>Service</th>
+                              <th>Target</th><th>Arguments</th><th>Detail</th>
+                          </tr>
+                      </thead>
+                      <tbody>
+                          ${opts.rows.map(
+                              r => html`<tr>
+                                  <td class="mono">${shortTime(r.at)}</td>
+                                  <td>${r.outcome}</td>
+                                  <td>${r.tool}</td>
+                                  <td>${r.service}</td>
+                                  <td class="mono">${r.target}</td>
+                                  <td class="mono">${r.args}</td>
+                                  <td>${r.detail ?? ''}</td>
+                              </tr>`
+                          )}
+                      </tbody>
+                  </table>
+              </div>`}`;
+
+    return layout({ title: 'Write audit', nav: 'audit', version: opts.version, body });
+}
+
+export { humanBytes };

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -1,0 +1,309 @@
+import type { Context, Hono } from 'hono';
+import { saveConfig } from '../config/save.ts';
+import { ServiceIdSchema, type Config, type ServiceId } from '../config/schema.ts';
+import type { WriteAudit } from '../core/audit.ts';
+import { logger } from '../core/logger.ts';
+import { LEVELS, type LogStore } from '../core/logs.ts';
+import type { Runtime } from '../core/runtime.ts';
+import {
+    clearedSessionCookie,
+    generateBearerToken,
+    hashPassword,
+    readCookie,
+    sessionCookie,
+    SESSION_COOKIE,
+    SESSION_TTL_MS,
+    verifyPassword
+} from '../core/session.ts';
+import { CSS, JS } from './assets.ts';
+import { configPage, SERVICE_IDS } from './configPage.ts';
+import { auditPage, dashboardPage, loginPage, logsPage, type AuditRow } from './pages.ts';
+
+export type WebDeps = { runtime: Runtime; audit: WriteAudit; logs: LogStore; name: string; version: string };
+
+/**
+ * The config UI (design spec §6): a dashboard, connection tests that diagnose
+ * rather than pass/fail, log streams, the write audit, and configuration
+ * editing that applies without a restart.
+ *
+ * Server rendered, no build step. The only client JavaScript polls the log
+ * stream and copies the bearer token.
+ */
+export function registerWebRoutes(app: Hono, deps: WebDeps): void {
+    const { runtime, audit, logs, version } = deps;
+
+    // --- assets ---------------------------------------------------------
+    //
+    // Unauthenticated on purpose: they are constants compiled into the binary
+    // and reveal nothing. Requiring a session for the stylesheet would make
+    // the login page render unstyled, which looks broken.
+    app.get('/ui/app.css', c => c.body(CSS, 200, { 'content-type': 'text/css; charset=utf-8', ...CACHE }));
+    app.get('/ui/app.js', c => c.body(JS, 200, { 'content-type': 'text/javascript; charset=utf-8', ...CACHE }));
+
+    // --- login ----------------------------------------------------------
+
+    app.get('/ui/login', c => {
+        if (sessionOf(c, runtime) !== undefined) return c.redirect('/ui', 302);
+        return c.html(loginPage({ version }));
+    });
+
+    app.post('/ui/login', async c => {
+        const form = await c.req.parseBody();
+        const username = str(form.username);
+        const password = str(form.password);
+        const auth = runtime.config.auth;
+
+        // One message for both wrong-username and wrong-password, and the
+        // password check runs either way: a login form that answers faster for
+        // an unknown user tells an attacker which names exist.
+        const nameOk = username === auth.username;
+        const passOk = verifyPassword(password, auth.password_hash);
+
+        if (!nameOk || !passOk) {
+            logger.warn({ ip: ipOf(c), username }, 'rejected config UI sign-in');
+            return c.html(loginPage({ version, error: 'Wrong username or password.' }), 401);
+        }
+
+        const token = runtime.sessions.issue();
+        c.header('set-cookie', sessionCookie(token, Math.floor(SESSION_TTL_MS / 1000)));
+        logger.info({ ip: ipOf(c), username }, 'config UI sign-in');
+        return c.redirect('/ui', 302);
+    });
+
+    app.post('/ui/logout', c => {
+        c.header('set-cookie', clearedSessionCookie());
+        return c.redirect('/ui/login', 302);
+    });
+
+    // --- everything below requires a session ----------------------------
+
+    const guard = (c: Context): string | undefined => sessionOf(c, runtime);
+
+    app.get('/', c => c.redirect(guard(c) === undefined ? '/ui/login' : '/ui', 302));
+
+    app.get('/ui', async c => {
+        if (guard(c) === undefined) return c.redirect('/ui/login', 302);
+
+        const snapshot = runtime.current;
+        // Live, in parallel: a dashboard showing cached status is a dashboard
+        // that tells you a dead service is fine. `testConnection` never throws
+        // (services/types.ts), so one unreachable service cannot fail the page.
+        const diagnoses = await Promise.all(snapshot.adapters.map(a => a.testConnection()));
+        const rows = audit.recent(500) as { outcome: string }[];
+
+        return c.html(
+            dashboardPage({
+                version,
+                diagnoses,
+                configured: snapshot.adapters.map(a => a.id),
+                bearerToken: snapshot.config.auth.bearer_token,
+                writeCounts: {
+                    applied: rows.filter(r => r.outcome === 'applied').length,
+                    denied: rows.filter(r => r.outcome === 'denied').length,
+                    total: rows.length
+                }
+            })
+        );
+    });
+
+    // --- logs -----------------------------------------------------------
+
+    app.get('/ui/logs', c => {
+        if (guard(c) === undefined) return c.redirect('/ui/login', 302);
+
+        const { minLevel, service } = logQuery(c);
+        const stream = `/ui/logs.json?level=${minLevel}&service=${encodeURIComponent(service ?? '')}`;
+
+        return c.html(
+            logsPage({
+                version,
+                services: logs.services(),
+                selectedService: service ?? '',
+                minLevel,
+                streamUrl: stream,
+                rows: logs.recent({ minLevel, service, limit: 300 })
+            })
+        );
+    });
+
+    /** JSON, not HTML — the client builds rows with textContent, because log
+     *  lines carry release names from public indexers. See web/assets.ts. */
+    app.get('/ui/logs.json', c => {
+        if (guard(c) === undefined) return c.json({ error: 'unauthorized' }, 401);
+
+        const { minLevel, service } = logQuery(c);
+        return c.json({ rows: logs.recent({ minLevel, service, limit: 300 }) }, 200, NO_STORE);
+    });
+
+    // --- write audit ----------------------------------------------------
+
+    app.get('/ui/audit', c => {
+        if (guard(c) === undefined) return c.redirect('/ui/login', 302);
+        return c.html(auditPage({ version, rows: audit.recent(300) as AuditRow[] }));
+    });
+
+    // --- configuration --------------------------------------------------
+
+    app.get('/ui/config', c => {
+        const session = guard(c);
+        if (session === undefined) return c.redirect('/ui/login', 302);
+        return c.html(configPage({ version, config: runtime.config, csrf: runtime.sessions.csrfFor(session) }));
+    });
+
+    app.post('/ui/config', async c => {
+        const session = guard(c);
+        if (session === undefined) return c.redirect('/ui/login', 302);
+
+        const form = await c.req.parseBody();
+        if (!runtime.sessions.csrfValid(session, str(form.csrf))) {
+            logger.warn({ ip: ipOf(c) }, 'rejected config save with a bad CSRF token');
+            return c.html(
+                configPage({
+                    version,
+                    config: runtime.config,
+                    csrf: runtime.sessions.csrfFor(session),
+                    message: { kind: 'err', text: 'That form was stale. Reload the page and try again.' }
+                }),
+                403
+            );
+        }
+
+        let next: Config;
+        try {
+            next = buildConfig(runtime.config, form);
+        } catch (err) {
+            return c.html(
+                configPage({
+                    version,
+                    config: runtime.config,
+                    csrf: runtime.sessions.csrfFor(session),
+                    message: { kind: 'err', text: (err as Error).message }
+                }),
+                400
+            );
+        }
+
+        try {
+            await saveConfig(runtime.configDir, next);
+            await runtime.reload();
+        } catch (err) {
+            // The file is written atomically and validated first, so reaching
+            // here means the config on disk is still the working one.
+            logger.error({ err }, 'config save failed');
+            return c.html(
+                configPage({
+                    version,
+                    config: runtime.config,
+                    csrf: runtime.sessions.csrfFor(session),
+                    message: { kind: 'err', text: (err as Error).message }
+                }),
+                400
+            );
+        }
+
+        logger.info({ ip: ipOf(c) }, 'configuration saved from the config UI');
+        return c.html(
+            configPage({
+                version,
+                config: runtime.config,
+                csrf: runtime.sessions.csrfFor(session),
+                message: { kind: 'ok', text: 'Saved and applied. No restart needed.' }
+            })
+        );
+    });
+}
+
+const CACHE = { 'cache-control': 'public, max-age=3600' };
+const NO_STORE = { 'cache-control': 'no-store' };
+
+const str = (value: unknown): string => (typeof value === 'string' ? value : '');
+const on = (value: unknown): boolean => value === 'on' || value === 'true';
+const ipOf = (c: Context): string => c.req.header('x-forwarded-for') ?? 'unknown';
+
+function sessionOf(c: Context, runtime: Runtime): string | undefined {
+    const token = readCookie(c.req.header('cookie'), SESSION_COOKIE);
+    return runtime.sessions.verify(token).valid ? token : undefined;
+}
+
+function logQuery(c: Context): { minLevel: number; service: ServiceId | undefined } {
+    const level = Number(c.req.query('level'));
+    const raw = c.req.query('service') ?? '';
+    const parsed = ServiceIdSchema.safeParse(raw);
+
+    return {
+        minLevel: Number.isFinite(level) && level > 0 ? level : LEVELS.info,
+        service: parsed.success ? parsed.data : undefined
+    };
+}
+
+/**
+ * Form fields into a `Config`, carrying forward every secret the form did not
+ * set.
+ *
+ * A blank secret means "unchanged", never "clear" — the page never renders a
+ * secret back, so blank is what an untouched field always looks like. Clearing
+ * is expressed by switching the service off, which is unambiguous.
+ */
+export function buildConfig(current: Config, form: Record<string, unknown>): Config {
+    const services: Record<string, unknown> = {};
+
+    for (const id of SERVICE_IDS) {
+        if (!on(form[`svc.${id}.enabled`])) continue;
+
+        const existing = (current.services as Record<string, Record<string, unknown> | undefined>)[id];
+        const url = str(form[`svc.${id}.url`]).trim();
+        if (url === '') throw new Error(`${id} is switched on but has no URL.`);
+
+        const timeout = Number(str(form[`svc.${id}.timeout_ms`]));
+        const service: Record<string, unknown> = {
+            url,
+            timeout_ms: Number.isFinite(timeout) && timeout > 0 ? Math.trunc(timeout) : 10_000,
+            permissions: {
+                safe_write: on(form[`svc.${id}.safe_write`]),
+                destructive: on(form[`svc.${id}.destructive`])
+            }
+        };
+
+        if (id === 'transmission') {
+            const username = str(form[`svc.${id}.username`]).trim();
+            if (username !== '') service.username = username;
+            const password = str(form[`svc.${id}.password`]);
+            const carried = password === '' ? existing?.password : password;
+            if (typeof carried === 'string' && carried !== '') service.password = carried;
+        } else {
+            const key = str(form[`svc.${id}.api_key`]).trim();
+            const carried = key === '' ? existing?.api_key : key;
+            if (typeof carried !== 'string' || carried === '') {
+                throw new Error(`${id} is switched on but has no API key.`);
+            }
+            service.api_key = carried;
+        }
+
+        if (id === 'jellyfin' || id === 'seerr') {
+            const user = str(form[`svc.${id}.default_user`]).trim();
+            if (user !== '') service.default_user = user;
+            service.allow_other_users = on(form[`svc.${id}.allow_other_users`]);
+        }
+
+        services[id] = service;
+    }
+
+    const username = str(form['auth.username']).trim();
+    const password = str(form['auth.password']);
+    const hosts = str(form['auth.allowed_hosts'])
+        .split(',')
+        .map(h => h.trim())
+        .filter(h => h !== '');
+
+    return {
+        auth: {
+            bearer_token: on(form['auth.rotate_token'])
+                ? generateBearerToken()
+                : current.auth.bearer_token,
+            username: username === '' ? current.auth.username : username,
+            password_hash: password === '' ? current.auth.password_hash : hashPassword(password),
+            allowed_hosts: hosts
+        },
+        services: services as Config['services']
+    };
+}

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { buildApp } from '../src/app.ts';
-import { ConfigSchema } from '../src/config/schema.ts';
+import { ConfigSchema, type Config } from '../src/config/schema.ts';
 import { WriteAudit } from '../src/core/audit.ts';
+import { LogStore } from '../src/core/logs.ts';
+import { Runtime } from '../src/core/runtime.ts';
+import { hashPassword } from '../src/core/session.ts';
 import { RadarrAdapter } from '../src/services/radarr.ts';
+import type { ServiceAdapter } from '../src/services/types.ts';
 import { TOOL_NAMES } from '../src/tools/register.ts';
 
 const TOKEN = 'a'.repeat(64);
@@ -11,8 +15,22 @@ const WRONG = 'b'.repeat(64);
 /** In-memory, so these tests never touch a config directory. */
 const audit = () => WriteAudit.ephemeral();
 
-const config = ConfigSchema.parse({ auth: { bearer_token: TOKEN }, services: {} });
-const app = () => buildApp({ config, adapters: [], audit: audit() });
+const configWith = (over: Record<string, unknown> = {}): Config =>
+    ConfigSchema.parse({
+        auth: { bearer_token: TOKEN, password_hash: hashPassword('unused-here'), ...over },
+        services: {}
+    });
+
+const config = configWith();
+
+const appWith = (cfg: Config, adapters: readonly ServiceAdapter[] = []) =>
+    buildApp({
+        runtime: Runtime.fromConfig(cfg, audit(), { adapters }),
+        audit: audit(),
+        logs: LogStore.ephemeral()
+    });
+
+const app = () => appWith(config);
 
 const rpc = (body: unknown, headers: Record<string, string> = {}) => ({
     method: 'POST',
@@ -131,14 +149,7 @@ describe('DNS rebinding protection', () => {
     });
 
     it('rejects a foreign Host once hostnames are pinned', async () => {
-        const pinned = buildApp({
-            config: ConfigSchema.parse({
-                auth: { bearer_token: TOKEN, allowed_hosts: ['arr.example.com'] },
-                services: {}
-            }),
-            adapters: [],
-            audit: audit()
-        });
+        const pinned = appWith(configWith({ allowed_hosts: ['arr.example.com'] }));
 
         // Hono's synthetic request helper does not derive a Host header from
         // the URL, so set it explicitly — the validator reads the header, not
@@ -214,11 +225,7 @@ describe('a thrown ServiceError reaches the client with its remedy', () => {
                 status: 401,
                 headers: { 'content-type': 'application/json' }
             });
-        const withRadarr = buildApp({
-            config,
-            adapters: [new RadarrAdapter(radarrConfig, unauthorized)],
-            audit: audit()
-        });
+        const withRadarr = appWith(config, [new RadarrAdapter(radarrConfig, unauthorized)]);
 
         const callTool = {
             jsonrpc: '2.0',
@@ -250,11 +257,7 @@ describe('a thrown ServiceError reaches the client with its remedy', () => {
                 status: 404,
                 headers: { 'content-type': 'application/json' }
             });
-        const withRadarr = buildApp({
-            config,
-            adapters: [new RadarrAdapter(radarrConfig, notFound)],
-            audit: audit()
-        });
+        const withRadarr = appWith(config, [new RadarrAdapter(radarrConfig, notFound)]);
 
         const callTool = {
             jsonrpc: '2.0',

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -6,7 +6,54 @@ import { ConfigSchema } from '../src/config/schema.ts';
 import { loadConfig } from '../src/config/load.ts';
 
 const freshDir = () => mkdtemp(join(tmpdir(), 'arr-mcp-cfg-'));
-const AUTH = { bearer_token: 'a'.repeat(64) };
+/**
+ * A literal hash rather than `hashPassword('…')`: scrypt is deliberately slow
+ * (~50ms), and paying that in every schema test would add seconds to the suite
+ * to prove something `session.test.ts` already proves properly.
+ */
+const AUTH = { bearer_token: 'a'.repeat(64), password_hash: 'scrypt$00$11' };
+
+describe('reading without writing', () => {
+    /**
+     * The maintainer scripts load this file only to reach the services it
+     * names. A read must not have side effects on the user's credentials.
+     *
+     * Before `persist: false` existed, `npm run integration` against a config
+     * predating the config UI silently backfilled a `password_hash` into it —
+     * generating a password the script never printed, so nobody could ever
+     * know it. It happened to a real config.
+     */
+    it('leaves a config missing the new credentials completely untouched', async () => {
+        const dir = await freshDir();
+        const path = join(dir, 'config.yaml');
+        const original = `auth:\n  bearer_token: ${'c'.repeat(64)}\nservices:\n  radarr:\n    url: http://192.0.2.10:7878\n    api_key: k\n`;
+        await writeFile(path, original, 'utf8');
+
+        const { config } = await loadConfig(dir, { persist: false });
+
+        // In memory it is complete, so the schema is satisfied…
+        expect(config.auth.password_hash.length).toBeGreaterThan(0);
+        // …and on disk nothing moved.
+        expect(await readFile(path, 'utf8')).toBe(original);
+    });
+
+    it('still backfills and persists when asked to', async () => {
+        const dir = await freshDir();
+        const path = join(dir, 'config.yaml');
+        await writeFile(path, `auth:\n  bearer_token: ${'d'.repeat(64)}\nservices: {}\n`, 'utf8');
+
+        const { generated } = await loadConfig(dir);
+
+        expect(generated.password).toBeTypeOf('string');
+        expect(await readFile(path, 'utf8')).toContain('password_hash');
+    });
+
+    // A script pointed at the wrong directory should say so, not create one.
+    it('refuses to invent a config directory when reading only', async () => {
+        const dir = await freshDir();
+        await expect(loadConfig(join(dir, 'nope'), { persist: false })).rejects.toThrow(/no config\.yaml/);
+    });
+});
 
 describe('ConfigSchema', () => {
     it('defaults both permission tiers to off for a newly added service', () => {

--- a/test/configUi.test.ts
+++ b/test/configUi.test.ts
@@ -1,0 +1,341 @@
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { buildApp } from '../src/app.ts';
+import { loadConfig } from '../src/config/load.ts';
+import { WriteAudit } from '../src/core/audit.ts';
+import { LogStore } from '../src/core/logs.ts';
+import { Runtime } from '../src/core/runtime.ts';
+import { hashPassword } from '../src/core/session.ts';
+
+/**
+ * The config UI driven through the real Hono app — same routes, same session
+ * cookie, same form parsing a browser hits.
+ *
+ * These use a real temp directory rather than a fake filesystem because the
+ * thing most worth testing is that a save reaches disk, survives a reload, and
+ * comes back through the loader that the process actually starts from.
+ */
+
+const PASSWORD = 'test-password-1234';
+const BEARER = 'a'.repeat(64);
+
+let dir: string;
+let runtime: Runtime;
+let app: ReturnType<typeof buildApp>;
+let logs: LogStore;
+let audit: WriteAudit;
+
+const seed = async (extra = '') => {
+    dir = await mkdtemp(join(tmpdir(), 'arr-mcp-ui-'));
+    await writeFile(
+        join(dir, 'config.yaml'),
+        `auth:\n  bearer_token: ${BEARER}\n  username: admin\n  password_hash: ${hashPassword(PASSWORD)}\n  allowed_hosts: []\nservices:${extra === '' ? ' {}' : `\n${extra}`}\n`,
+        'utf8'
+    );
+
+    const { config } = await loadConfig(dir);
+    audit = WriteAudit.ephemeral();
+    logs = LogStore.ephemeral();
+    runtime = Runtime.fromConfig(config, audit, { configDir: dir });
+    app = buildApp({ runtime, audit, logs });
+};
+
+beforeEach(async () => {
+    await seed();
+});
+
+afterEach(() => {
+    logs.close();
+    audit.close();
+});
+
+let cookie = '';
+
+const call = async (path: string, opts: RequestInit = {}) => {
+    const res = await app.request(`http://localhost:6060${path}`, {
+        ...opts,
+        headers: { ...(opts.headers ?? {}), ...(cookie === '' ? {} : { cookie }) }
+    });
+    const set = res.headers.get('set-cookie');
+    if (set !== null) cookie = set.split(';')[0] ?? '';
+    return res;
+};
+
+const form = (body: Record<string, string>): RequestInit => ({
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams(body).toString()
+});
+
+const signIn = async () => {
+    cookie = '';
+    await call('/ui/login', form({ username: 'admin', password: PASSWORD }));
+};
+
+const csrfFrom = async (): Promise<string> => {
+    const page = await (await call('/ui/config')).text();
+    return /name="csrf" value="([^"]+)"/.exec(page)?.[1] ?? '';
+};
+
+describe('access control', () => {
+    it('sends an anonymous visitor to the login page', async () => {
+        cookie = '';
+        const res = await call('/ui');
+        expect(res.status).toBe(302);
+        expect(res.headers.get('location')).toBe('/ui/login');
+    });
+
+    it('refuses the log API without a session rather than redirecting it', async () => {
+        cookie = '';
+        expect((await call('/ui/logs.json')).status).toBe(401);
+    });
+
+    // An unstyled login page looks broken, and the CSS reveals nothing.
+    it('serves the stylesheet without a session', async () => {
+        cookie = '';
+        const res = await call('/ui/app.css');
+        expect(res.status).toBe(200);
+        expect(res.headers.get('content-type')).toContain('text/css');
+    });
+
+    it('rejects a wrong password', async () => {
+        cookie = '';
+        expect((await call('/ui/login', form({ username: 'admin', password: 'nope' }))).status).toBe(401);
+    });
+
+    it('rejects a wrong username with the same status and message', async () => {
+        cookie = '';
+        const res = await call('/ui/login', form({ username: 'root', password: PASSWORD }));
+        expect(res.status).toBe(401);
+        // Naming which half was wrong would confirm valid usernames.
+        expect(await res.text()).toContain('Wrong username or password');
+    });
+
+    it('signs in and reaches the dashboard', async () => {
+        await signIn();
+        const res = await call('/ui');
+        expect(res.status).toBe(200);
+        expect(await res.text()).toContain('MCP endpoint');
+    });
+
+    it('signs out', async () => {
+        await signIn();
+        await call('/ui/logout', { method: 'POST' });
+        expect((await call('/ui')).status).toBe(302);
+    });
+});
+
+describe('secrets', () => {
+    it('never renders an API key back into the form', async () => {
+        await seed('  radarr:\n    url: http://192.0.2.10:7878\n    api_key: super-secret-key\n');
+        await signIn();
+
+        const page = await (await call('/ui/config')).text();
+        expect(page).toContain('192.0.2.10:7878');
+        expect(page).not.toContain('super-secret-key');
+    });
+
+    it('never renders the password hash', async () => {
+        await signIn();
+        expect(await (await call('/ui/config')).text()).not.toContain('scrypt$');
+    });
+
+    // It is the one secret the UI exists to hand out, so it is shown — but
+    // masked until asked for.
+    it('shows the bearer token on the dashboard, in a masked field', async () => {
+        await signIn();
+        const page = await (await call('/ui')).text();
+        expect(page).toContain(BEARER);
+        expect(page).toContain('type="password"');
+    });
+});
+
+describe('saving configuration', () => {
+    it('refuses a forged CSRF token', async () => {
+        await signIn();
+        const res = await call('/ui/config', form({ csrf: 'forged', 'svc.radarr.enabled': 'on' }));
+        expect(res.status).toBe(403);
+    });
+
+    it('refuses a service switched on with no URL', async () => {
+        await signIn();
+        const res = await call(
+            '/ui/config',
+            form({ csrf: await csrfFrom(), 'svc.radarr.enabled': 'on', 'svc.radarr.url': '' })
+        );
+        expect(res.status).toBe(400);
+        expect(await res.text()).toContain('no URL');
+    });
+
+    it('refuses a service switched on with no API key', async () => {
+        await signIn();
+        const res = await call(
+            '/ui/config',
+            form({
+                csrf: await csrfFrom(),
+                'svc.radarr.enabled': 'on',
+                'svc.radarr.url': 'http://192.0.2.10:7878',
+                'svc.radarr.api_key': ''
+            })
+        );
+        expect(res.status).toBe(400);
+        expect(await res.text()).toContain('no API key');
+    });
+
+    it('writes the service to disk', async () => {
+        await signIn();
+        await call(
+            '/ui/config',
+            form({
+                csrf: await csrfFrom(),
+                'svc.radarr.enabled': 'on',
+                'svc.radarr.url': 'http://192.0.2.10:7878',
+                'svc.radarr.api_key': 'k',
+                'svc.radarr.timeout_ms': '4000',
+                'auth.username': 'admin'
+            })
+        );
+
+        const onDisk = await readFile(join(dir, 'config.yaml'), 'utf8');
+        expect(onDisk).toContain('192.0.2.10:7878');
+        expect(onDisk).toContain('timeout_ms: 4000');
+    });
+
+    // The reason hot reload exists: editing config from a web page and then
+    // telling the user to restart would be worse than the YAML it replaces.
+    it('applies without a restart', async () => {
+        await signIn();
+        expect(runtime.current.adapters).toHaveLength(0);
+
+        await call(
+            '/ui/config',
+            form({
+                csrf: await csrfFrom(),
+                'svc.radarr.enabled': 'on',
+                'svc.radarr.url': 'http://192.0.2.10:7878',
+                'svc.radarr.api_key': 'k',
+                'auth.username': 'admin'
+            })
+        );
+
+        expect(runtime.current.adapters.map(a => a.id)).toEqual(['radarr']);
+    });
+
+    it('keeps an existing key when the field is left blank', async () => {
+        await seed('  radarr:\n    url: http://192.0.2.10:7878\n    api_key: keep-me\n');
+        await signIn();
+
+        await call(
+            '/ui/config',
+            form({
+                csrf: await csrfFrom(),
+                'svc.radarr.enabled': 'on',
+                'svc.radarr.url': 'http://192.0.2.10:9999',
+                'svc.radarr.api_key': '',
+                'auth.username': 'admin'
+            })
+        );
+
+        const onDisk = await readFile(join(dir, 'config.yaml'), 'utf8');
+        expect(onDisk).toContain('keep-me');
+        expect(onDisk).toContain('192.0.2.10:9999');
+    });
+
+    it('removes a service that was switched off', async () => {
+        await seed('  radarr:\n    url: http://192.0.2.10:7878\n    api_key: k\n');
+        await signIn();
+
+        await call('/ui/config', form({ csrf: await csrfFrom(), 'auth.username': 'admin' }));
+
+        expect(runtime.current.adapters).toHaveLength(0);
+        expect(await readFile(join(dir, 'config.yaml'), 'utf8')).not.toContain('192.0.2.10');
+    });
+
+    it('rotates the bearer token only when asked', async () => {
+        await signIn();
+        await call('/ui/config', form({ csrf: await csrfFrom(), 'auth.username': 'admin' }));
+        expect(runtime.config.auth.bearer_token).toBe(BEARER);
+
+        await call('/ui/config', form({ csrf: await csrfFrom(), 'auth.username': 'admin', 'auth.rotate_token': 'on' }));
+        expect(runtime.config.auth.bearer_token).not.toBe(BEARER);
+        expect(runtime.config.auth.bearer_token).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    // Rotating from the UI has to take effect on the very next MCP request,
+    // or the old token keeps working until a restart.
+    it('makes a rotated token effective immediately on /mcp', async () => {
+        await signIn();
+        await call('/ui/config', form({ csrf: await csrfFrom(), 'auth.username': 'admin', 'auth.rotate_token': 'on' }));
+
+        const res = await app.request('http://localhost:6060/mcp', {
+            method: 'POST',
+            headers: {
+                'content-type': 'application/json',
+                accept: 'application/json, text/event-stream',
+                authorization: `Bearer ${BEARER}`
+            },
+            body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' })
+        });
+        expect(res.status).toBe(401);
+    });
+
+    it('changes the password, and the old one stops working', async () => {
+        await signIn();
+        await call(
+            '/ui/config',
+            form({ csrf: await csrfFrom(), 'auth.username': 'admin', 'auth.password': 'a-new-password' })
+        );
+
+        cookie = '';
+        expect((await call('/ui/login', form({ username: 'admin', password: PASSWORD }))).status).toBe(401);
+        expect((await call('/ui/login', form({ username: 'admin', password: 'a-new-password' }))).status).toBe(302);
+    });
+
+    it('leaves the password alone when the field is blank', async () => {
+        await signIn();
+        await call('/ui/config', form({ csrf: await csrfFrom(), 'auth.username': 'admin', 'auth.password': '' }));
+
+        cookie = '';
+        expect((await call('/ui/login', form({ username: 'admin', password: PASSWORD }))).status).toBe(302);
+    });
+});
+
+describe('logs and audit', () => {
+    it('serves log rows as JSON', async () => {
+        logs.write(JSON.stringify({ level: 30, time: Date.now(), msg: 'hello', service: 'radarr' }));
+        await signIn();
+
+        const body = (await (await call('/ui/logs.json')).json()) as { rows: { msg: string }[] };
+        expect(body.rows.some(r => r.msg === 'hello')).toBe(true);
+    });
+
+    it('filters the log stream by service', async () => {
+        logs.write(JSON.stringify({ level: 30, time: Date.now(), msg: 'r', service: 'radarr' }));
+        logs.write(JSON.stringify({ level: 30, time: Date.now(), msg: 's', service: 'sonarr' }));
+        await signIn();
+
+        const body = (await (await call('/ui/logs.json?service=sonarr&level=10')).json()) as {
+            rows: { msg: string }[];
+        };
+        expect(body.rows.map(r => r.msg)).toEqual(['s']);
+    });
+
+    it('ignores a service filter that is not a real service id', async () => {
+        logs.write(JSON.stringify({ level: 30, time: Date.now(), msg: 'r', service: 'radarr' }));
+        await signIn();
+
+        const body = (await (await call('/ui/logs.json?service=%27%20OR%201=1--&level=10')).json()) as {
+            rows: unknown[];
+        };
+        expect(body.rows.length).toBeGreaterThan(0);
+    });
+
+    it('renders the audit page', async () => {
+        await signIn();
+        const res = await call('/ui/audit');
+        expect(res.status).toBe(200);
+        expect(await res.text()).toContain('Write audit');
+    });
+});

--- a/test/logs.test.ts
+++ b/test/logs.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { LEVELS, LOG_RING_SIZE, LogStore } from '../src/core/logs.ts';
+
+let store: LogStore | undefined;
+const open = (): LogStore => (store = LogStore.ephemeral());
+
+afterEach(() => {
+    store?.close();
+    store = undefined;
+});
+
+const line = (over: Record<string, unknown> = {}): string =>
+    JSON.stringify({ level: LEVELS.info, time: 1_786_000_000_000, app: 'arr-mcp', msg: 'hello', ...over });
+
+describe('the log ring buffer', () => {
+    it('stores a pino line', () => {
+        const logs = open();
+        logs.write(line({ msg: 'listening' }));
+
+        const [row] = logs.recent();
+        expect(row?.msg).toBe('listening');
+        expect(row?.level).toBe(LEVELS.info);
+        expect(row?.levelName).toBe('info');
+    });
+
+    it('promotes the service a line is about into its own column', () => {
+        const logs = open();
+        logs.write(line({ service: 'radarr', msg: 'unreachable' }));
+        expect(logs.recent()[0]?.service).toBe('radarr');
+    });
+
+    // `app` is the process; `service` is the media service a line is about.
+    it('does not mistake the app name for a service', () => {
+        const logs = open();
+        logs.write(line());
+        expect(logs.recent()[0]?.service).toBeNull();
+    });
+
+    it('keeps everything else as fields rather than dropping it', () => {
+        const logs = open();
+        logs.write(line({ service: 'radarr', port: 7878, err: { kind: 'Unreachable' } }));
+
+        const fields = JSON.parse(logs.recent()[0]?.fields ?? '{}') as Record<string, unknown>;
+        expect(fields.port).toBe(7878);
+        expect(fields.err).toEqual({ kind: 'Unreachable' });
+    });
+
+    it('returns newest first', () => {
+        const logs = open();
+        logs.write(line({ msg: 'first' }));
+        logs.write(line({ msg: 'second' }));
+        expect(logs.recent()[0]?.msg).toBe('second');
+    });
+
+    // Logging must never be able to break the thing it is logging about.
+    it('swallows a malformed line rather than throwing', () => {
+        const logs = open();
+        expect(() => logs.write('not json')).not.toThrow();
+        expect(() => logs.write('')).not.toThrow();
+        expect(logs.count()).toBe(0);
+    });
+
+    it('survives a line with no message or level', () => {
+        const logs = open();
+        logs.write(JSON.stringify({ time: 1 }));
+        expect(logs.recent()[0]?.msg).toBe('');
+    });
+});
+
+describe('filtering', () => {
+    const seeded = (): LogStore => {
+        const logs = open();
+        logs.write(line({ level: LEVELS.info, msg: 'ok', service: 'radarr' }));
+        logs.write(line({ level: LEVELS.warn, msg: 'slow', service: 'sonarr' }));
+        logs.write(line({ level: LEVELS.error, msg: 'broken', service: 'radarr' }));
+        return logs;
+    };
+
+    it('filters by minimum level, inclusively', () => {
+        const rows = seeded().recent({ minLevel: LEVELS.warn });
+        expect(rows.map(r => r.msg).sort()).toEqual(['broken', 'slow']);
+    });
+
+    it('filters by service', () => {
+        const rows = seeded().recent({ service: 'radarr' });
+        expect(rows.map(r => r.msg).sort()).toEqual(['broken', 'ok']);
+    });
+
+    it('combines both filters', () => {
+        const rows = seeded().recent({ service: 'radarr', minLevel: LEVELS.error });
+        expect(rows.map(r => r.msg)).toEqual(['broken']);
+    });
+
+    it('lists only services that actually logged, so the filter offers no dead options', () => {
+        expect(seeded().services()).toEqual(['radarr', 'sonarr']);
+    });
+
+    it('returns only rows newer than one already seen, for polling', () => {
+        const logs = seeded();
+        const newest = logs.recent()[0]!.id;
+        logs.write(line({ msg: 'later' }));
+
+        expect(logs.recent({ afterId: newest }).map(r => r.msg)).toEqual(['later']);
+    });
+
+    it('clamps a silly limit rather than trusting it', () => {
+        const logs = seeded();
+        expect(logs.recent({ limit: 0 })).toHaveLength(1);
+        expect(logs.recent({ limit: 10_000_000 }).length).toBeLessThanOrEqual(LOG_RING_SIZE);
+    });
+});
+
+describe('ring behaviour', () => {
+    // The whole point of a ring buffer: a chatty service must not fill a home
+    // server's disk.
+    it('discards the oldest rows once it is full', () => {
+        const logs = open();
+        for (let i = 0; i < LOG_RING_SIZE + 250; i += 1) logs.write(line({ msg: `line ${i}` }));
+        logs.prune();
+
+        expect(logs.count()).toBeLessThanOrEqual(LOG_RING_SIZE);
+        // The newest survived, the oldest did not.
+        expect(logs.recent(  { limit: 1 })[0]?.msg).toBe(`line ${LOG_RING_SIZE + 249}`);
+        expect(logs.recent({ limit: LOG_RING_SIZE }).some(r => r.msg === 'line 0')).toBe(false);
+    });
+});

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { ConfigSchema } from '../src/config/schema.ts';
 import { buildAdapters } from '../src/services/registry.ts';
 
-const AUTH = { bearer_token: 'a'.repeat(64) };
+const AUTH = { bearer_token: 'a'.repeat(64), password_hash: 'scrypt$00$11' };
 const keyed = (port: number) => ({ url: `http://h:${port}`, api_key: 'k' });
 
 describe('buildAdapters', () => {

--- a/test/scriptsRedact.test.ts
+++ b/test/scriptsRedact.test.ts
@@ -7,7 +7,7 @@ const TOKEN = 'a'.repeat(64);
 
 const configWith = (url: string) =>
     ConfigSchema.parse({
-        auth: { bearer_token: TOKEN },
+        auth: { bearer_token: TOKEN, password_hash: 'scrypt$00$11' },
         services: { radarr: { url, api_key: 'k' } }
     });
 

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest';
+import {
+    clearedSessionCookie,
+    generateBearerToken,
+    generatePassword,
+    hashPassword,
+    readCookie,
+    sessionCookie,
+    SESSION_COOKIE,
+    Sessions,
+    verifyPassword
+} from '../src/core/session.ts';
+
+describe('password storage', () => {
+    it('accepts the right password', () => {
+        const stored = hashPassword('correct horse battery staple');
+        expect(verifyPassword('correct horse battery staple', stored)).toBe(true);
+    });
+
+    it('rejects the wrong one', () => {
+        const stored = hashPassword('correct horse');
+        expect(verifyPassword('wrong horse', stored)).toBe(false);
+    });
+
+    // The password must not be recoverable from config.yaml, only replaceable.
+    it('never stores the password itself', () => {
+        const stored = hashPassword('hunter2');
+        expect(stored).not.toContain('hunter2');
+        expect(stored.startsWith('scrypt$')).toBe(true);
+    });
+
+    it('salts, so the same password hashes differently every time', () => {
+        expect(hashPassword('same')).not.toBe(hashPassword('same'));
+    });
+
+    it('rejects a malformed or truncated stored value rather than throwing', () => {
+        for (const bad of ['', 'nonsense', 'scrypt$', 'scrypt$aa', 'bcrypt$aa$bb', 'scrypt$aa$bb']) {
+            expect(verifyPassword('x', bad), bad).toBe(false);
+        }
+    });
+});
+
+describe('generated credentials', () => {
+    it('generates a bearer token of the length the schema requires', () => {
+        expect(generateBearerToken()).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    // It is read off a terminal and retyped into a browser.
+    it('generates a password with no visually ambiguous characters', () => {
+        for (let i = 0; i < 25; i += 1) {
+            expect(generatePassword()).not.toMatch(/[l1O0]/);
+        }
+    });
+
+    it('generates a different password every time', () => {
+        expect(new Set(Array.from({ length: 20 }, () => generatePassword())).size).toBe(20);
+    });
+});
+
+const stoppedClock = (start = 1_700_000_000_000) => {
+    let now = start;
+    return { now: () => now, advance: (ms: number) => (now += ms) };
+};
+
+describe('sessions', () => {
+    it('accepts a token it issued', () => {
+        const sessions = new Sessions();
+        expect(sessions.verify(sessions.issue()).valid).toBe(true);
+    });
+
+    it('expires', () => {
+        const clock = stoppedClock();
+        const sessions = new Sessions({ now: clock.now, ttlMs: 1000 });
+        const token = sessions.issue();
+
+        clock.advance(1001);
+        const result = sessions.verify(token);
+        expect(result.valid).toBe(false);
+        if (result.valid) return;
+        expect(result.reason).toBe('expired');
+    });
+
+    // Editing the expiry must invalidate the token, not extend it.
+    it('refuses a token whose expiry has been edited', () => {
+        const sessions = new Sessions();
+        const [, nonce, signature] = sessions.issue().split('.');
+        // Same nonce and signature, an expiry pushed far into the future.
+        const forged = `${(Date.now() + 999_999_999).toString(36)}.${nonce}.${signature}`;
+
+        const result = sessions.verify(forged);
+        expect(result.valid).toBe(false);
+        if (result.valid) return;
+        expect(result.reason).toBe('bad-signature');
+    });
+
+    it('refuses malformed tokens', () => {
+        const sessions = new Sessions();
+        for (const bad of [undefined, '', 'nonsense', 'a.b', 'a.b.c.d']) {
+            expect(sessions.verify(bad).valid, String(bad)).toBe(false);
+        }
+    });
+
+    // Without a nonce the token is a pure function of its expiry, so every
+    // sign-in inside the same millisecond produced the same string.
+    it('issues a distinct token every time, even within one millisecond', () => {
+        const clock = stoppedClock();
+        const sessions = new Sessions({ now: clock.now });
+        const issued = new Set(Array.from({ length: 50 }, () => sessions.issue()));
+        expect(issued.size).toBe(50);
+    });
+
+    // A restart should log everyone out — the credentials may have changed.
+    it('does not honour a token from a different instance', () => {
+        expect(new Sessions().verify(new Sessions().issue()).valid).toBe(false);
+    });
+});
+
+describe('csrf tokens', () => {
+    it('accepts the token issued for that session', () => {
+        const sessions = new Sessions();
+        const session = sessions.issue();
+        expect(sessions.csrfValid(session, sessions.csrfFor(session))).toBe(true);
+    });
+
+    // The point: a form stolen from one session cannot be replayed in another.
+    it('refuses a token issued for a different session', () => {
+        const sessions = new Sessions();
+        const a = sessions.issue();
+        const b = sessions.issue();
+        expect(sessions.csrfValid(a, sessions.csrfFor(b))).toBe(false);
+    });
+
+    it('refuses a missing token', () => {
+        const sessions = new Sessions();
+        expect(sessions.csrfValid(sessions.issue(), undefined)).toBe(false);
+        expect(sessions.csrfValid(undefined, 'anything')).toBe(false);
+    });
+});
+
+describe('cookies', () => {
+    it('reads one cookie out of several', () => {
+        expect(readCookie('a=1; arr_mcp_session=xyz; b=2', SESSION_COOKIE)).toBe('xyz');
+    });
+
+    it('returns undefined when absent or when there is no header', () => {
+        expect(readCookie('a=1', SESSION_COOKIE)).toBeUndefined();
+        expect(readCookie(undefined, SESSION_COOKIE)).toBeUndefined();
+    });
+
+    it('does not match a cookie whose name merely ends with the one asked for', () => {
+        expect(readCookie('not_arr_mcp_session=xyz', SESSION_COOKIE)).toBeUndefined();
+    });
+
+    it('sets HttpOnly and SameSite, and deliberately not Secure', () => {
+        const cookie = sessionCookie('tok', 3600);
+        expect(cookie).toContain('HttpOnly');
+        expect(cookie).toContain('SameSite=Strict');
+        // Secure would never be stored over the plain http this is served on
+        // across a LAN, locking every user out.
+        expect(cookie).not.toContain('Secure');
+    });
+
+    it('clears by expiring immediately', () => {
+        expect(clearedSessionCookie()).toContain('Max-Age=0');
+    });
+});

--- a/test/webHtml.test.ts
+++ b/test/webHtml.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { esc, html, humanBytes, raw, shortTime } from '../src/web/html.ts';
+
+describe('escaping', () => {
+    it('neutralises the characters that end a tag or an attribute', () => {
+        expect(esc(`<script>alert('x')</script>`)).toBe(
+            '&lt;script&gt;alert(&#39;x&#39;)&lt;/script&gt;'
+        );
+        expect(esc('a"b')).toBe('a&quot;b');
+        expect(esc('a&b')).toBe('a&amp;b');
+    });
+
+    it('renders null and undefined as nothing, not as the words', () => {
+        expect(esc(null)).toBe('');
+        expect(esc(undefined)).toBe('');
+    });
+});
+
+describe('the html template', () => {
+    it('escapes every interpolation by default', () => {
+        const evil = '<img src=x onerror=alert(1)>';
+        expect(html`<p>${evil}</p>`.value).toBe('<p>&lt;img src=x onerror=alert(1)&gt;</p>');
+    });
+
+    // The escape hatch has to be visible at the call site, or it becomes the
+    // accidental default.
+    it('passes SafeHtml through untouched', () => {
+        expect(html`<p>${raw('<b>bold</b>')}</p>`.value).toBe('<p><b>bold</b></p>');
+    });
+
+    it('joins arrays without separators, so rendered rows drop straight in', () => {
+        const rows = [html`<li>a</li>`, html`<li>b</li>`];
+        expect(html`<ul>${rows}</ul>`.value).toBe('<ul><li>a</li><li>b</li></ul>');
+    });
+
+    it('escapes inside an array too', () => {
+        expect(html`<ul>${['<x>', '<y>']}</ul>`.value).toBe('<ul>&lt;x&gt;&lt;y&gt;</ul>');
+    });
+
+    // A release name from a public indexer is the most attacker-controllable
+    // string in the system, and it reaches the audit view and the log table.
+    it('is safe for a release name that tries to break out of an attribute', () => {
+        const release = `Film.2026" onload="alert(1)`;
+        const out = html`<td title="${release}">x</td>`.value;
+        expect(out).not.toContain('onload="alert(1)"');
+        expect(out).toContain('&quot;');
+    });
+
+    it('is safe for a fenced value, whose brackets are literal text', () => {
+        const fenced = '<<untrusted:radarr.title>>Alien<</untrusted>>';
+        expect(html`<td>${fenced}</td>`.value).toBe(
+            '<td>&lt;&lt;untrusted:radarr.title&gt;&gt;Alien&lt;&lt;/untrusted&gt;&gt;</td>'
+        );
+    });
+});
+
+describe('formatting helpers', () => {
+    it('scales bytes to something a person reads', () => {
+        expect(humanBytes(0)).toBe('0 B');
+        expect(humanBytes(1024)).toBe('1.0 KB');
+        expect(humanBytes(25_900_000_000)).toBe('24.1 GB');
+    });
+
+    it('reports unknown sizes as unknown rather than as zero', () => {
+        expect(humanBytes(undefined)).toBe('—');
+        expect(humanBytes(Number.NaN)).toBe('—');
+    });
+
+    it('shortens an ISO timestamp for a log table', () => {
+        expect(shortTime('2026-08-06T12:11:18.123Z')).toBe('2026-08-06 12:11:18');
+    });
+});


### PR DESCRIPTION
Phase 5. A dashboard, connection tests that diagnose rather than pass/fail, log streams, the write audit, and configuration editing that **applies without a restart**.

Server rendered from `src/web/`. No bundler, no framework, **no new dependencies** — assets live in modules because `tsc` doesn't emit non-TypeScript files, so a `public/` directory would work in development and be silently missing from the Docker image.

## Hot reload is the invasive part

Everything a config change can invalidate now lives behind one immutable snapshot in `core/runtime.ts`, swapped by a single assignment and **read per request** rather than captured when the app is built. A call that starts before a reload finishes against the configuration it began with — which is what makes reloading during an in-flight tool call safe without any locking.

Two things deliberately survive a reload:

- **Confirmation tokens** — a write handshake spans two calls, and a config edit between them must not silently invalidate it. Safety is unaffected: the permission check re-runs at confirm time against the *new* config.
- **Sessions** — saving config must not log you out of the page you saved from.

## Auth

Username and password generated on first run beside the bearer token, stored only as an **scrypt hash**, printed once. Sessions are signed expiring cookies rather than a server-side table: a table would either lose every session on restart or need a third database for something with no audit value. CSRF tokens are bound to the session cookie; `SameSite=Strict` covers the rest. `Secure` is deliberately absent — this is served over plain http on a LAN by design, and a Secure cookie would never be stored, locking everyone out.

The bearer token is shown on the dashboard, masked until asked for, so nobody has to dig through `docker logs` to configure an MCP client.

## Three things the browser makes different

All three are in CONTRIBUTING, because breaking them is quiet rather than loud:

1. **Every interpolation goes through an escaping template.** `raw()` is the only way out and must be written deliberately.
2. **The live log stream is JSON; the client builds rows with `textContent`, never `innerHTML`.** Everything else is server-rendered and escaped, which is sound — but that surface carries release names from public indexers on a timer, and building nodes makes an XSS *impossible* rather than merely unlikely.
3. **Secrets are never rendered back.** API keys, the Transmission password and the UI password render as empty fields meaning *unchanged*. That is also why blank can never mean "clear" — clearing is switching the service off.

## Two defects found by running it

**Sessions issued in the same millisecond were identical.** The token was only a signed expiry, so it was a pure function of its expiry. Not an authentication hole on its own — there are no per-user identities — but it made the CSRF binding meaningless between colliding sessions. Tokens now carry a nonce. A test caught this.

**`loadConfig` rewrote the user's credentials file as a side effect of being read.** Running `npm run integration` against a config predating this phase backfilled a `password_hash` into it — generating a password the script never printed, so nobody could ever know it. **This happened to a real config**, and I restored it. `loadConfig` now takes `persist: false`, which both maintainer scripts use: missing credentials are synthesised in memory so the schema is satisfied, and the file is never touched. Three regression tests.

## Verification

- **938 tests / 47 files**; typecheck, lint and build clean.
- **A real instance driven through the whole flow**: sign-in, wrong-password rejection, dashboard, CSRF rejection, validation failures, a save that reaches disk, the service live without a restart, secrets not round-tripping, log ring buffer, audit page, sign-out. 21 checks.
- **Outstanding**: `npm run integration` against a live media stack. Every service on that host is currently unreachable, so it could not run — this is stated as not-done rather than passing.

## Upgrade note

An existing `config.yaml` gains `username: admin` and a generated `password_hash` on first start after this, with the password printed once to the container log. Lost it? Delete the `password_hash` line and restart — documented in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
