### PR TITLE
fix: close the gaps the config UI shipped with

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,17 +20,14 @@ Jellyfin. arr-mcp correlates them and gives you the causal chain.
   broken and what to do about it, and read the logs and the write audit — no
   hand-edited YAML, no restart.
 
-> ### Status: 0.5 — writes, opt-in and previewed
+> ### Status: 0.6 — a config page that diagnoses
 >
-> Six write tools behind per-service permission tiers, each previewing exactly
-> what it would do before it does it, and recording every attempt — applied,
-> refused or failed — in an audit trail. `get_library` and `diagnose` from 0.4
-> still do the correlation work. See [the roadmap](#roadmap).
->
-> **On `main`, ahead of the 0.5 tag:** the [config UI](#config-ui) — a
-> dashboard, connection tests that diagnose rather than pass or fail, log
-> streams, the write audit, and configuration editing that applies without a
-> restart. Released images tagged `0.5` still need hand-edited YAML.
+> Add your services from a browser and see what is broken and why: connection
+> tests report the same `kind`, `detail` and `remedy` the tools do, rather than
+> a red cross you then have to investigate. Saving applies immediately, with no
+> restart. Log streams and the write audit are on the same page. The writes
+> from 0.5 and the correlation from 0.4 are unchanged underneath.
+> See [the roadmap](#roadmap).
 
 ## Services
 
@@ -205,7 +202,7 @@ none, **it refuses and lists them** rather than picking:
 ```yaml
 services:
   arr-mcp:
-    image: ghcr.io/bardesss/arr-mcp:0.5
+    image: ghcr.io/bardesss/arr-mcp:0.6
     ports: ['6060:6060']
     volumes: ['./config:/config']
     environment:
@@ -263,9 +260,14 @@ from Radarr/Sonarr alone.
 A misspelled key, an unknown service, or an `api_key` on Transmission fails at
 startup with the offending field named, rather than being silently ignored.
 
-Changes saved from the config UI take effect immediately. A change you make by
-hand-editing the file still needs a restart, because nothing is watching the
-file — the UI reloads because it knows it just wrote.
+Changes saved from the config UI take effect immediately — every field,
+including `allowed_hosts`. A change you make by hand-editing the file still
+needs a restart, because nothing is watching the file; the UI reloads because
+it knows it just wrote.
+
+One thing to be careful with: pinning `allowed_hosts` applies at once, so a
+wrong hostname locks you out of the page you would fix it from. Recover by
+editing `config.yaml` by hand and restarting.
 
 ## Config UI
 
@@ -273,15 +275,18 @@ file — the UI reloads because it knows it just wrote.
 
 | Page | What it is for |
 | --- | --- |
-| Dashboard | Every service tested live, with the bearer token for your MCP client |
+| Dashboard | Every service tested live, plus disk space, failed health checks, library scan staleness, and the bearer token for your MCP client |
 | Configuration | Add, edit and remove services; change credentials |
-| Logs | The last few thousand lines, filtered by level and by service |
+| Logs | Three streams — all activity, problems only, or one service |
 | Write audit | Every write attempt — applied, previewed, refused or failed |
 
 **Connection tests diagnose rather than pass or fail.** A service that is down
 says what is wrong and what to do about it — the same `kind`, `detail` and
 `remedy` the MCP tools return — instead of showing a red cross you then have to
-investigate.
+investigate. The dashboard answers the same four questions `stack_health` does,
+from the same code: is it reachable, is anything reporting a problem, is a disk
+filling up, and when did each library last finish a scan. A stale scan is the
+usual reason something downloaded is still not playable.
 
 **Secrets never come back out.** API keys, the Transmission password and the UI
 password all render as empty fields meaning *unchanged*, so a saved page or a
@@ -307,7 +312,7 @@ Put it behind a reverse proxy with TLS if it needs to leave the LAN, and pin
 | 0.3 | The remaining seven service adapters and ten read tools |
 | 0.4 | Cross-service correlation: identity resolver, three-way library join, `diagnose` |
 | 0.5 | Writes: permission tiers, `dry_run`, write audit, per-call confirmation |
-| 0.6 | Web config page: dashboard, diagnosing connection tests, log streams, config editing with hot reload — on `main`, unreleased |
+| 0.6 | Web config page: dashboard, diagnosing connection tests, log streams, config editing with hot reload |
 | 0.7 → 1.0 | Metadata providers, MCP resources and prompts |
 
 Each version is a self-contained, shippable slice — the goal is that 0.4 already

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -155,6 +155,13 @@ when `TOOL_NAMES` gains a tool no case covers, so a new tool cannot ship
 uncalled — which is exactly how 0.3.0 shipped a `get_subtitles` that crashed
 on the first real request.
 
+It also renders every config UI page against the live stack, signs in, and
+asserts that no API key reaches the configuration form. Those cases are
+read-only and never save, so running the script cannot change your
+configuration — and since 0.6 it never writes to `config.yaml` at all
+(`loadConfig(dir, { persist: false })`). Before that it silently backfilled a
+generated password into a real config, one that nothing ever printed.
+
 ## Recapture fixtures when an adapter starts reading a new endpoint
 
 `test/fixtures/` is what the contract tests check against, so an endpoint with

--- a/scripts/integration.ts
+++ b/scripts/integration.ts
@@ -413,6 +413,110 @@ await expectError(
     'DRY RUN ONLY — expects the refuse-to-guess path, with the profiles listed'
 );
 
+/**
+ * The config UI, against the same live stack.
+ *
+ * The tool cases above prove the adapters; nothing in them touches `/ui`, so
+ * before this a UI regression reached a release with a green script — the
+ * shape of failure that put seven defects into 0.3.0. These are read-only:
+ * they sign in, render every page against real services, and never save, so
+ * running this cannot change a maintainer's configuration.
+ */
+async function checkUi(): Promise<void> {
+    console.log('\n--- config UI ---');
+    let cookie = '';
+
+    const fetchUi = async (path: string, init: RequestInit = {}): Promise<Response> => {
+        const res = await app.request(`http://localhost:6060${path}`, {
+            redirect: 'manual',
+            ...init,
+            headers: { ...(init.headers ?? {}), ...(cookie === '' ? {} : { cookie }) }
+        });
+        const set = res.headers.get('set-cookie');
+        if (set !== null) cookie = set.split(';')[0] ?? '';
+        return res;
+    };
+
+    const check = async (label: string, run: () => Promise<boolean>): Promise<void> => {
+        const started = performance.now();
+        try {
+            const ok = await run();
+            const ms = Math.round(performance.now() - started);
+            if (ok) {
+                console.log(`PASS ui ${label} (${ms}ms)`);
+                passes += 1;
+            } else {
+                console.error(`FAIL ui ${label} (${ms}ms)`);
+                failures += 1;
+            }
+        } catch (err) {
+            console.error(`FAIL ui ${label} — ${redactHosts((err as Error).message, hosts)}`);
+            failures += 1;
+        }
+    };
+
+    await check('redirects an anonymous visitor to the login page', async () => {
+        const res = await fetchUi('/ui');
+        return res.status === 302 && res.headers.get('location') === '/ui/login';
+    });
+
+    await check('renders the login page', async () => {
+        const res = await fetchUi('/ui/login');
+        return res.status === 200 && (await res.text()).includes('Sign in');
+    });
+
+    // The password is only knowable on the run that generated it, so this
+    // signs in against a hash it sets itself rather than asking for one.
+    const password = 'integration-only-not-persisted';
+    const { hashPassword } = await import('../src/core/session.ts');
+    const uiConfig = { ...config, auth: { ...config.auth, password_hash: hashPassword(password) } };
+    const uiRuntime = Runtime.fromConfig(uiConfig, WriteAudit.ephemeral(), { configDir: CONFIG_DIR });
+    const uiApp = buildApp({ runtime: uiRuntime, audit: WriteAudit.ephemeral(), logs: LogStore.ephemeral() });
+
+    cookie = '';
+    const signIn = await uiApp.request('http://localhost:6060/ui/login', {
+        method: 'POST',
+        redirect: 'manual',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({ username: uiConfig.auth.username, password }).toString()
+    });
+    cookie = (signIn.headers.get('set-cookie') ?? '').split(';')[0] ?? '';
+
+    const authed = async (path: string): Promise<Response> =>
+        uiApp.request(`http://localhost:6060${path}`, { headers: { cookie }, redirect: 'manual' });
+
+    await check('signs in', async () => signIn.status === 302 && cookie.startsWith('arr_mcp_session='));
+
+    // The one that needs a live stack: every service tested for real.
+    await check('dashboard renders live diagnoses for every service', async () => {
+        const res = await authed('/ui');
+        const body = await res.text();
+        return res.status === 200 && config.services !== undefined
+            ? Object.keys(config.services).every(id => body.includes(id))
+            : false;
+    });
+
+    for (const [label, path] of [
+        ['configuration page renders', '/ui/config'],
+        ['logs page renders', '/ui/logs?stream=all'],
+        ['problems stream renders', '/ui/logs?stream=problems'],
+        ['by-service stream renders', '/ui/logs?stream=service'],
+        ['write audit renders', '/ui/audit']
+    ] as const) {
+        await check(label, async () => (await authed(path)).status === 200);
+    }
+
+    await check('no API key is ever rendered into the configuration form', async () => {
+        const body = await (await authed('/ui/config')).text();
+        const keys = Object.values(config.services)
+            .map(s => (s as { api_key?: string } | undefined)?.api_key)
+            .filter((k): k is string => typeof k === 'string' && k.length > 0);
+        return keys.length > 0 && keys.every(k => !body.includes(k));
+    });
+}
+
+await checkUi();
+
 console.log(`\n${passes}/${passes + failures} calls succeeded.`);
 if (missing.length > 0) {
     // Repeated here, not just at the top: a maintainer skimming only the last

--- a/src/app.ts
+++ b/src/app.ts
@@ -46,21 +46,37 @@ export function buildApp(opts: { runtime: Runtime; audit: WriteAudit; logs: LogS
     // We bind 0.0.0.0 because the container must be reachable across the LAN,
     // which drops the SDK's default localhost Host/Origin validation.
     //
-    // `allowedHosts` must be OMITTED, not empty, when the user has pinned no
-    // hostnames: the adapter gates the middleware on `if (allowedHosts)`, and
-    // `[]` is truthy — so passing an empty array installs validation with an
-    // empty allow-list and rejects *every* request with 403. Authentication is
-    // what protects us here; Host pinning is an extra a reverse-proxy user can
-    // opt into.
+    // `allowedHosts` is deliberately NOT passed to the adapter, even though it
+    // accepts one. The adapter installs its middleware when the app is
+    // constructed, which would freeze the value at build time — so pinning a
+    // hostname from the config UI would silently do nothing until a restart,
+    // and that is the one kind of security setting that must never appear to
+    // have applied when it has not.
     //
-    // Read once, at build time, unlike everything else: the Hono adapter
-    // installs this middleware when the app is constructed, so a reload cannot
-    // change it. Pinning hostnames therefore still needs a restart, which is
-    // documented — it is a transport concern, not a service one.
-    const allowedHosts = runtime.config.auth.allowed_hosts;
-    const app = createMcpHonoApp({
-        host: '0.0.0.0',
-        ...(allowedHosts.length > 0 ? { allowedHosts } : {})
+    // Validating here instead means the list is read from the runtime on every
+    // request, like the bearer token, and takes effect the moment it is saved.
+    const app = createMcpHonoApp({ host: '0.0.0.0' });
+
+    /**
+     * An empty list means "accept any Host", which is the right default for a
+     * LAN container reached by IP — and the reason the adapter's own option
+     * could not be used naively: it gates on `if (allowedHosts)`, and `[]` is
+     * truthy, so an empty array installed validation with an empty allow-list
+     * and rejected *every* request with 403. A container that rejects 100% of
+     * traffic looks healthy until someone uses it.
+     */
+    app.use('*', async (c, next) => {
+        const allowed = runtime.config.auth.allowed_hosts;
+        if (allowed.length === 0) return next();
+
+        // Compared without the port: a pinned `arr.example.com` should not stop
+        // working because the browser sent `arr.example.com:6060`.
+        const host = (c.req.header('host') ?? '').toLowerCase();
+        const bare = host.split(':')[0] ?? '';
+        if (allowed.some(a => a.toLowerCase() === host || a.toLowerCase() === bare)) return next();
+
+        logger.warn({ host, ip: c.req.header('x-forwarded-for') ?? 'unknown' }, 'rejected request with an unlisted Host');
+        return c.text('forbidden: Host not allowed', 403);
     });
 
     app.get('/healthz', c => c.json({ status: 'ok', name: NAME, version: VERSION }));

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -44,8 +44,14 @@ export const logger = pino(
         level: process.env.LOG_LEVEL ?? 'info',
         // `app`, not `service`: `service` belongs to the media service a log
         // line is about (radarr, sonarr, …), which is what the config UI's
-        // per-service log stream filters on. Binding both to `service` emits a
+        // "By service" stream filters on. Binding both to `service` emits a
         // duplicate JSON key and silently loses one of them.
+        //
+        // This file used to promise "three log streams" from a design spec
+        // that is not in this repository, so nothing could check the claim.
+        // The three that exist are defined in `web/pages.ts` as LOG_STREAMS —
+        // all activity, problems, and one service — chosen from what this
+        // logger actually binds rather than from the unavailable spec.
         base: { app: 'arr-mcp' },
         serializers: {
             // pino's default `err` serializer spreads every own enumerable

--- a/src/web/configPage.ts
+++ b/src/web/configPage.ts
@@ -184,7 +184,7 @@ export function configPage(opts: {
                 name: 'auth.allowed_hosts',
                 label: 'Allowed hosts (comma separated)',
                 value: opts.config.auth.allowed_hosts.join(', '),
-                note: 'Leave empty to accept any Host — right for a LAN container reached by IP. Changing this one needs a restart.'
+                note: 'Leave empty to accept any Host — right for a LAN container reached by IP. Applies immediately; pin the wrong name and you will lock yourself out until you edit config.yaml by hand.'
             })}
         </fieldset>
 

--- a/src/web/pages.ts
+++ b/src/web/pages.ts
@@ -1,6 +1,6 @@
 import type { ServiceId } from '../config/schema.ts';
 import type { LogRow } from '../core/logs.ts';
-import type { ConnectionDiagnosis } from '../services/types.ts';
+import type { ConnectionDiagnosis, DiskSpace, HealthCheck, ScanState } from '../services/types.ts';
 import { esc, html, humanBytes, raw, shortTime, type SafeHtml } from './html.ts';
 
 /**
@@ -102,6 +102,9 @@ export function dashboardPage(opts: {
     configured: ServiceId[];
     bearerToken: string;
     writeCounts: { applied: number; denied: number; total: number };
+    disks: DiskSpace[];
+    failures: HealthCheck[];
+    scans: ScanState[];
 }): string {
     const cards =
         opts.diagnoses.length === 0
@@ -130,11 +133,83 @@ export function dashboardPage(opts: {
                   )}
               </div>`;
 
+    /**
+     * The four things `stack_health` answers, on the page rather than only
+     * through a tool. Reachability alone is a dashboard that calls a service
+     * healthy while its disk is full and its library has not been scanned for
+     * a day — which is exactly the gap `diagnose` exists to explain after the
+     * fact.
+     */
+    const problems =
+        opts.failures.length === 0
+            ? html`<p class="note">Nothing is reporting a problem.</p>`
+            : html`<table>
+                  <thead><tr><th>Service</th><th>Source</th><th>Type</th><th>Message</th></tr></thead>
+                  <tbody>
+                      ${opts.failures.map(
+                          f => html`<tr>
+                              <td>${f.service}</td>
+                              <td>${f.source}</td>
+                              <td>${f.type}</td>
+                              <td>${f.message}</td>
+                          </tr>`
+                      )}
+                  </tbody>
+              </table>`;
+
+    const disks =
+        opts.disks.length === 0
+            ? html`<p class="note">No service reported disk space.</p>`
+            : html`<table>
+                  <thead><tr><th>Service</th><th>Location</th><th>Free</th><th>Total</th></tr></thead>
+                  <tbody>
+                      ${opts.disks.map(
+                          d => html`<tr>
+                              <td>${d.service}</td>
+                              <td class="mono">${d.path ?? d.label}</td>
+                              <td>${humanBytes(d.freeSpace)}</td>
+                              <td>${d.totalSpace === undefined ? '—' : humanBytes(d.totalSpace)}</td>
+                          </tr>`
+                      )}
+                  </tbody>
+              </table>`;
+
+    const scans =
+        opts.scans.length === 0
+            ? html`<p class="note">No service reported a library scan.</p>`
+            : html`<table>
+                  <thead><tr><th>Service</th><th>Last completed</th><th>Running now</th></tr></thead>
+                  <tbody>
+                      ${opts.scans.map(
+                          s => html`<tr>
+                              <td>${s.service}</td>
+                              <td class="mono">${s.lastCompleted === undefined ? 'unknown' : shortTime(s.lastCompleted)}</td>
+                              <td>${s.running === true ? 'yes' : 'no'}</td>
+                          </tr>`
+                      )}
+                  </tbody>
+              </table>`;
+
     const body = html`<h2>Services</h2>
         <p class="note">
             Tested live, just now. A failure shows what to fix rather than only that it failed.
         </p>
         ${cards}
+
+        <h2>Problems</h2>
+        <div class="panel">${problems}</div>
+
+        <h2>Disk space</h2>
+        <div class="panel">${disks}</div>
+
+        <h2>Library scans</h2>
+        <div class="panel">
+            <p class="note">
+                A library that has not been scanned recently is the usual reason something downloaded is
+                still not playable.
+            </p>
+            ${scans}
+        </div>
 
         <h2>MCP endpoint</h2>
         <div class="panel">
@@ -165,20 +240,81 @@ export function dashboardPage(opts: {
     return layout({ title: 'Dashboard', nav: 'dashboard', version: opts.version, body });
 }
 
+/**
+ * The three streams.
+ *
+ * `logger.ts` has promised "the config UI's three log streams" since Phase 1,
+ * and the design spec that named them is not in this repository — so these are
+ * the three the code can actually support, chosen from what the logger already
+ * binds: everything, only what is wrong, and one service at a time. They are
+ * named tabs rather than a level dropdown because "show me what is broken" is
+ * a question, and picking `40` from a list of numbers is an implementation
+ * detail leaking into the page.
+ */
+export const LOG_STREAMS = [
+    { key: 'all', label: 'All activity', minLevel: 10, hint: 'Everything the server has logged.' },
+    {
+        key: 'problems',
+        label: 'Problems',
+        minLevel: 40,
+        hint: 'Warnings and errors only — what to read first when something is wrong.'
+    },
+    {
+        key: 'service',
+        label: 'By service',
+        minLevel: 10,
+        hint: 'Everything logged about one service, whichever level it was logged at.'
+    }
+] as const;
+
+export type LogStreamKey = (typeof LOG_STREAMS)[number]['key'];
+
 export function logsPage(opts: {
     version: string;
     services: string[];
     selectedService: string;
-    minLevel: number;
+    stream: LogStreamKey;
     streamUrl: string;
     rows: LogRow[];
 }): string {
-    const levels: [number, string][] = [
-        [10, 'Everything'],
-        [30, 'Info and above'],
-        [40, 'Warnings and errors'],
-        [50, 'Errors only']
-    ];
+    const active = LOG_STREAMS.find(s => s.key === opts.stream) ?? LOG_STREAMS[0];
+
+    const tabs = html`<nav style="margin-bottom:.75rem">
+        ${LOG_STREAMS.map(
+            s =>
+                html`<a
+                    href="/ui/logs?stream=${s.key}${s.key === 'service' && opts.selectedService !== ''
+                        ? raw(`&service=${encodeURIComponent(opts.selectedService)}`)
+                        : raw('')}"
+                    class="${s.key === opts.stream ? 'on' : ''}"
+                    >${s.label}</a
+                >`
+        )}
+    </nav>`;
+
+    const picker =
+        opts.stream !== 'service'
+            ? raw('')
+            : html`<form class="inline" method="get" action="/ui/logs">
+                  <input type="hidden" name="stream" value="service">
+                  <div>
+                      <label for="service">Service</label>
+                      <select id="service" name="service">
+                          ${opts.services.length === 0
+                              ? html`<option value="">nothing logged yet</option>`
+                              : opts.services.map(
+                                    s =>
+                                        html`<option
+                                            value="${s}"
+                                            ${s === opts.selectedService ? raw('selected') : raw('')}
+                                        >
+                                            ${s}
+                                        </option>`
+                                )}
+                      </select>
+                  </div>
+                  <button type="submit">Show</button>
+              </form>`;
 
     const body = html`<h2>Logs</h2>
         <p class="note">
@@ -186,33 +322,13 @@ export function logsPage(opts: {
             <span class="mono">docker logs</span>.
         </p>
 
-        <form class="inline" method="get" action="/ui/logs">
-            <div>
-                <label for="level">Level</label>
-                <select id="level" name="level">
-                    ${levels.map(
-                        ([value, label]) =>
-                            html`<option value="${value}" ${value === opts.minLevel ? raw('selected') : raw('')}>
-                                ${label}
-                            </option>`
-                    )}
-                </select>
-            </div>
-            <div>
-                <label for="service">Service</label>
-                <select id="service" name="service">
-                    <option value="">All services</option>
-                    ${opts.services.map(
-                        s =>
-                            html`<option value="${s}" ${s === opts.selectedService ? raw('selected') : raw('')}>
-                                ${s}
-                            </option>`
-                    )}
-                </select>
-            </div>
-            <button type="submit">Apply</button>
-            <label class="row" style="margin:0"><input type="checkbox" id="follow" checked> Auto-refresh</label>
-        </form>
+        ${tabs}
+        <p class="note">${active.hint}</p>
+        ${picker}
+
+        <label class="row" style="margin:0 0 .75rem">
+            <input type="checkbox" id="follow" checked> Auto-refresh
+        </label>
 
         <div class="scroll" id="log-stream" data-url="${opts.streamUrl}">${logTable(opts.rows)}</div>`;
 

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -3,7 +3,7 @@ import { saveConfig } from '../config/save.ts';
 import { ServiceIdSchema, type Config, type ServiceId } from '../config/schema.ts';
 import type { WriteAudit } from '../core/audit.ts';
 import { logger } from '../core/logger.ts';
-import { LEVELS, type LogStore } from '../core/logs.ts';
+import type { LogStore } from '../core/logs.ts';
 import type { Runtime } from '../core/runtime.ts';
 import {
     clearedSessionCookie,
@@ -15,9 +15,18 @@ import {
     SESSION_TTL_MS,
     verifyPassword
 } from '../core/session.ts';
+import { buildStackHealth } from '../tools/stackHealth.ts';
 import { CSS, JS } from './assets.ts';
 import { configPage, SERVICE_IDS } from './configPage.ts';
-import { auditPage, dashboardPage, loginPage, logsPage, type AuditRow } from './pages.ts';
+import {
+    auditPage,
+    dashboardPage,
+    loginPage,
+    logsPage,
+    LOG_STREAMS,
+    type AuditRow,
+    type LogStreamKey
+} from './pages.ts';
 
 export type WebDeps = { runtime: Runtime; audit: WriteAudit; logs: LogStore; name: string; version: string };
 
@@ -85,18 +94,26 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
         if (guard(c) === undefined) return c.redirect('/ui/login', 302);
 
         const snapshot = runtime.current;
-        // Live, in parallel: a dashboard showing cached status is a dashboard
-        // that tells you a dead service is fine. `testConnection` never throws
-        // (services/types.ts), so one unreachable service cannot fail the page.
-        const diagnoses = await Promise.all(snapshot.adapters.map(a => a.testConnection()));
+
+        // Gathered through `buildStackHealth`, the same function `stack_health`
+        // answers from, rather than by calling the adapters again here. Two
+        // implementations of "is the stack healthy" is how the page and the
+        // tool come to disagree — the same reason §8 keeps one library join.
+        // It is live, not cached: a dashboard showing cached status is one
+        // that tells you a dead service is fine, and it degrades rather than
+        // failing when a service is unreachable.
+        const health = await buildStackHealth(snapshot.adapters, { detail: 'full', limit: 50 });
         const rows = audit.recent(500) as { outcome: string }[];
 
         return c.html(
             dashboardPage({
                 version,
-                diagnoses,
+                diagnoses: health.services,
                 configured: snapshot.adapters.map(a => a.id),
                 bearerToken: snapshot.config.auth.bearer_token,
+                disks: health.disks.items,
+                failures: health.failures.items,
+                scans: health.scans,
                 writeCounts: {
                     applied: rows.filter(r => r.outcome === 'applied').length,
                     denied: rows.filter(r => r.outcome === 'denied').length,
@@ -111,16 +128,16 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
     app.get('/ui/logs', c => {
         if (guard(c) === undefined) return c.redirect('/ui/login', 302);
 
-        const { minLevel, service } = logQuery(c);
-        const stream = `/ui/logs.json?level=${minLevel}&service=${encodeURIComponent(service ?? '')}`;
+        const { stream, minLevel, service } = logQuery(c, logs);
+        const url = `/ui/logs.json?stream=${stream}&service=${encodeURIComponent(service ?? '')}`;
 
         return c.html(
             logsPage({
                 version,
                 services: logs.services(),
                 selectedService: service ?? '',
-                minLevel,
-                streamUrl: stream,
+                stream,
+                streamUrl: url,
                 rows: logs.recent({ minLevel, service, limit: 300 })
             })
         );
@@ -131,7 +148,7 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
     app.get('/ui/logs.json', c => {
         if (guard(c) === undefined) return c.json({ error: 'unauthorized' }, 401);
 
-        const { minLevel, service } = logQuery(c);
+        const { minLevel, service } = logQuery(c, logs);
         return c.json({ rows: logs.recent({ minLevel, service, limit: 300 }) }, 200, NO_STORE);
     });
 
@@ -225,15 +242,36 @@ function sessionOf(c: Context, runtime: Runtime): string | undefined {
     return runtime.sessions.verify(token).valid ? token : undefined;
 }
 
-function logQuery(c: Context): { minLevel: number; service: ServiceId | undefined } {
-    const level = Number(c.req.query('level'));
-    const raw = c.req.query('service') ?? '';
-    const parsed = ServiceIdSchema.safeParse(raw);
+/**
+ * Resolves which of the three streams was asked for, and what that means as a
+ * query.
+ *
+ * The service filter is parsed through `ServiceIdSchema`, so an unknown value
+ * becomes "no filter" rather than reaching the store — the ids are a closed
+ * set, and validating against it costs nothing.
+ *
+ * The "by service" stream with no service chosen defaults to the first that
+ * has actually logged, so the tab is never a blank page with a dropdown.
+ */
+function logQuery(
+    c: Context,
+    logs: LogStore
+): { stream: LogStreamKey; minLevel: number; service: ServiceId | undefined } {
+    const requested = c.req.query('stream') ?? 'all';
+    const stream = LOG_STREAMS.find(s => s.key === requested) ?? LOG_STREAMS[0];
 
-    return {
-        minLevel: Number.isFinite(level) && level > 0 ? level : LEVELS.info,
-        service: parsed.success ? parsed.data : undefined
-    };
+    const parsed = ServiceIdSchema.safeParse(c.req.query('service') ?? '');
+    let service = parsed.success ? parsed.data : undefined;
+
+    if (stream.key === 'service' && service === undefined) {
+        const first = ServiceIdSchema.safeParse(logs.services()[0] ?? '');
+        service = first.success ? first.data : undefined;
+    }
+    // Only the by-service stream filters by service; picking one and then
+    // switching to Problems must not silently keep filtering.
+    if (stream.key !== 'service') service = undefined;
+
+    return { stream: stream.key, minLevel: stream.minLevel, service };
 }
 
 /**

--- a/test/configUi.test.ts
+++ b/test/configUi.test.ts
@@ -302,6 +302,73 @@ describe('saving configuration', () => {
     });
 });
 
+describe('allowed_hosts', () => {
+    const get = (host: string) => call('/healthz', { headers: { host } });
+
+    it('accepts any Host when nothing is pinned', async () => {
+        expect((await get('192.168.1.50:6060')).status).toBe(200);
+    });
+
+    // The whole reason this moved out of the adapter: pinning from the config
+    // UI must apply at once, or a security setting appears to have worked when
+    // it has not.
+    it('applies a pinned host immediately, with no restart', async () => {
+        await signIn();
+        await call(
+            '/ui/config',
+            form({ csrf: await csrfFrom(), 'auth.username': 'admin', 'auth.allowed_hosts': 'arr.example.com' })
+        );
+
+        expect((await get('arr.example.com')).status).toBe(200);
+        expect((await get('evil.example.com')).status).toBe(403);
+    });
+
+    // A pinned bare hostname must not stop working because the browser sent a
+    // port, which is what every browser does.
+    it('matches a pinned bare hostname when the request carries a port', async () => {
+        await signIn();
+        await call(
+            '/ui/config',
+            form({ csrf: await csrfFrom(), 'auth.username': 'admin', 'auth.allowed_hosts': 'arr.example.com' })
+        );
+
+        expect((await get('arr.example.com:6060')).status).toBe(200);
+    });
+
+    /**
+     * The lockout the README warns about, demonstrated.
+     *
+     * Once a host is pinned, the config page is only reachable *through that
+     * host* — so the browser you pinned from stops working if you pinned the
+     * wrong name. Undoing it therefore has to come from an allowed Host, which
+     * is why the second save below sets the header explicitly. From a real
+     * browser with no matching name, the only way back is editing config.yaml.
+     */
+    it('locks out an unlisted host, and can be undone from a listed one', async () => {
+        await signIn();
+        await call(
+            '/ui/config',
+            form({ csrf: await csrfFrom(), 'auth.username': 'admin', 'auth.allowed_hosts': 'arr.example.com' })
+        );
+        expect((await get('other.example.com')).status).toBe(403);
+
+        // Even the config page itself is unreachable from an unlisted host.
+        expect((await call('/ui/config', { headers: { host: 'other.example.com' } })).status).toBe(403);
+
+        const page = await (await call('/ui/config', { headers: { host: 'arr.example.com' } })).text();
+        const csrf = /name="csrf" value="([^"]+)"/.exec(page)?.[1] ?? '';
+        await call('/ui/config', {
+            ...form({ csrf, 'auth.username': 'admin', 'auth.allowed_hosts': '' }),
+            headers: {
+                'content-type': 'application/x-www-form-urlencoded',
+                host: 'arr.example.com'
+            }
+        });
+
+        expect((await get('other.example.com')).status).toBe(200);
+    });
+});
+
 describe('logs and audit', () => {
     it('serves log rows as JSON', async () => {
         logs.write(JSON.stringify({ level: 30, time: Date.now(), msg: 'hello', service: 'radarr' }));
@@ -311,25 +378,61 @@ describe('logs and audit', () => {
         expect(body.rows.some(r => r.msg === 'hello')).toBe(true);
     });
 
-    it('filters the log stream by service', async () => {
-        logs.write(JSON.stringify({ level: 30, time: Date.now(), msg: 'r', service: 'radarr' }));
-        logs.write(JSON.stringify({ level: 30, time: Date.now(), msg: 's', service: 'sonarr' }));
-        await signIn();
+    const seedLogs = () => {
+        logs.write(JSON.stringify({ level: 30, time: Date.now(), msg: 'radarr-info', service: 'radarr' }));
+        logs.write(JSON.stringify({ level: 30, time: Date.now(), msg: 'sonarr-info', service: 'sonarr' }));
+        logs.write(JSON.stringify({ level: 50, time: Date.now(), msg: 'sonarr-error', service: 'sonarr' }));
+    };
 
-        const body = (await (await call('/ui/logs.json?service=sonarr&level=10')).json()) as {
-            rows: { msg: string }[];
-        };
-        expect(body.rows.map(r => r.msg)).toEqual(['s']);
+    const streamRows = async (query: string): Promise<string[]> => {
+        const body = (await (await call(`/ui/logs.json${query}`)).json()) as { rows: { msg: string }[] };
+        return body.rows.map(r => r.msg).sort();
+    };
+
+    // The three streams `logger.ts` has promised since Phase 1.
+    it('the "all" stream returns everything', async () => {
+        seedLogs();
+        await signIn();
+        expect(await streamRows('?stream=all')).toEqual(['radarr-info', 'sonarr-error', 'sonarr-info']);
+    });
+
+    it('the "problems" stream returns only warnings and errors', async () => {
+        seedLogs();
+        await signIn();
+        expect(await streamRows('?stream=problems')).toEqual(['sonarr-error']);
+    });
+
+    it('the "by service" stream returns one service at every level', async () => {
+        seedLogs();
+        await signIn();
+        expect(await streamRows('?stream=service&service=sonarr')).toEqual(['sonarr-error', 'sonarr-info']);
+    });
+
+    // Picking a service and then switching to Problems must not keep filtering.
+    it('ignores a service on a stream that is not the by-service one', async () => {
+        seedLogs();
+        await signIn();
+        expect(await streamRows('?stream=all&service=sonarr')).toHaveLength(3);
+    });
+
+    it('falls back to the first service that logged, so the tab is never blank', async () => {
+        seedLogs();
+        await signIn();
+        expect(await streamRows('?stream=service')).toEqual(['radarr-info']);
+    });
+
+    it('falls back to the all stream when asked for one that does not exist', async () => {
+        seedLogs();
+        await signIn();
+        expect(await streamRows('?stream=nonsense')).toHaveLength(3);
     });
 
     it('ignores a service filter that is not a real service id', async () => {
-        logs.write(JSON.stringify({ level: 30, time: Date.now(), msg: 'r', service: 'radarr' }));
+        seedLogs();
         await signIn();
-
-        const body = (await (await call('/ui/logs.json?service=%27%20OR%201=1--&level=10')).json()) as {
-            rows: unknown[];
-        };
-        expect(body.rows.length).toBeGreaterThan(0);
+        const rows = await streamRows('?stream=service&service=%27%20OR%201=1--');
+        // Falls back to the first real service rather than reaching the store.
+        expect(rows).toEqual(['radarr-info']);
     });
 
     it('renders the audit page', async () => {


### PR DESCRIPTION
Closes the four gaps I listed as outstanding on #54, plus the README, which was wrong the moment 0.6.0 tagged.

## The README was stale again

0.6.0 released after #54's docs merged, so the status callout still said "0.5 — writes", the quick start pinned `:0.5`, and the roadmap row said 0.6 was unreleased. `RELEASING.md` already has a section about exactly this. Fixed, and the timing is worth noting: updating the README *in* the feature PR isn't enough when the release merges afterwards.

## Dashboard showed only reachability

It now answers the same four questions `stack_health` does — reachable, reporting a problem, disk filling up, when each library last finished a scan — and gathers them **through `buildStackHealth`** rather than calling the adapters again. Two implementations of "is the stack healthy" is how a page and a tool come to disagree; same reasoning as §8 keeping one library join.

A dashboard that calls a service healthy while its disk is full is the gap `diagnose` exists to explain after the fact.

## "Three log streams" was a promise with nothing behind it

`logger.ts` has claimed three since Phase 1, from a design spec that isn't in this repository — so nothing could check the claim, and #54 shipped a level dropdown instead.

There are now three, defined once as `LOG_STREAMS` and chosen from what the logger actually binds:

| Stream | Shows |
| --- | --- |
| All activity | Everything |
| Problems | Warnings and errors only |
| By service | One service, at every level |

Named tabs rather than a numeric level picker, because *"show me what is broken"* is a question and `40` is an implementation detail. The stale comment now points at the code instead of at a spec nobody can read.

## `allowed_hosts` needed a restart

This was the one field where that mattered — **a security setting that appears to have applied when it hasn't is worse than one that plainly refuses.** The adapter freezes its allow-list when the app is constructed, so validation moved into middleware that reads the runtime per request. A pinned bare hostname now also matches a request carrying a port, which every browser sends.

The lockout this creates is real, and tested rather than hidden: pinning the wrong name locks you out of the page you'd fix it from, and the way back is editing `config.yaml`. Documented in the README and in the form's own help text.

## Nothing mechanical caught a UI regression

The tool cases proved the adapters; nothing touched `/ui`. That's the shape of failure that put seven defects into 0.3.0 with a green script.

`npm run integration` now signs in and renders every page against the live stack, and asserts **no API key reaches the configuration form**. The cases are read-only — they never save, so running the script cannot change a maintainer's configuration.

## Verification

- **947 tests / 47 files**; typecheck, lint and build clean.
- **37/37 against a live eight-service stack**, including ten UI cases, with the dashboard rendering live diagnoses for all eight.
- Confirmed the run leaves `config.yaml` byte-untouched — the `persist: false` fix from #54 holding against a real config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
