### PR TITLE
docs: point first-run instructions at the bare host

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,30 +199,59 @@ none, **it refuses and lists them** rather than picking:
 
 ## Quick start
 
+Also in the repo as [`docker-compose.example.yml`](docker-compose.example.yml).
+
 ```yaml
 services:
   arr-mcp:
-    image: ghcr.io/bardesss/arr-mcp:0.6
-    ports: ['6060:6060']
-    volumes: ['./config:/config']
+    image: ghcr.io/bardesss/arr-mcp:latest
+    container_name: arr-mcp
+    ports:
+      - 6060:6060
+    volumes:
+      - ./config:/config
     environment:
       - PUID=1000
       - PGID=1000
       - TZ=Europe/Amsterdam
     restart: unless-stopped
+    healthcheck:
+      test: ['CMD', 'wget', '-qO-', 'http://localhost:6060/healthz']
 ```
 
 Tags are `X.Y.Z`, `X.Y`, `X` and `latest` for releases, plus `main` for
-bleeding edge. Pin a minor while the tool surface is still moving.
+bleeding edge. Pin a minor — `:0.6` — if you would rather approve each new tool
+surface yourself.
 
-On first start, `config/config.yaml` is created and **the config UI password
-and the MCP bearer token are printed once to the container log** —
-`docker logs arr-mcp`. The password is not stored anywhere and will not be
-shown again; only a hash of it is kept.
+### First run
 
-Then open **`http://<host>:6060/ui`**, sign in, and add your services from the
-Configuration page. Saving applies immediately — no restart. The bearer token
-your MCP client needs is on the dashboard, so you only need the log once.
+**1. Start it, then read the log once.** On first start `config/config.yaml` is
+created and two generated credentials are printed — the config UI password and
+the MCP bearer token:
+
+```console
+$ docker compose up -d && docker compose logs arr-mcp
+config UI credentials — this password is not stored and will not be shown again
+    username: admin  password: ……
+bearer token for /mcp — also shown in the config UI
+    token: ……
+first run — sign in to the config UI to add services
+```
+
+Only a hash of the password is kept, so **this is the only time you will see
+it.** The bearer token you can always read again from the dashboard; the
+password you cannot — if you lose it, see [Config UI](#config-ui) for the reset.
+
+**2. Open `http://<host>:6060`** — the bare host, no path — and sign in with
+that username and password.
+
+**3. Add your services** on the Configuration page: switch one on, paste its URL
+and API key, save. Saving applies immediately; there is no restart. Nothing is
+configured until you do this, and a fresh install with no services answers
+nothing — that is expected, not a fault.
+
+**4. Point your MCP client at `http://<host>:6060/mcp`** using the bearer token
+shown on the dashboard.
 
 Everything the UI does is still just `config.yaml`, and editing it by hand
 remains supported:
@@ -271,7 +300,7 @@ editing `config.yaml` by hand and restarting.
 
 ## Config UI
 
-`http://<host>:6060/ui`
+`http://<host>:6060`
 
 | Page | What it is for |
 | --- | --- |

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -2,8 +2,10 @@ services:
   arr-mcp:
     image: ghcr.io/bardesss/arr-mcp:latest
     container_name: arr-mcp
-    ports: ['6060:6060']
-    volumes: ['./config:/config']
+    ports: 
+      - 6060:6060
+    volumes:
+      - ./config:/config
     environment:
       - PUID=1000
       - PGID=1000
@@ -12,9 +14,10 @@ services:
     healthcheck:
       test: ['CMD', 'wget', '-qO-', 'http://localhost:6060/healthz']
 
-# On first start, read the generated bearer token out of the log:
+# On first start the config UI password and the MCP bearer token are printed
+# once to the log — the password is only ever shown here:
 #
-#   docker compose logs arr-mcp | grep 'first run'
+#   docker compose logs arr-mcp
 #
-# then add your services to ./config/config.yaml and restart. Hot-reload
-# arrives with the config UI in 0.5; until then a restart is required.
+# Then open http://<host>:6060, sign in, and add your services from the
+# Configuration page. Saving applies immediately; no restart.

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,6 @@ if (runtime.current.adapters.length === 0) {
 serve({ fetch: buildApp({ runtime, audit, logs }).fetch, port: PORT, hostname: '0.0.0.0' }, info => {
     logger.info(
         { port: info.port, adapters: runtime.current.adapters.map(a => a.id) },
-        'arr-mcp listening — config UI at /ui'
+        `arr-mcp listening — open the config UI at http://<host>:${info.port}`
     );
 });


### PR DESCRIPTION
The docs advertised `http://<host>:6060/ui`, which reads as though the path is
required. It never was — `/` has redirected to the dashboard since the UI
shipped (`src/web/routes.ts:91`).

No routing changes. The `/ui` prefix earns its keep: it reserves a namespace so
the UI cannot collide with `/mcp` or `/healthz`, and it keeps reverse-proxy
rules simple to write. The problem was only that the docs pointed at the long
form.

## What changed

- **Quick start now mirrors `docker-compose.example.yml` verbatim** and links to
  it, rather than carrying a second copy that had already drifted — the README
  had collapsed `ports`/`volumes` to flow syntax and dropped `container_name`
  and the healthcheck.
- **First run is four numbered steps**, and step one shows the actual log lines.
  "Read the credentials out of the log" is not much help when you do not know
  what you are looking for. It also says outright that the password is the one
  credential that cannot be recovered, which the old wording left to inference.
- **The compose example's trailing comment predated the config UI.** It promised
  hot reload "in 0.5", told you to hand-edit `config.yaml` and restart, and
  suggested `grep 'first run'` — which matches neither credential line.
- **The startup log named a path**; it now prints the URL with the bound port,
  so the first thing in `docker logs` is the address you type.

Both `/ui` URLs in the README are now `http://<host>:6060`.

## Open items

Not in this PR, tracked here so they are not lost:

- **First-run should not require reading a log at all.** A browser setup wizard
  is designed and agreed — first visit to an unclaimed instance chooses the
  username and password, and secrets stop being written to container logs
  entirely. Spec and implementation plan are being written next; this PR is the
  interim improvement to the flow that exists today. It supersedes most of the
  "First run" section it just rewrote.
- **The log excerpt in step 1 is transcribed from `printCredentials`**
  (`src/core/runtime.ts:124`), not captured from a live container. Field names
  and messages match the source, but pino emits one JSON line per record whereas
  the README formats them as an indented pair for readability. A real
  `docker compose up` against a fresh config dir would settle the exact shape.
  The wizard work above will delete this excerpt anyway.

## Verification

`npm test` — 947 passing across 47 files. `tsc --noEmit` and `eslint` clean.
Docs-only plus one log string, so no behaviour is under test here.

## Note on the branch

`fix/config-ui-gaps` was merged as `8f92c30` and released as 0.6.1 while this
was in progress, so this branch is cut fresh from `main` with only the docs
commit cherry-picked. Nothing from #56 is duplicated.
