### PR TITLE
fix: set up arr-mcp in the browser instead of the container log

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,33 +225,30 @@ surface yourself.
 
 ### First run
 
-**1. Start it, then read the log once.** On first start `config/config.yaml` is
-created and two generated credentials are printed — the config UI password and
-the MCP bearer token:
+**1. Start it and open `http://<host>:6060`** — the bare host, no path. There is
+nothing to read out of the container log.
 
 ```console
-$ docker compose up -d && docker compose logs arr-mcp
-config UI credentials — this password is not stored and will not be shown again
-    username: admin  password: ……
-bearer token for /mcp — also shown in the config UI
-    token: ……
-first run — sign in to the config UI to add services
+$ docker compose up -d
 ```
 
-Only a hash of the password is kept, so **this is the only time you will see
-it.** The bearer token you can always read again from the dashboard; the
-password you cannot — if you lose it, see [Config UI](#config-ui) for the reset.
+**2. Claim it.** Nobody has set this instance up yet, so the first page is a
+setup form rather than a sign-in: choose a username and a password of at least
+12 characters. You land on the dashboard already signed in.
 
-**2. Open `http://<host>:6060`** — the bare host, no path — and sign in with
-that username and password.
+> Do this **before** exposing the port. Until the instance is claimed, whoever
+> loads that page first owns it — and it holds every service's API key. On a
+> home LAN that is a walk from the terminal to the browser; behind a port
+> forward it is a race with the internet.
 
 **3. Add your services** on the Configuration page: switch one on, paste its URL
 and API key, save. Saving applies immediately; there is no restart. Nothing is
 configured until you do this, and a fresh install with no services answers
 nothing — that is expected, not a fault.
 
-**4. Point your MCP client at `http://<host>:6060/mcp`** using the bearer token
-shown on the dashboard.
+Your MCP client goes to `http://<host>:6060/mcp`, with the bearer token shown on
+the dashboard. No password is ever written to a log, so `docker logs` is for
+diagnosing the container, not for retrieving credentials.
 
 Everything the UI does is still just `config.yaml`, and editing it by hand
 remains supported:
@@ -325,9 +322,12 @@ handing it to your MCP client is the point — and it is masked until you ask.
 **Logs are a ring buffer**, kept beside your config and capped, so a chatty
 service cannot fill the disk. Full history stays in `docker logs`.
 
-Sign-in is a username and password, generated on first run alongside the bearer
-token. If you lose the password, delete the `password_hash` line from
-`config.yaml` and restart — a new one is generated and printed.
+Sign-in is a username and password you choose the first time you open the UI.
+Only a scrypt hash is stored, so the password cannot be recovered — but it can
+be replaced: delete the `password_hash` line from `config.yaml` and restart, and
+the setup page comes back exactly as it does on a fresh install. An instance
+with no `password_hash` is *unclaimed*, and every page redirects to setup until
+someone claims it.
 
 The UI is served over plain http on your LAN, like the services it manages.
 Put it behind a reverse proxy with TLS if it needs to leave the LAN, and pin

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -14,10 +14,9 @@ services:
     healthcheck:
       test: ['CMD', 'wget', '-qO-', 'http://localhost:6060/healthz']
 
-# On first start the config UI password and the MCP bearer token are printed
-# once to the log — the password is only ever shown here:
-#
-#   docker compose logs arr-mcp
-#
-# Then open http://<host>:6060, sign in, and add your services from the
+# Nothing to read out of the log. Start it, open http://<host>:6060, and choose
+# a username and password on the setup page — then add your services from the
 # Configuration page. Saving applies immediately; no restart.
+#
+# Claim it before exposing the port: until you do, whoever loads that page
+# first owns the instance.

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -4,7 +4,6 @@ import { join } from 'node:path';
 import { parse, stringify } from 'yaml';
 import * as z from 'zod/v4';
 import { logger } from '../core/logger.ts';
-import { generatePassword, hashPassword } from '../core/session.ts';
 import { ConfigSchema, type Config } from './schema.ts';
 
 const FILENAME = 'config.yaml';
@@ -12,21 +11,25 @@ const FILENAME = 'config.yaml';
 const generateToken = (): string => randomBytes(32).toString('hex');
 
 /**
- * Credentials created on a run, returned so `index.ts` can print them once.
+ * Credentials created on a run.
  *
- * The password is deliberately not stored anywhere — only its hash reaches
- * `config.yaml` — so this is the only moment it exists in a form anyone can
- * read. That is why it travels back out of `loadConfig` rather than being
- * logged from in here: the loader should not decide what gets printed.
+ * Only the bearer token, which has no interactive path: a config without one
+ * has no working `/mcp` and no way to obtain one, so it must be generated. A
+ * password does have an interactive path — the setup page — so the loader
+ * never invents one, and no secret here is ever passed to the logger.
  */
-export type GeneratedCredentials = { bearerToken?: string; password?: string; username?: string };
+export type GeneratedCredentials = { bearerToken?: string };
 
-/** Written on first run so the knobs are discoverable without reading docs. */
-const seedConfig = (password: string) => ({
+/**
+ * Written on first run so the knobs are discoverable without reading docs.
+ *
+ * No `password_hash`: a fresh install is *unclaimed*, and the config UI serves
+ * its setup page until someone chooses a password in the browser.
+ */
+const seedConfig = () => ({
     auth: {
         bearer_token: generateToken(),
         username: 'admin',
-        password_hash: hashPassword(password),
         allowed_hosts: [] as string[]
     },
     services: {}
@@ -43,10 +46,9 @@ const seedConfig = (password: string) => ({
  * The maintainer scripts load this file only to reach the services it names,
  * and a read must not have side effects on the user's credentials. Before this
  * existed, running `npm run integration` against a config predating the config
- * UI silently backfilled a `password_hash` into it — generating a password
- * that the script never printed, so nobody could ever know it. Missing
- * credentials are still synthesised in memory, because the schema requires
- * them and a script has no business failing over a field it does not use.
+ * UI silently backfilled credentials into it. A missing bearer token is still
+ * synthesised in memory, because the schema requires it and a script has no
+ * business failing over a field it does not use.
  */
 export async function loadConfig(
     configDir: string,
@@ -69,15 +71,14 @@ export async function loadConfig(
                 `no config.yaml in ${configDir} — start arr-mcp once to create one, or point ARR_MCP_CONFIG_DIR at an existing config directory.`
             );
         }
-        const password = generatePassword();
-        const seeded = seedConfig(password);
+        const seeded = seedConfig();
         // 0o600: the file holds the bearer token and every service API key.
         await writeFile(path, stringify(seeded), { mode: 0o600 });
-        logger.info({ path }, 'created config.yaml with generated credentials');
+        logger.info({ path }, 'created config.yaml — no password set yet');
         return {
             config: ConfigSchema.parse(seeded),
             created: true,
-            generated: { bearerToken: seeded.auth.bearer_token, password, username: 'admin' }
+            generated: { bearerToken: seeded.auth.bearer_token }
         };
     }
 
@@ -96,28 +97,22 @@ export async function loadConfig(
     const auth = (obj.auth ?? {}) as { bearer_token?: string; password_hash?: string; username?: string };
     const generated: GeneratedCredentials = {};
 
-    // Backfill rather than refuse to start: someone who deleted a credential,
-    // or hand-wrote a config without one, should get a working server and be
-    // told where the replacement came from. Deleting `password_hash` is also
-    // the documented way to ask for a new password when you have lost it, so
-    // this path is a feature, not only a repair.
+    // The bearer token is backfilled rather than refused because it has no
+    // interactive path: a config missing one has no working /mcp, and no way
+    // to get a working one.
+    //
+    // `password_hash` is deliberately *not* backfilled. Its absence means
+    // unclaimed, which the config UI resolves in the browser — repairing it
+    // here would claim the instance on the user's behalf with a password
+    // nobody would ever see. Deleting the line is the documented way to ask
+    // for a new password, and this is what makes that work.
     if (!auth.bearer_token) {
         auth.bearer_token = generateToken();
         generated.bearerToken = auth.bearer_token;
-    }
-    if (!auth.password_hash) {
-        const password = generatePassword();
-        auth.password_hash = hashPassword(password);
-        auth.username ??= 'admin';
-        generated.password = password;
-        generated.username = auth.username;
-    }
-
-    if (generated.bearerToken !== undefined || generated.password !== undefined) {
         obj.auth = auth;
         if (persist) {
             await writeFile(path, stringify(obj), { mode: 0o600 });
-            logger.warn({ path }, 'config.yaml was missing a credential; generated one');
+            logger.warn({ path }, 'config.yaml was missing its bearer token; generated one');
         }
     }
 

--- a/src/config/save.ts
+++ b/src/config/save.ts
@@ -35,7 +35,12 @@ export async function saveConfig(configDir: string, next: Config): Promise<void>
 
     doc.setIn(['auth', 'bearer_token'], value.auth.bearer_token);
     doc.setIn(['auth', 'username'], value.auth.username);
-    doc.setIn(['auth', 'password_hash'], value.auth.password_hash);
+    // Deleted rather than set when absent: `setIn` with `undefined` writes a
+    // null-valued key, and a config carrying `password_hash: null` reads back
+    // as claimed-with-an-empty-hash — an instance nobody can sign in to, and
+    // one the setup page will not rescue because it no longer looks unclaimed.
+    if (value.auth.password_hash === undefined) doc.deleteIn(['auth', 'password_hash']);
+    else doc.setIn(['auth', 'password_hash'], value.auth.password_hash);
     doc.setIn(['auth', 'allowed_hosts'], value.auth.allowed_hosts);
 
     // Services are replaced wholesale rather than merged key by key: a service

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -112,17 +112,19 @@ export const ConfigSchema = z.object({
          *  a random username helps nobody and is one more thing to look up. */
         username: z.string().min(1).default('admin'),
         /**
-         * scrypt hash of the UI password, `scrypt$salt$hash`. Required for the
-         * same reason `bearer_token` is: loadConfig always injects one before
-         * parsing, so the only way it is missing is a hand-edited file that
-         * deleted it — which must fail loudly rather than default to something
-         * that lets anyone in.
+         * scrypt hash of the UI password, `scrypt$salt$hash`.
          *
-         * The password itself is never stored. It is printed once, on the run
-         * that generates it, and cannot be recovered afterwards — deleting
-         * this line is how you ask for a new one.
+         * Optional, unlike `bearer_token`, and the difference is the whole
+         * design: absent means **unclaimed**, and the config UI serves its
+         * setup page instead of a login form until someone chooses a password
+         * in the browser. A bearer token has no interactive path, so a missing
+         * one must be generated; a password does, so one is never invented.
+         *
+         * Deleting this line is how you ask for a new password, and it puts
+         * the instance on exactly the path a fresh install takes. The password
+         * itself is never stored and never logged.
          */
-        password_hash: z.string().min(1),
+        password_hash: z.string().min(1).optional(),
         /**
          * Hostnames the MCP endpoint may be reached on, for the SDK's DNS
          * rebinding protection. Empty means "accept any Host", which is the

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -57,10 +57,8 @@ export class Runtime {
     }
 
     static async start(configDir: string, audit: WriteAudit): Promise<{ runtime: Runtime; created: boolean }> {
-        const { config, created, generated } = await loadConfig(configDir);
-        const runtime = new Runtime(configDir, audit, config);
-        runtime.printCredentials(generated);
-        return { runtime, created };
+        const { config, created } = await loadConfig(configDir);
+        return { runtime: new Runtime(configDir, audit, config), created };
     }
 
     /**
@@ -119,19 +117,6 @@ export class Runtime {
         logger.info({ services: this.#snapshot.adapters.map(a => a.id) }, 'configuration reloaded');
     }
 
-    /** Printed once, on the run that generates them — the password cannot be
-     *  recovered afterwards, only replaced. */
-    printCredentials(generated: { bearerToken?: string; password?: string; username?: string }): void {
-        if (generated.password !== undefined) {
-            logger.info(
-                { username: generated.username ?? 'admin', password: generated.password },
-                'config UI credentials — this password is not stored and will not be shown again'
-            );
-        }
-        if (generated.bearerToken !== undefined) {
-            logger.info({ token: generated.bearerToken }, 'bearer token for /mcp — also shown in the config UI');
-        }
-    }
 }
 
 function buildSnapshot(config: Config, audit: WriteAudit, confirm: ConfirmTokens): RuntimeSnapshot {

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,13 +20,17 @@ attachLogStore(logs);
 // watching `docker logs`, rather than the first time they ask for a deletion.
 const audit = WriteAudit.open(CONFIG_DIR);
 
-const { runtime, created } = await Runtime.start(CONFIG_DIR, audit);
+const { runtime } = await Runtime.start(CONFIG_DIR, audit);
 
-if (created) {
-    logger.info({ config: `${CONFIG_DIR}/config.yaml` }, 'first run — sign in to the config UI to add services');
-}
-
-if (runtime.current.adapters.length === 0) {
+if (runtime.config.auth.password_hash === undefined) {
+    // Deliberately the loudest line at startup: until someone claims it, this
+    // instance belongs to whoever loads the page first. No credential is
+    // printed here or anywhere else — the password is chosen in the browser.
+    logger.warn(
+        { port: PORT },
+        `arr-mcp is not set up yet — open http://<host>:${PORT} to choose a username and password`
+    );
+} else if (runtime.current.adapters.length === 0) {
     logger.warn(
         { config: `${CONFIG_DIR}/config.yaml` },
         'no services configured — add them in the config UI, or edit config.yaml'

--- a/src/web/pages.ts
+++ b/src/web/pages.ts
@@ -56,13 +56,59 @@ export function layout(opts: {
 </html>`;
 }
 
+/**
+ * Shown until someone claims the instance — a fresh install has no password at
+ * all, so there is nothing a login form could accept.
+ *
+ * No `nav`: there is nowhere else to go yet, and a sign-out button on a page
+ * with no session is nonsense. The warning is not decoration — between the
+ * container starting and this form being submitted, the instance belongs to
+ * whoever reaches it first.
+ */
+export function setupPage(opts: { version: string; error?: string | undefined }): string {
+    const body = html`<div class="login">
+        <div class="panel">
+            <h2>Set up arr-mcp</h2>
+            <p class="note">
+                Nobody has claimed this instance yet. Choose a username and password — until you
+                do, anyone who reaches this page can claim it instead.
+            </p>
+            <form method="post" action="/ui/setup">
+                <div class="field">
+                    <label for="username">Username</label>
+                    <input id="username" name="username" value="admin" autocomplete="username" autofocus required>
+                </div>
+                <div class="field">
+                    <label for="password">Password</label>
+                    <input id="password" name="password" type="password" autocomplete="new-password"
+                           minlength="12" required>
+                </div>
+                <div class="field">
+                    <label for="confirm">Confirm password</label>
+                    <input id="confirm" name="confirm" type="password" autocomplete="new-password"
+                           minlength="12" required>
+                </div>
+                <button type="submit">Claim this instance</button>
+            </form>
+        </div>
+    </div>`;
+
+    return layout({
+        title: 'Set up',
+        version: opts.version,
+        body,
+        ...(opts.error === undefined ? {} : { message: { kind: 'err' as const, text: opts.error } })
+    });
+}
+
 export function loginPage(opts: { version: string; error?: string | undefined }): string {
     const body = html`<div class="login">
         <div class="panel">
             <h2>Sign in</h2>
             <p class="note">
-                The password was printed to the container log on first start —
-                <span class="mono">docker logs arr-mcp</span>.
+                Lost the password? Delete the <span class="mono">password_hash</span> line from
+                <span class="mono">config.yaml</span> and restart — you will be offered the setup
+                page again, the same as a fresh install.
             </p>
             <form method="post" action="/ui/login">
                 <div class="field">
@@ -215,7 +261,7 @@ export function dashboardPage(opts: {
         <div class="panel">
             <p class="note">
                 Point your MCP client at <span class="mono">/mcp</span> on this host and give it this bearer
-                token. It is the same token printed on first start.
+                token. This page is the only place it is shown — it is never written to a log.
             </p>
             <div class="token">
                 <input id="bearer" type="password" value="${opts.bearerToken}" readonly>

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -23,10 +23,15 @@ import {
     dashboardPage,
     loginPage,
     logsPage,
+    setupPage,
     LOG_STREAMS,
     type AuditRow,
     type LogStreamKey
 } from './pages.ts';
+
+/** Length only, no character-class rules: the classes push people towards
+ *  `Password1!` and buy nothing a longer passphrase does not. */
+const MIN_PASSWORD = 12;
 
 export type WebDeps = { runtime: Runtime; audit: WriteAudit; logs: LogStore; name: string; version: string };
 
@@ -49,14 +54,65 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
     app.get('/ui/app.css', c => c.body(CSS, 200, { 'content-type': 'text/css; charset=utf-8', ...CACHE }));
     app.get('/ui/app.js', c => c.body(JS, 200, { 'content-type': 'text/javascript; charset=utf-8', ...CACHE }));
 
+    // --- setup ----------------------------------------------------------
+    //
+    // An instance with no `password_hash` is *unclaimed*: nothing has been set
+    // up yet, so there is no password any sign-in could satisfy. Every UI route
+    // funnels here until someone claims it.
+
+    const unclaimed = (): boolean => runtime.config.auth.password_hash === undefined;
+    const entry = (): string => (unclaimed() ? '/ui/setup' : '/ui/login');
+
+    app.get('/ui/setup', c => {
+        if (!unclaimed()) return c.redirect('/ui/login', 302);
+        return c.html(setupPage({ version }));
+    });
+
+    /**
+     * No CSRF token on this form, deliberately.
+     *
+     * There is no session to bind one to, and forging a claim against an
+     * unclaimed instance gets an attacker precisely what loading the page
+     * directly would have got them. Every other form in this file keeps its
+     * token, because every other form acts on an instance someone owns.
+     */
+    app.post('/ui/setup', async c => {
+        if (!unclaimed()) return c.redirect('/ui/login', 302);
+
+        const body = await c.req.parseBody();
+        const username = str(body.username).trim();
+        const password = str(body.password);
+
+        const reject = (text: string) => c.html(setupPage({ version, error: text }), 400);
+        if (username === '') return reject('Choose a username.');
+        if (password.length < MIN_PASSWORD) return reject(`Use a password of at least ${MIN_PASSWORD} characters.`);
+        if (password !== str(body.confirm)) return reject('Those two passwords do not match.');
+
+        // Single-threaded through the await below, so no second request can
+        // interleave between the `unclaimed()` check above and the write.
+        await saveConfig(runtime.configDir, {
+            ...runtime.config,
+            auth: { ...runtime.config.auth, username, password_hash: hashPassword(password) }
+        });
+        await runtime.reload();
+
+        const token = runtime.sessions.issue();
+        c.header('set-cookie', sessionCookie(token, Math.floor(SESSION_TTL_MS / 1000)));
+        logger.info({ ip: ipOf(c), username }, 'config UI claimed');
+        return c.redirect('/ui', 302);
+    });
+
     // --- login ----------------------------------------------------------
 
     app.get('/ui/login', c => {
+        if (unclaimed()) return c.redirect('/ui/setup', 302);
         if (sessionOf(c, runtime) !== undefined) return c.redirect('/ui', 302);
         return c.html(loginPage({ version }));
     });
 
     app.post('/ui/login', async c => {
+        if (unclaimed()) return c.redirect('/ui/setup', 302);
+
         const form = await c.req.parseBody();
         const username = str(form.username);
         const password = str(form.password);
@@ -65,8 +121,11 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
         // One message for both wrong-username and wrong-password, and the
         // password check runs either way: a login form that answers faster for
         // an unknown user tells an attacker which names exist.
+        //
+        // The hash is present by the time we get here, but the type no longer
+        // proves it, and a missing hash must never read as a valid login.
         const nameOk = username === auth.username;
-        const passOk = verifyPassword(password, auth.password_hash);
+        const passOk = auth.password_hash !== undefined && verifyPassword(password, auth.password_hash);
 
         if (!nameOk || !passOk) {
             logger.warn({ ip: ipOf(c), username }, 'rejected config UI sign-in');
@@ -86,12 +145,14 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
 
     // --- everything below requires a session ----------------------------
 
-    const guard = (c: Context): string | undefined => sessionOf(c, runtime);
+    // Unclaimed counts as "no session" regardless of what cookie was presented:
+    // a session predating a credential reset must not outlive it.
+    const guard = (c: Context): string | undefined => (unclaimed() ? undefined : sessionOf(c, runtime));
 
-    app.get('/', c => c.redirect(guard(c) === undefined ? '/ui/login' : '/ui', 302));
+    app.get('/', c => c.redirect(guard(c) === undefined ? entry() : '/ui', 302));
 
     app.get('/ui', async c => {
-        if (guard(c) === undefined) return c.redirect('/ui/login', 302);
+        if (guard(c) === undefined) return c.redirect(entry(), 302);
 
         const snapshot = runtime.current;
 
@@ -126,7 +187,7 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
     // --- logs -----------------------------------------------------------
 
     app.get('/ui/logs', c => {
-        if (guard(c) === undefined) return c.redirect('/ui/login', 302);
+        if (guard(c) === undefined) return c.redirect(entry(), 302);
 
         const { stream, minLevel, service } = logQuery(c, logs);
         const url = `/ui/logs.json?stream=${stream}&service=${encodeURIComponent(service ?? '')}`;
@@ -155,7 +216,7 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
     // --- write audit ----------------------------------------------------
 
     app.get('/ui/audit', c => {
-        if (guard(c) === undefined) return c.redirect('/ui/login', 302);
+        if (guard(c) === undefined) return c.redirect(entry(), 302);
         return c.html(auditPage({ version, rows: audit.recent(300) as AuditRow[] }));
     });
 
@@ -163,13 +224,13 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
 
     app.get('/ui/config', c => {
         const session = guard(c);
-        if (session === undefined) return c.redirect('/ui/login', 302);
+        if (session === undefined) return c.redirect(entry(), 302);
         return c.html(configPage({ version, config: runtime.config, csrf: runtime.sessions.csrfFor(session) }));
     });
 
     app.post('/ui/config', async c => {
         const session = guard(c);
-        if (session === undefined) return c.redirect('/ui/login', 302);
+        if (session === undefined) return c.redirect(entry(), 302);
 
         const form = await c.req.parseBody();
         if (!runtime.sessions.csrfValid(session, str(form.csrf))) {
@@ -333,13 +394,23 @@ export function buildConfig(current: Config, form: Record<string, unknown>): Con
         .map(h => h.trim())
         .filter(h => h !== '');
 
+    // Refused rather than carried forward as `undefined`. Since `password_hash`
+    // became optional this assignment type-checks either way, so nothing but
+    // this guard stops a blank password field on a config save from writing a
+    // config with no hash — silently un-claiming a live instance and handing it
+    // to whoever loads /ui/setup next.
+    const carriedHash = password === '' ? current.auth.password_hash : hashPassword(password);
+    if (carriedHash === undefined) {
+        throw new Error('This instance has no password set yet. Reload the page and set one up.');
+    }
+
     return {
         auth: {
             bearer_token: on(form['auth.rotate_token'])
                 ? generateBearerToken()
                 : current.auth.bearer_token,
             username: username === '' ? current.auth.username : username,
-            password_hash: password === '' ? current.auth.password_hash : hashPassword(password),
+            password_hash: carriedHash,
             allowed_hosts: hosts
         },
         services: services as Config['services']

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { ConfigSchema } from '../src/config/schema.ts';
 import { loadConfig } from '../src/config/load.ts';
+import { saveConfig } from '../src/config/save.ts';
 
 const freshDir = () => mkdtemp(join(tmpdir(), 'arr-mcp-cfg-'));
 /**
@@ -31,21 +32,39 @@ describe('reading without writing', () => {
 
         const { config } = await loadConfig(dir, { persist: false });
 
-        // In memory it is complete, so the schema is satisfied…
-        expect(config.auth.password_hash.length).toBeGreaterThan(0);
+        // Unclaimed in memory, because inventing a password is precisely the
+        // side effect this test exists to prevent…
+        expect(config.auth.password_hash).toBeUndefined();
         // …and on disk nothing moved.
         expect(await readFile(path, 'utf8')).toBe(original);
     });
 
-    it('still backfills and persists when asked to', async () => {
+    /**
+     * The inverse of what this test used to assert. Backfilling a generated
+     * password was how a missing hash got repaired; now a missing hash is a
+     * state — unclaimed — and repairing it would claim the instance on the
+     * user's behalf with a password only the log ever saw.
+     */
+    it('never invents a password, even when persisting', async () => {
         const dir = await freshDir();
         const path = join(dir, 'config.yaml');
         await writeFile(path, `auth:\n  bearer_token: ${'d'.repeat(64)}\nservices: {}\n`, 'utf8');
 
+        const { config } = await loadConfig(dir);
+
+        expect(config.auth.password_hash).toBeUndefined();
+        expect(await readFile(path, 'utf8')).not.toContain('password_hash');
+    });
+
+    it('still backfills a missing bearer token, which has no interactive path', async () => {
+        const dir = await freshDir();
+        const path = join(dir, 'config.yaml');
+        await writeFile(path, 'auth: {}\nservices: {}\n', 'utf8');
+
         const { generated } = await loadConfig(dir);
 
-        expect(generated.password).toBeTypeOf('string');
-        expect(await readFile(path, 'utf8')).toContain('password_hash');
+        expect(generated.bearerToken).toHaveLength(64);
+        expect(await readFile(path, 'utf8')).toContain('bearer_token');
     });
 
     // A script pointed at the wrong directory should say so, not create one.
@@ -103,6 +122,37 @@ describe('ConfigSchema', () => {
             services: { plex: { url: 'http://h:32400', api_key: 'k' } }
         });
         expect(result.success).toBe(false);
+    });
+});
+
+describe('an unclaimed config', () => {
+    it('parses a config with no password_hash', () => {
+        const parsed = ConfigSchema.parse({
+            auth: { bearer_token: 'a'.repeat(64) },
+            services: {}
+        });
+        expect(parsed.auth.password_hash).toBeUndefined();
+    });
+
+    /**
+     * `setIn` with `undefined` writes a null-valued key, which reads back as a
+     * *claimed* instance holding an empty hash — one nobody can sign in to and
+     * that the setup page will not rescue, because it no longer looks
+     * unclaimed. The only step in the unclaimed change the types do not catch.
+     */
+    it('omits password_hash from the file rather than writing a null', async () => {
+        const dir = await freshDir();
+        const path = join(dir, 'config.yaml');
+        await writeFile(path, `auth:\n  bearer_token: ${'e'.repeat(64)}\nservices: {}\n`, 'utf8');
+
+        await saveConfig(
+            dir,
+            ConfigSchema.parse({ auth: { bearer_token: 'e'.repeat(64) }, services: {} })
+        );
+
+        const written = await readFile(path, 'utf8');
+        expect(written).not.toContain('password_hash');
+        expect(written).not.toContain('null');
     });
 });
 

--- a/test/configUi.test.ts
+++ b/test/configUi.test.ts
@@ -27,6 +27,32 @@ let app: ReturnType<typeof buildApp>;
 let logs: LogStore;
 let audit: WriteAudit;
 
+/**
+ * The same fixture as `seed`, minus `password_hash` — an *unclaimed* instance,
+ * which is what a fresh install looks like before anyone visits it.
+ *
+ * The two `close()` calls come first because `beforeEach` has already opened a
+ * claimed fixture by the time this runs, and `afterEach` only closes the latest
+ * pair; without them every unclaimed test leaks a log and an audit handle.
+ */
+const seedUnclaimed = async () => {
+    logs.close();
+    audit.close();
+
+    dir = await mkdtemp(join(tmpdir(), 'arr-mcp-ui-'));
+    await writeFile(
+        join(dir, 'config.yaml'),
+        `auth:\n  bearer_token: ${BEARER}\n  username: admin\n  allowed_hosts: []\nservices: {}\n`,
+        'utf8'
+    );
+
+    const { config } = await loadConfig(dir);
+    audit = WriteAudit.ephemeral();
+    logs = LogStore.ephemeral();
+    runtime = Runtime.fromConfig(config, audit, { configDir: dir });
+    app = buildApp({ runtime, audit, logs });
+};
+
 const seed = async (extra = '') => {
     dir = await mkdtemp(join(tmpdir(), 'arr-mcp-ui-'));
     await writeFile(
@@ -366,6 +392,96 @@ describe('allowed_hosts', () => {
         });
 
         expect((await get('other.example.com')).status).toBe(200);
+    });
+});
+
+/**
+ * These call `app.request` directly rather than the `call` helper above: `call`
+ * reads and writes the module-level `cookie`, which is never reset between
+ * tests, so a signed-in test earlier in the file would poison the `set-cookie`
+ * assertions here.
+ */
+describe('an unclaimed instance', () => {
+    const claim = (body: Record<string, string>) =>
+        app.request('http://localhost:6060/ui/setup', form(body));
+
+    const GOOD = { username: 'me', password: 'correct-horse-battery', confirm: 'correct-horse-battery' };
+
+    beforeEach(async () => {
+        await seedUnclaimed();
+    });
+
+    it('sends every UI route to the setup page', async () => {
+        for (const path of ['/', '/ui', '/ui/login', '/ui/logs', '/ui/audit', '/ui/config']) {
+            const res = await app.request(`http://localhost:6060${path}`);
+            expect(res.status, path).toBe(302);
+            expect(res.headers.get('location'), path).toBe('/ui/setup');
+        }
+    });
+
+    it('serves the setup page rather than a login form', async () => {
+        const body = await (await app.request('http://localhost:6060/ui/setup')).text();
+        expect(body).toContain('Claim this instance');
+    });
+
+    it('claims on the first post, and signs that person in', async () => {
+        const res = await claim(GOOD);
+
+        expect(res.status).toBe(302);
+        expect(res.headers.get('location')).toBe('/ui');
+        expect(res.headers.get('set-cookie')).toContain('arr_mcp_session=');
+        expect(runtime.config.auth.username).toBe('me');
+        expect(runtime.config.auth.password_hash).toBeTypeOf('string');
+    });
+
+    it('refuses a second claim, leaving the first owner in place', async () => {
+        await claim(GOOD);
+        const second = await claim({
+            username: 'attacker',
+            password: 'another-long-one',
+            confirm: 'another-long-one'
+        });
+
+        expect(second.status).toBe(302);
+        expect(second.headers.get('location')).toBe('/ui/login');
+        expect(second.headers.get('set-cookie')).toBeNull();
+        expect(runtime.config.auth.username).toBe('me');
+    });
+
+    it.each([
+        ['a short password', { username: 'me', password: 'short', confirm: 'short' }],
+        ['a mismatched confirmation', { username: 'me', password: 'correct-horse-battery', confirm: 'nope-not-that' }],
+        ['a blank username', { username: '   ', password: 'correct-horse-battery', confirm: 'correct-horse-battery' }]
+    ])('rejects %s without claiming', async (_label, body) => {
+        const res = await claim(body);
+
+        expect(res.status).toBe(400);
+        expect(res.headers.get('set-cookie')).toBeNull();
+        expect(runtime.config.auth.password_hash).toBeUndefined();
+    });
+
+    it('survives a restart as an unclaimed instance rather than repairing itself', async () => {
+        const { config } = await loadConfig(dir);
+        expect(config.auth.password_hash).toBeUndefined();
+    });
+});
+
+describe('a claimed instance', () => {
+    it('will not serve the setup page', async () => {
+        const res = await app.request('http://localhost:6060/ui/setup');
+        expect(res.status).toBe(302);
+        expect(res.headers.get('location')).toBe('/ui/login');
+    });
+
+    it('will not let a post to setup overwrite the password', async () => {
+        const before = runtime.config.auth.password_hash;
+        const res = await app.request(
+            'http://localhost:6060/ui/setup',
+            form({ username: 'attacker', password: 'another-long-one', confirm: 'another-long-one' })
+        );
+
+        expect(res.status).toBe(302);
+        expect(runtime.config.auth.password_hash).toBe(before);
     });
 });
 


### PR DESCRIPTION
Follows #58, which merged while this was in progress; rebased onto `main`, so
the diff here is just the wizard.

First run printed a generated password to the container log and told you to go
and read it. It needed a terminal, it needed knowing what to grep for, and the
line scrolled away. Jellyfin, Home Assistant and Nextcloud all do first-run
setup in the browser; qBittorrent does the log thing and its users complain
about it.

## How it works

An instance whose `config.yaml` has no `auth.password_hash` is **unclaimed**.
Every UI route redirects to `/ui/setup`, where you choose a username and a
password of at least 12 characters, and land on the dashboard already signed in.

`password_hash` becomes optional in `ConfigSchema` — a widening, so every
existing config still parses and every existing install already carries a hash.
**No migration, no upgrade step.**

The loader stops inventing passwords. It still backfills a missing *bearer
token*, because that has no interactive path: a config without one has no
working `/mcp` and no way to obtain one. A password does have an interactive
path now, so generating one would claim the instance on the user's behalf with
a secret nobody would ever see.

`printCredentials` is deleted rather than reworded — **no secret is written to
a log any more.** Container logs get shipped, aggregated and retained in places
config files are not, so this is a security improvement independent of the UX
one.

Losing your password and installing fresh become the same flow: delete the
line, restart, claim it again.

## The tradeoff, stated plainly

Between the container starting and your first visit, whoever reaches the port
owns the instance. **There was no such window before** — a random password was
in place from the first millisecond.

This is accepted deliberately for the trusted-LAN deployment this targets. It
is why the startup log now warns while unclaimed, why the setup page says so,
and why the README tells you to claim the instance *before* exposing the port.
Setup codes, claim windows and source-IP gating were all considered and
rejected as disproportionate for a home LAN; revisit if off-LAN exposure ever
becomes supported.

## Three places that needed care

- **`saveConfig` wrote a null.** `setIn` with `undefined` produces
  `password_hash: null`, which reads back as *claimed with an empty hash* — an
  instance nobody can sign in to, and one the setup page will not rescue
  because it no longer looks unclaimed. It deletes the key now.
- **`buildConfig` could silently un-claim a live instance.** It carries the
  current hash forward when the password field is blank. Since the field became
  optional, that assignment type-checks either way — I had predicted a compile
  error here and there wasn't one. Only an explicit guard stops a routine
  config save from writing no hash at all.
- **The login page pointed at the container log** for a password that will
  never appear there. It documents the reset path instead.

## Tests

947 → **960**. Two tests in `config.test.ts` encoded the removed behaviour and
are inverted rather than deleted: a `persist: false` read now leaves the
instance unclaimed, and a persisting load never invents a password.

Both guarded a real incident where `npm run integration` backfilled a hash into
a live config, generating a password nobody ever saw. Removing backfill
altogether makes that class of bug unreachable rather than merely guarded, so
the weakened assertion is a genuine strengthening.

New coverage: every UI route redirects while unclaimed; a claim signs you in;
a second claim is refused with the first owner intact; short passwords, blank
usernames and mismatched confirmations are rejected without claiming; a claimed
instance will not serve setup, and a POST to it cannot overwrite the password.

## Deliberately not done

- **No CSRF token on the setup form.** There is no session to bind one to, and
  forging a claim on an unclaimed instance gets an attacker exactly what
  loading the page directly would. Commented as such in the code; every other
  form keeps its token.
- **`/mcp` is untouched while unclaimed.** Someone who hand-writes a
  `config.yaml` with services and no password should not find their MCP client
  broken.
- **No `/ui` routing changes.** The prefix keeps the UI from colliding with
  `/mcp` and `/healthz`.

## Release

Typed `fix:`, so release-please cuts **0.6.2** and 0.7.0 stays free for the
metadata-providers phase on the roadmap.

## Verification

`npm test` — 960 passing across 47 files. `npx tsc --noEmit` and
`npx eslint src test scripts --max-warnings 0` both clean. Every task was
written test-first, with each new test confirmed failing for the right reason
before implementation.

Not verified against a live container — the flow is covered through the real
Hono app in `configUi.test.ts` (real temp dirs, real config round-trip through
the loader), but nobody has run `docker compose up` on a fresh volume and
clicked through it. Worth doing before release, since first-run is exactly the
path fixtures are worst at.
