### PR TITLE
feat: show the MCP endpoint and a copyable client config on the dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,14 @@ password all render as empty fields meaning *unchanged*, so a saved page or a
 screenshot cannot carry them. The bearer token is the deliberate exception —
 handing it to your MCP client is the point — and it is masked until you ask.
 
+**The dashboard gives you the whole MCP connection.** It shows the endpoint as
+an absolute URL, built from the address you reached the page on — so it is
+already correct behind a reverse proxy, and there is nothing to assemble by
+hand. **Copy client config** puts a ready-to-paste JSON block on your clipboard
+with the endpoint and token filled in. That block is assembled in your browser
+at the moment you click, never rendered into the page, so the screenshot
+property above still holds.
+
 **Logs are a ring buffer**, kept beside your config and capped, so a chatty
 service cannot fill the disk. Full history stays in `docker logs`.
 

--- a/src/web/assets.ts
+++ b/src/web/assets.ts
@@ -98,8 +98,9 @@ button:hover { filter: brightness(1.1); }
 fieldset { border: 1px solid var(--line); border-radius: 10px; padding: .9rem 1rem; margin: 0 0 1rem; }
 legend { padding: 0 .4rem; color: var(--dim); font-size: .85rem; }
 .svc-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: .75rem; }
-.token { display: flex; gap: .5rem; align-items: center; }
+.token { display: flex; gap: .5rem; align-items: center; margin-bottom: .5rem; }
 .token input { flex: 1; font-family: var(--mono); font-size: .8rem; }
+#mcp-config { width: 100%; margin-top: .6rem; font-size: .78rem; white-space: pre; }
 `;
 
 /**
@@ -108,6 +109,22 @@ legend { padding: 0 .4rem; color: var(--dim); font-size: .85rem; }
  * Everything else is a form post and a server render.
  */
 export const JS = `
+// Say what actually happened. The clipboard write below fails on every plain
+// http origin, and reporting "Copied" for a fallback that only selected the
+// text is how someone pastes the wrong thing and blames the field.
+const flash = (btn, text) => {
+  if (btn.dataset.label === undefined) btn.dataset.label = btn.textContent.trim();
+  btn.textContent = text;
+  setTimeout(() => { btn.textContent = btn.dataset.label; }, 1600);
+};
+
+const selectIn = (el) => {
+  el.hidden = false;
+  el.removeAttribute('readonly');
+  el.select();
+  el.setAttribute('readonly', '');
+};
+
 document.addEventListener('click', async (e) => {
   const btn = e.target.closest('[data-copy]');
   if (!btn) return;
@@ -115,16 +132,49 @@ document.addEventListener('click', async (e) => {
   if (!input) return;
   try {
     await navigator.clipboard.writeText(input.value);
+    flash(btn, 'Copied');
   } catch {
     // Clipboard API needs a secure context, and this is deliberately served
     // over http on a LAN — so fall back to selecting the text for the user.
-    input.removeAttribute('readonly');
-    input.select();
-    input.setAttribute('readonly', '');
+    selectIn(input);
+    flash(btn, 'Selected — copy it');
   }
-  const original = btn.textContent;
-  btn.textContent = 'Copied';
-  setTimeout(() => { btn.textContent = original; }, 1200);
+});
+
+// The client config is assembled here, in the browser, and never rendered by
+// the server. The token is masked three lines above it on the page; putting the
+// same value into the HTML as readable JSON would quietly undo that, and a
+// screenshot of the dashboard would carry a working credential.
+document.addEventListener('click', async (e) => {
+  const btn = e.target.closest('[data-copy-config]');
+  if (!btn) return;
+  const box = document.getElementById(btn.dataset.copyConfig);
+  const url = document.getElementById('mcp-url');
+  const token = document.getElementById('bearer');
+  if (!box || !url || !token) return;
+
+  const config = JSON.stringify({
+    mcpServers: {
+      'arr-mcp': {
+        type: 'http',
+        url: url.value,
+        headers: { Authorization: 'Bearer ' + token.value }
+      }
+    }
+  }, null, 2);
+
+  try {
+    await navigator.clipboard.writeText(config);
+    flash(btn, 'Copied');
+  } catch {
+    // No clipboard on http, and unlike the fields above there is nothing
+    // already on screen to select — so fill the textarea now and reveal it.
+    // That puts the token on screen, which is acceptable only because it takes
+    // an explicit click on a button that says it copies credentials.
+    box.value = config;
+    selectIn(box);
+    flash(btn, 'Selected — copy it');
+  }
 });
 
 // Reveal a secret only on request, so a screenshot or a shoulder does not

--- a/src/web/origin.ts
+++ b/src/web/origin.ts
@@ -1,0 +1,62 @@
+/**
+ * The absolute MCP endpoint, derived from the request that asked for the page.
+ *
+ * The dashboard used to print the relative path `/mcp` and leave the reader to
+ * assemble the rest, which is the one thing the server is better placed to do
+ * than they are: the request URL *is* the address the browser reached us on,
+ * port included, so it is right without a setting to configure and right behind
+ * a reverse proxy for free.
+ *
+ * Strings rather than a Hono `Context` on purpose — this is a parsing rule, and
+ * a parsing rule should be testable without standing up a server.
+ *
+ * The host is taken from the request URL rather than from `c.req.header('host')`
+ * because that is the one source present in both places it has to work: the
+ * node adapter builds the URL out of the `Host` header, so the two agree on a
+ * real server, but a `Request` constructed in a test carries no `Host` header at
+ * all and the header read is simply `undefined`. Reading the URL means the code
+ * under test is the code that ships.
+ */
+
+/**
+ * Hostname, IPv4, or bracketed IPv6, each optionally with a port. Anything else
+ * is refused rather than interpolated: `Host` is caller-supplied, and the result
+ * is rendered into a page and copied into a client config. A value carrying a
+ * space, a slash or a quote has no legitimate reading, so it does not get one.
+ */
+const HOST = /^(\[[0-9A-Fa-f:.]+\]|[A-Za-z0-9.-]+)(:\d{1,5})?$/;
+
+/**
+ * `X-Forwarded-Proto` is the only forwarded header read here, and only because
+ * omitting it breaks the TLS-terminating-proxy case outright — the page would
+ * hand out an `http://` URL that cannot work.
+ *
+ * `X-Forwarded-Host` is deliberately not read. nginx, Caddy and Traefik all pass
+ * the external `Host` through by default, so it buys nothing in the common case
+ * and would take a rendered string from a second header anyone can set.
+ *
+ * Note that when `auth.allowed_hosts` is non-empty, an unlisted `Host` is
+ * already rejected in `app.ts` before any UI route runs — so a pinned instance
+ * only ever renders a host that passed validation. Pinning it is the answer for
+ * anyone reachable off a trusted LAN.
+ *
+ * Returns `undefined` when there is no usable `Host`, which the dashboard shows
+ * as the old relative-path prose. A fabricated URL would be worse than the
+ * sentence it replaces.
+ */
+export function mcpEndpoint(requestUrl: string, proto: string | undefined): string | undefined {
+    let host: string;
+    try {
+        host = new URL(requestUrl).host;
+    } catch {
+        return undefined;
+    }
+    if (!HOST.test(host)) return undefined;
+
+    // Chained proxies append rather than replace, so this arrives as
+    // `https, http` and only the first hop describes what the browser spoke.
+    const first = (proto ?? '').split(',')[0]?.trim().toLowerCase();
+    const scheme = first === 'https' ? 'https' : 'http';
+
+    return `${scheme}://${host}/mcp`;
+}

--- a/src/web/pages.ts
+++ b/src/web/pages.ts
@@ -147,6 +147,8 @@ export function dashboardPage(opts: {
     diagnoses: ConnectionDiagnosis[];
     configured: ServiceId[];
     bearerToken: string;
+    /** Absent when the request carried no usable `Host` — see `origin.ts`. */
+    mcpUrl?: string | undefined;
     writeCounts: { applied: number; denied: number; total: number };
     disks: DiskSpace[];
     failures: HealthCheck[];
@@ -260,14 +262,35 @@ export function dashboardPage(opts: {
         <h2>MCP endpoint</h2>
         <div class="panel">
             <p class="note">
-                Point your MCP client at <span class="mono">/mcp</span> on this host and give it this bearer
-                token. This page is the only place it is shown — it is never written to a log.
+                Point your MCP client at this URL and give it the bearer token. This page is the
+                only place the token is shown — it is never written to a log.
             </p>
+            ${opts.mcpUrl === undefined
+                ? html`<p class="note">
+                      Use <span class="mono">/mcp</span> on this host — the address you reached this
+                      page on.
+                  </p>`
+                : html`<div class="token">
+                      <input id="mcp-url" type="text" value="${opts.mcpUrl}" readonly>
+                      <button class="ghost" type="button" data-copy="mcp-url">Copy</button>
+                  </div>`}
             <div class="token">
                 <input id="bearer" type="password" value="${opts.bearerToken}" readonly>
                 <button class="ghost" type="button" data-reveal="bearer">Show</button>
                 <button class="ghost" type="button" data-copy="bearer">Copy</button>
             </div>
+            ${opts.mcpUrl === undefined
+                ? raw('')
+                : html`<div class="row" style="margin-top:.75rem">
+                          <button class="ghost" type="button" data-copy-config="mcp-config">
+                              Copy client config
+                          </button>
+                          <span class="note" style="margin:0">Ready to paste — includes the token.</span>
+                      </div>
+                      <!-- Filled in by the browser at click time, never by the server: rendering
+                           the token here would undo the masked field above it, and a screenshot
+                           of this page would carry it. -->
+                      <textarea id="mcp-config" class="mono" rows="9" readonly hidden></textarea>`}
         </div>
 
         <h2>Writes</h2>

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -18,6 +18,7 @@ import {
 import { buildStackHealth } from '../tools/stackHealth.ts';
 import { CSS, JS } from './assets.ts';
 import { configPage, SERVICE_IDS } from './configPage.ts';
+import { mcpEndpoint } from './origin.ts';
 import {
     auditPage,
     dashboardPage,
@@ -172,6 +173,7 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
                 diagnoses: health.services,
                 configured: snapshot.adapters.map(a => a.id),
                 bearerToken: snapshot.config.auth.bearer_token,
+                mcpUrl: mcpEndpoint(c.req.url, c.req.header('x-forwarded-proto')),
                 disks: health.disks.items,
                 failures: health.failures.items,
                 scans: health.scans,

--- a/test/configUi.test.ts
+++ b/test/configUi.test.ts
@@ -178,6 +178,38 @@ describe('secrets', () => {
     });
 });
 
+describe('MCP endpoint', () => {
+    it('shows the endpoint built from the host the browser reached it on', async () => {
+        await signIn();
+        expect(await (await call('/ui')).text()).toContain('http://localhost:6060/mcp');
+    });
+
+    it('renders an https endpoint behind a TLS-terminating proxy', async () => {
+        await signIn();
+        const page = await (await call('/ui', { headers: { 'x-forwarded-proto': 'https' } })).text();
+        expect(page).toContain('https://localhost:6060/mcp');
+        expect(page).not.toContain('http://localhost:6060/mcp');
+    });
+
+    /**
+     * The regression guard for the whole design. The client config is assembled
+     * in the browser precisely so the token is in the HTML exactly once, inside
+     * the masked field — a future change that server-renders the JSON would put
+     * a live credential into readable text and into any screenshot of the page,
+     * and this is what would catch it.
+     */
+    it('ships the config textarea empty, leaving the token in the masked field alone', async () => {
+        await signIn();
+        const page = await (await call('/ui')).text();
+
+        expect(page).toContain('data-copy-config="mcp-config"');
+        expect(page).toContain('<textarea id="mcp-config"');
+        expect(page).toContain('></textarea>');
+        expect(page.split(BEARER).length - 1).toBe(1);
+    });
+
+});
+
 describe('saving configuration', () => {
     it('refuses a forged CSRF token', async () => {
         await signIn();

--- a/test/origin.test.ts
+++ b/test/origin.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { mcpEndpoint } from '../src/web/origin.ts';
+
+describe('mcpEndpoint', () => {
+    it('builds the endpoint from the address the browser actually used', () => {
+        expect(mcpEndpoint('http://192.168.1.20:6060/ui', undefined)).toBe('http://192.168.1.20:6060/mcp');
+    });
+
+    it('keeps a host that carries no port', () => {
+        expect(mcpEndpoint('http://arr.example.com/ui', undefined)).toBe('http://arr.example.com/mcp');
+    });
+
+    it('replaces whatever path the request was for', () => {
+        expect(mcpEndpoint('http://arr.example.com/ui/logs?stream=all', undefined)).toBe(
+            'http://arr.example.com/mcp'
+        );
+    });
+
+    // The whole reason to read a forwarded header: without it a proxy that
+    // terminates TLS gets handed an http:// URL that cannot work.
+    it('uses https when the proxy reports the browser spoke https', () => {
+        expect(mcpEndpoint('http://arr.example.com/ui', 'https')).toBe('https://arr.example.com/mcp');
+    });
+
+    it('reads only the first hop of a chained X-Forwarded-Proto', () => {
+        expect(mcpEndpoint('http://arr.example.com/ui', 'https, http')).toBe('https://arr.example.com/mcp');
+    });
+
+    it('treats an unrecognised proto as plain http rather than trusting it', () => {
+        expect(mcpEndpoint('http://arr.example.com:6060/ui', 'gopher')).toBe('http://arr.example.com:6060/mcp');
+    });
+
+    // The scheme comes from the proxy header, never from the request URL: the
+    // node adapter always builds an http:// URL, so trusting it would make the
+    // https case unreachable.
+    it('ignores the scheme of the request URL', () => {
+        expect(mcpEndpoint('https://arr.example.com/ui', undefined)).toBe('http://arr.example.com/mcp');
+    });
+
+    it('handles a bracketed IPv6 host', () => {
+        expect(mcpEndpoint('http://[2001:db8::1]:6060/ui', undefined)).toBe('http://[2001:db8::1]:6060/mcp');
+    });
+
+    it('gives up rather than inventing a URL when the request URL is unusable', () => {
+        expect(mcpEndpoint('', undefined)).toBeUndefined();
+        expect(mcpEndpoint('/ui', undefined)).toBeUndefined();
+        expect(mcpEndpoint('not a url', 'https')).toBeUndefined();
+    });
+
+    // A URL with no authority parses, but has nothing to point a client at.
+    it('gives up on a URL that carries no host', () => {
+        expect(mcpEndpoint('file:///etc/passwd', undefined)).toBeUndefined();
+    });
+});


### PR DESCRIPTION
The dashboard handed you a bearer token and the sentence "Point your MCP client at `/mcp` on this host" — a relative path, in prose, beside a copyable secret. The one component that knows the full URL made the reader assemble it. I hit exactly that and had to ask what to paste into an agent, right after re-claiming a production instance.

What you paste into a client is not a URL either. It's a config block carrying the endpoint and token together.

## What this does

The MCP endpoint panel now shows the endpoint as a copyable field, and adds **Copy client config** — a ready-to-paste JSON block with the endpoint and token filled in.

## Where the host comes from

The request URL, not the `Host` header. They agree on a real server (the node adapter builds one from the other), but a `Request` built by `app.request()` in a test carries no `Host` header, so the header read returns `undefined` and the dashboard silently fell back to prose in every test. Reading the URL means the code under test is the code that ships.

`X-Forwarded-Proto` is the only forwarded header read, and only because omitting it hands a TLS-terminating proxy an `http://` URL that cannot work. `X-Forwarded-Host` is deliberately ignored — nginx, Caddy and Traefik all pass the external `Host` through, so it buys nothing and would take a rendered string from a second header anyone can set.

A host that isn't a hostname and port is refused rather than interpolated. No usable host falls back to the old prose; a fabricated URL is worse than the sentence it replaces.

## The constraint that shaped it

The config JSON is assembled in the browser at click time and **never rendered by the server**. The token is masked three lines above it, and server-rendering the same value as readable JSON would quietly undo that and put a live credential into any screenshot of the page — the property README claims. The textarea ships empty, and a test asserts the token appears in the HTML exactly once.

## The clipboard fallback is the normal path

`navigator.clipboard` needs a secure context, and this is served over plain http on a LAN by design. The existing handler already fell back to selecting the input's text; the new button has no such element, so it fills the textarea and reveals it. That puts the token on screen — acceptable only because it takes an explicit click on a button that says it copies credentials.

## One existing bug fixed, because the new button inherits it

The copy handler said "Copied" even when the clipboard write threw and the text was merely selected. Success now says `Copied`, the fallback says `Selected — copy it`. Naming a key chord would be wrong on half the machines this runs beside.

## Verification

Beyond the suite — driven against a real server:

- panel renders the address the request arrived on
- `X-Forwarded-Proto: https` yields an `https://` endpoint
- the token appears in the HTML exactly once
- **the endpoint and token the page hands out authenticate a real `tools/list` call** (200)

960 → 973 tests. Typecheck and lint clean.

## Not covered

`assets.ts` is a string constant with no DOM harness in this repo, so the clipboard paths themselves are unexercised by the suite. Worth a click in a browser before cutting a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
