### PR TITLE
chore: keep features on the patch line while pre-1.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,9 +49,20 @@ reads them to decide the next version and to write `CHANGELOG.md`.
 | Prefix | Effect on version |
 | --- | --- |
 | `fix:` | patch |
-| `feat:` | minor |
+| `feat:` | patch while on 0.x, minor after 1.0 |
 | `feat!:` or a `BREAKING CHANGE:` footer | minor while on 0.x, major after 1.0 |
 | `chore:`, `docs:`, `ci:`, `test:`, `refactor:` | none |
+
+**Minor versions are reserved for phases while we are pre-1.0.** `0.6`, `0.7`
+and so on each mark a phase from the roadmap, not an individual feature — that
+is what the roadmap table in the README is numbering. A feature therefore lands
+as a patch (`0.6.3`, `0.6.4`), and the minor is cut deliberately when the phase
+is complete, with a `Release-As: 0.7.0` footer on the last commit of the phase.
+
+This is what `bump-patch-for-minor-pre-major` in `release-please-config.json`
+does, and it is the reason it is on. Without it a single `feat:` consumes the
+next phase number: a one-panel dashboard change proposed `0.7.0` and would have
+taken the number Phase 7 is meant to carry.
 
 ## The tool surface is the public API
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,7 @@
       "package-name": "arr-mcp",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": false,
+      "bump-patch-for-minor-pre-major": true,
       "draft": false,
       "prerelease": false,
       "initial-version": "0.1.0",


### PR DESCRIPTION
`bump-patch-for-minor-pre-major` was `false`, so `feat:` bumped the **minor** on a 0.x line. PR #61 was a single dashboard panel, and release-please duly proposed **0.7.0** — taking the number Phase 7 is meant to carry.

My fault: I picked `feat:` for #61 without checking it against how this project numbers versions.

## Why patch is right here

Minor versions in this repo are **phase markers**. The README roadmap numbers them that way, and 0.1 → 0.6 have each been a phase rather than a feature. A scheme where any feature can consume the next phase number isn't expressing that.

With the flag on:

| Prefix | Pre-1.0 | After 1.0 |
| --- | --- | --- |
| `fix:` | patch | patch |
| `feat:` | **patch** | minor |
| `feat!:` / `BREAKING CHANGE:` | minor | major |

The minor gets cut deliberately at the end of a phase, with a `Release-As: 0.7.0` footer on its last commit.

## Nothing shipped under the wrong number

- `v0.6.2` is still the latest release
- no `v0.7.0` tag exists
- release PR #62 is **open, not merged**

It should recompute to **0.6.3** once this lands. If it doesn't retitle on the next run, closing #62 will make release-please recreate it.

## Docs move with the behaviour

CONTRIBUTING's version table said `feat:` → minor. That was accurate and would not be, so it changes here rather than later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
