### PR TITLE
feat: let tools name which instance, and merge reads across them

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,61 @@ One thing to be careful with: pinning `allowed_hosts` applies at once, so a
 wrong hostname locks you out of the page you would fix it from. Recover by
 editing `config.yaml` by hand and restarting.
 
+### Multiple Radarr, Sonarr and Bazarr instances
+
+Running an HD and a 4K Radarr side by side is a common setup, and arr-mcp reads
+both. Give each one a name:
+
+```yaml
+services:
+  radarr:
+    - name: hd
+      url: http://192.168.1.20:7878
+      api_key: "…"
+    - name: 4k
+      url: http://192.168.1.20:7879
+      api_key: "…"
+  bazarr:                    # one per stack — Bazarr takes a single *arr of each
+    - name: hd
+      url: http://192.168.1.20:6767
+      api_key: "…"
+    - name: 4k
+      url: http://192.168.1.20:6768
+      api_key: "…"
+  sonarr:                    # one instance needs no name and no list
+    url: http://192.168.1.20:8989
+    api_key: "…"
+```
+
+**Reads span every instance.** `stack_health` reports each separately, and a
+library question answers from all of them at once — which is the whole point of
+running a second one. Every row says which instance it came from, as
+`radarr/4k`.
+
+**Writes name one.** Adding a film with two Radarrs configured and no `instance`
+is refused, and the refusal lists the names rather than guessing — a 4K release
+landing in the HD instance is only discovered once the download has finished.
+
+```
+add_media { service: "radarr", external_id: "550" }
+```
+
+> radarr has 2 instances configured, so "radarr" alone does not say which —
+> pass `instance` with one of: "4k", "hd".
+
+That means **adding a second instance changes how existing prompts behave**:
+requests that used to be unambiguous start asking which instance you meant. That
+is deliberate, and it only affects writes.
+
+**Permissions are per instance**, so `safe_write` on `hd` and nothing on `4k` is
+a configuration you can express — each entry carries its own `permissions`
+block.
+
+Only Radarr, Sonarr and Bazarr take a list. The other five are one each:
+Prowlarr feeds every *arr from one place, Seerr connects to your instances
+itself, and a second download client is a different kind of setup from a quality
+tier.
+
 ## Config UI
 
 `http://<host>:6060`

--- a/src/core/confirm.ts
+++ b/src/core/confirm.ts
@@ -1,5 +1,4 @@
 import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
-import type { ServiceId } from '../config/schema.ts';
 import type { Clock } from './cache.ts';
 import type { WriteTier } from './permissions.ts';
 
@@ -44,7 +43,7 @@ const MAX_CONSUMED = 10_000;
  */
 export type WriteIntent = {
     tool: string;
-    service: ServiceId;
+    service: string;
     tier: WriteTier;
     /** The adapter-level verb, e.g. `delete_movie`. Distinct from `tool` because
      *  one tool may reach more than one operation. */

--- a/src/core/permissions.ts
+++ b/src/core/permissions.ts
@@ -60,15 +60,36 @@ export function permissionSourceFrom(instances: readonly ServiceInstance[]): Per
  * a dry run reports it as part of the preview without failing (see
  * `src/tools/write.ts` for why a dry run is not gated).
  */
+/**
+ * Where to set a permission, in the reader's actual config file.
+ *
+ * A named instance lives inside a list, so `services.radarr/4k.permissions` —
+ * the obvious string to build from the id — names a key that does not exist and
+ * cannot be created. Someone following it edits nothing and the write stays
+ * refused, which is a worse failure than a vague message: it looks like the
+ * remedy did not work.
+ */
+function permissionPath(instance: string, tier: WriteTier): string {
+    const slash = instance.indexOf('/');
+    if (slash === -1) {
+        return `\`services.${instance}.permissions.${TIER_KEY[tier]}: true\``;
+    }
+
+    const type = instance.slice(0, slash);
+    const name = instance.slice(slash + 1);
+    return `\`permissions.${TIER_KEY[tier]}: true\` on the \`name: ${name}\` entry under \`services.${type}\``;
+}
+
 export function checkPermission(source: PermissionSource, service: string, tier: WriteTier): PermissionVerdict {
     const config = source.get(service);
 
     if (config === undefined) {
+        const type = service.split('/')[0] ?? service;
         return {
             allowed: false,
             tier,
             reason: `${service} is not configured`,
-            remedy: `Add a \`services.${service}\` block to config.yaml and restart. Writes additionally need \`services.${service}.permissions.${TIER_KEY[tier]}: true\`.`
+            remedy: `Add a \`services.${type}\` block to config.yaml and restart. Writes additionally need ${permissionPath(service, tier)}.`
         };
     }
 
@@ -83,7 +104,7 @@ export function checkPermission(source: PermissionSource, service: string, tier:
         allowed: false,
         tier,
         reason: `${tier} writes are disabled for ${service}`,
-        remedy: `Set \`services.${service}.permissions.${TIER_KEY[tier]}: true\` in config.yaml and restart arr-mcp. This is off by default; nothing but a deliberate edit turns it on.`
+        remedy: `Set ${permissionPath(service, tier)} in config.yaml and restart arr-mcp. This is off by default; nothing but a deliberate edit turns it on.`
     };
 }
 

--- a/src/tools/addMedia.ts
+++ b/src/tools/addMedia.ts
@@ -1,3 +1,4 @@
+import { INSTANCE_PARAM_DESCRIPTION, resolveInstance } from './resolveInstance.ts';
 import type { McpServer } from '@modelcontextprotocol/server';
 import * as z from 'zod/v4';
 import { ServiceIdSchema, type ServiceId } from '../config/schema.ts';
@@ -28,13 +29,12 @@ import { registerWriteTool, type WriteContext, type WritePlan } from './write.ts
  * cheaper than it is.
  */
 
-const findAdapter = (adapters: readonly ServiceAdapter[], service: ServiceId): ServiceAdapter & MediaAddCapable => {
-    const adapter = adapters.find(a => a.id === service);
-    if (adapter === undefined) {
-        throw new ServiceError('NotFound', service, `${service} is not configured`, {
-            remedy: `Add a services.${service} block to config.yaml and restart, or name a configured service.`
-        });
-    }
+const findAdapter = (
+    adapters: readonly ServiceAdapter[],
+    service: ServiceId,
+    instance?: string
+): ServiceAdapter & MediaAddCapable => {
+    const adapter = resolveInstance(adapters, service, instance);
     if (!hasMediaAdd(adapter)) {
         throw new ServiceError('NotFound', service, `${service} cannot add media`, {
             remedy: 'Only radarr (films, by TMDB id) and sonarr (series, by TVDB id) can.'
@@ -131,6 +131,7 @@ export function registerAddMedia(server: McpServer, context: WriteContext, adapt
             'Adds a film to Radarr or a series to Sonarr and, by default, starts searching for it. Radarr takes a TMDB id, Sonarr takes a TVDB id — get the right one from lookup_media, which returns both under `ids`. If the service has more than one quality profile or root folder you must name which, because guessing wrong is only discovered once the download finishes. Previews by default — call again with the returned `confirm` token to actually add it.',
         inputSchema: z.object({
             service: ServiceIdSchema.describe('radarr for a film, sonarr for a series.'),
+            instance: z.string().optional().describe(INSTANCE_PARAM_DESCRIPTION),
             external_id: z
                 .string()
                 .min(1)
@@ -149,12 +150,15 @@ export function registerAddMedia(server: McpServer, context: WriteContext, adapt
                 .default(true)
                 .describe('Start searching immediately. Defaults to true — set false to add without downloading yet.')
         }),
-        service: ({ service }) => service,
+        // The resolved instance id, not the bare type: permissions are granted per
+        // instance, so checking `radarr` against a config that only grants
+        // `radarr/hd` would deny a permitted write — or worse, the reverse.
+        service: ({ service, instance }) => findAdapter(adapters, service, instance).id,
         operation: 'add_media',
         tier: 'safe',
 
-        async plan({ service, external_id, quality_profile, root_folder, monitored, search_now }): Promise<WritePlan> {
-            const adapter = findAdapter(adapters, service);
+        async plan({ service, instance, external_id, quality_profile, root_folder, monitored, search_now }): Promise<WritePlan> {
+            const adapter = findAdapter(adapters, service, instance);
 
             // All three reads together: they are independent, and a preview
             // that takes three sequential round trips on a LAN service is
@@ -228,7 +232,7 @@ export function registerAddMedia(server: McpServer, context: WriteContext, adapt
             };
         },
 
-        async apply(plan, { service }) {
+        async apply(plan, { service, instance }) {
             const a = plan.args as {
                 externalId: string;
                 qualityProfileId: number;
@@ -241,7 +245,7 @@ export function registerAddMedia(server: McpServer, context: WriteContext, adapt
             // re-running `chooseOne` here could land on a different profile if
             // one was added in between, and the token guaranteed the one that
             // was previewed.
-            return findAdapter(adapters, service).addMedia({
+            return findAdapter(adapters, service, instance).addMedia({
                 externalId: a.externalId,
                 qualityProfileId: a.qualityProfileId,
                 rootFolderPath: a.rootFolderPath,

--- a/src/tools/deleteMedia.ts
+++ b/src/tools/deleteMedia.ts
@@ -1,3 +1,4 @@
+import { INSTANCE_PARAM_DESCRIPTION, resolveInstance } from './resolveInstance.ts';
 import type { McpServer } from '@modelcontextprotocol/server';
 import * as z from 'zod/v4';
 import { ServiceIdSchema, type ServiceId } from '../config/schema.ts';
@@ -24,13 +25,8 @@ function humanSize(bytes: number | undefined): string | undefined {
     return bytes >= GIB ? `${(bytes / GIB).toFixed(1)} GB` : `${Math.round(bytes / 1024 ** 2)} MB`;
 }
 
-const findAdapter = (adapters: readonly ServiceAdapter[], service: ServiceId) => {
-    const adapter = adapters.find(a => a.id === service);
-    if (adapter === undefined) {
-        throw new ServiceError('NotFound', service, `${service} is not configured`, {
-            remedy: `Add a services.${service} block to config.yaml and restart, or name a configured service.`
-        });
-    }
+const findAdapter = (adapters: readonly ServiceAdapter[], service: ServiceId, instance?: string) => {
+    const adapter = resolveInstance(adapters, service, instance);
     if (!hasMediaDelete(adapter)) {
         throw new ServiceError('NotFound', service, `${service} has no media to delete`, {
             remedy: 'Only radarr and sonarr manage media that delete_media can remove.'
@@ -50,6 +46,7 @@ export function registerDeleteMedia(
             'Removes a film from Radarr or a whole series from Sonarr, optionally deleting its files from disk. Destructive and not undoable — files are gone, not moved to a recycle bin unless the service itself is configured for one. Takes `service` and `id`, never a title: get those from get_media_details or get_library first. Sonarr deletes the entire series; there is no per-episode form. Previews by default — call again with the returned `confirm` token to actually delete.',
         inputSchema: z.object({
             service: ServiceIdSchema.describe('radarr or sonarr.'),
+            instance: z.string().optional().describe(INSTANCE_PARAM_DESCRIPTION),
             id: z.string().min(1).describe("The item's id within that service, as an integer string."),
             delete_files: z
                 .boolean()
@@ -64,12 +61,15 @@ export function registerDeleteMedia(
                     'Also add an import exclusion so it is never re-added automatically. Defaults to false.'
                 )
         }),
-        service: ({ service }) => service,
+        // The resolved instance id, not the bare type: permissions are granted per
+        // instance, so checking `radarr` against a config that only grants
+        // `radarr/hd` would deny a permitted write — or worse, the reverse.
+        service: ({ service, instance }) => findAdapter(adapters, service, instance).id,
         operation: 'delete_media',
         tier: 'destructive',
 
-        async plan({ service, id, delete_files, add_import_exclusion }): Promise<WritePlan> {
-            const adapter = findAdapter(adapters, service);
+        async plan({ service, instance, id, delete_files, add_import_exclusion }): Promise<WritePlan> {
+            const adapter = findAdapter(adapters, service, instance);
             if (!hasMediaDetails(adapter)) {
                 throw new ServiceError('NotFound', service, `${service} cannot describe its own items`);
             }
@@ -117,8 +117,8 @@ export function registerDeleteMedia(
             };
         },
 
-        async apply(_plan, { service, id, delete_files, add_import_exclusion }) {
-            await findAdapter(adapters, service).deleteMedia(id, {
+        async apply(_plan, { service, instance, id, delete_files, add_import_exclusion }) {
+            await findAdapter(adapters, service, instance).deleteMedia(id, {
                 deleteFiles: delete_files,
                 addImportExclusion: add_import_exclusion
             });

--- a/src/tools/getMediaDetails.ts
+++ b/src/tools/getMediaDetails.ts
@@ -1,3 +1,4 @@
+import { INSTANCE_PARAM_DESCRIPTION, resolveInstance } from './resolveInstance.ts';
 import type { McpServer } from '@modelcontextprotocol/server';
 import * as z from 'zod/v4';
 import { ServiceIdSchema, type ServiceId } from '../config/schema.ts';
@@ -14,12 +15,12 @@ import type { LibraryLoader } from './library.ts';
  */
 export async function buildGetMediaDetails(
     adapters: readonly ServiceAdapter[],
-    opts: { service: ServiceId; id: string; detail: DetailLevel; limit: number }
+    opts: { service: ServiceId; instance?: string | undefined; id: string; detail: DetailLevel; limit: number }
 ): Promise<MediaDetails> {
-    const adapter = adapters.find(a => a.id === opts.service);
-    if (adapter === undefined || !hasMediaDetails(adapter)) {
-        throw new ServiceError('NotFound', opts.service, `${opts.service} is not configured`, {
-            remedy: `Add services.${opts.service} to config.yaml, or name a configured service.`
+    const adapter = resolveInstance(adapters, opts.service, opts.instance);
+    if (!hasMediaDetails(adapter)) {
+        throw new ServiceError('NotFound', adapter.id, `${adapter.id} has no media details to return`, {
+            remedy: 'Only radarr, sonarr and jellyfin can answer get_media_details.'
         });
     }
 
@@ -32,6 +33,7 @@ export async function buildGetMediaDetails(
 export type MediaDetailsQuery = {
     query?: string;
     service?: ServiceId;
+    instance?: string | undefined;
     id?: string;
     detail: DetailLevel;
     limit: number;
@@ -82,6 +84,7 @@ export async function resolveMediaDetails(
     if (opts.service !== undefined && opts.id !== undefined) {
         return buildGetMediaDetails(adapters, {
             service: opts.service,
+            ...(opts.instance === undefined ? {} : { instance: opts.instance }),
             id: opts.id,
             detail: opts.detail,
             limit: opts.limit
@@ -110,15 +113,17 @@ export function registerGetMediaDetails(
             inputSchema: z.object({
                 query: z.string().min(1).optional().describe('A title. Resolved through the library index.'),
                 service: ServiceIdSchema.optional().describe('With `id`: one service’s own view.'),
+                instance: z.string().optional().describe(INSTANCE_PARAM_DESCRIPTION),
                 id: z.string().min(1).optional().describe("The item's id within that service."),
                 detail: DetailSchema,
                 limit: LimitSchema
             })
         },
-        async ({ query, service, id, detail, limit }) => {
+        async ({ query, service, instance, id, detail, limit }) => {
             const result = await resolveMediaDetails(adapters, loader, {
                 ...(query === undefined ? {} : { query }),
                 ...(service === undefined ? {} : { service }),
+                ...(instance === undefined ? {} : { instance }),
                 ...(id === undefined ? {} : { id }),
                 detail,
                 limit

--- a/src/tools/getSubtitles.ts
+++ b/src/tools/getSubtitles.ts
@@ -28,42 +28,69 @@ const project = (g: SubtitleGap, detail: DetailLevel): SubtitleGap => {
     return { service: g.service, kind: g.kind, id: g.id, title: g.title, missing: [] };
 };
 
+/**
+ * Every configured Bazarr, merged.
+ *
+ * Bazarr connects to a single Radarr and a single Sonarr, so an HD + 4K *arr
+ * pair implies one Bazarr per stack. Reading from only the first would hide
+ * subtitle state for half the library — the same failure multiple instances
+ * exist to remove, so this is a read that spans them rather than one that asks
+ * which to look in.
+ *
+ * One instance failing degrades to a named entry and the others still answer.
+ * A partial subtitle list that says which Bazarr is missing is useful; one that
+ * silently drops half is not.
+ */
 export async function buildGetSubtitles(
-    adapter: (ServiceAdapter & SubtitleCapable) | undefined,
+    adapters: readonly (ServiceAdapter & SubtitleCapable)[],
     opts: { detail: DetailLevel; limit: number }
 ): Promise<GetSubtitlesResult> {
-    if (adapter === undefined) {
+    if (adapters.length === 0) {
         return { items: [], total: 0, returned: 0, truncated: false, degraded: [] };
     }
 
-    let gaps: SubtitleGap[];
-    try {
-        gaps = await adapter.getMissingSubtitles();
-    } catch (err) {
-        logger.warn({ service: adapter.id, err }, 'subtitle read failed; degrading');
-        return { items: [], total: 0, returned: 0, truncated: false, degraded: [adapter.id] };
-    }
+    const gaps: SubtitleGap[] = [];
+    const providers: SubtitleProvider[] = [];
+    const degraded: string[] = [];
+    let sawProviders = false;
 
-    // Provider state is fetched alongside and never allowed to fail the call.
-    let providers: SubtitleProvider[] | undefined;
-    if (opts.detail !== 'minimal') {
-        try {
-            providers = await adapter.getProviders();
-        } catch (err) {
-            logger.warn({ service: adapter.id, err }, 'provider state unavailable; omitting');
-        }
-    }
+    await Promise.all(
+        adapters.map(async adapter => {
+            try {
+                gaps.push(...(await adapter.getMissingSubtitles()));
+            } catch (err) {
+                logger.warn({ service: adapter.id, err }, 'subtitle read failed; degrading');
+                degraded.push(adapter.id);
+                return;
+            }
 
-    const shaped = applyLimit(gaps, opts.limit);
+            // Provider state is fetched alongside and never allowed to fail the
+            // call — an instance that answered its gaps still contributed them.
+            if (opts.detail === 'minimal') return;
+            try {
+                providers.push(...(await adapter.getProviders()));
+                sawProviders = true;
+            } catch (err) {
+                logger.warn({ service: adapter.id, err }, 'provider state unavailable; omitting');
+            }
+        })
+    );
+
+    // Sorted so two instances produce a stable order rather than whichever
+    // answered first, which would make the output differ run to run.
+    const shaped = applyLimit(
+        gaps.sort((a, b) => a.service.localeCompare(b.service) || a.title.localeCompare(b.title)),
+        opts.limit
+    );
     return {
         ...shaped,
         items: shaped.items.map(g => project(g, opts.detail)),
-        degraded: [],
-        ...(providers === undefined ? {} : { providers })
+        degraded: degraded.sort(),
+        ...(sawProviders ? { providers } : {})
     };
 }
 
-export function registerGetSubtitles(server: McpServer, adapter: (ServiceAdapter & SubtitleCapable) | undefined): void {
+export function registerGetSubtitles(server: McpServer, adapters: readonly (ServiceAdapter & SubtitleCapable)[]): void {
     server.registerTool(
         'get_subtitles',
         {
@@ -72,11 +99,11 @@ export function registerGetSubtitles(server: McpServer, adapter: (ServiceAdapter
             inputSchema: z.object({ detail: DetailSchema, limit: LimitSchema })
         },
         async ({ detail, limit }) => {
-            const result = await buildGetSubtitles(adapter, { detail, limit });
+            const result = await buildGetSubtitles(adapters, { detail, limit });
             const unhealthy = (result.providers ?? []).filter(p => !p.healthy).length;
             const summary =
                 result.degraded.length > 0
-                    ? 'Bazarr could not be reached; no subtitle information available.'
+                    ? `Bazarr could not be reached (${result.degraded.join(', ')}); subtitle information may be incomplete.`
                     : `${result.returned} of ${result.total} item(s) missing subtitles` +
                       (unhealthy > 0 ? `; ${unhealthy} provider(s) unavailable.` : '.');
 

--- a/src/tools/manageRequests.ts
+++ b/src/tools/manageRequests.ts
@@ -24,7 +24,7 @@ import { registerWriteTool, type WriteContext, type WritePlan } from './write.ts
  */
 
 const seerrAdapter = (adapters: readonly ServiceAdapter[]): ServiceAdapter & RequestManageCapable => {
-    const adapter = adapters.find(a => a.id === 'seerr');
+    const adapter = adapters.find(a => a.type === 'seerr');
     if (adapter === undefined) {
         throw new ServiceError('NotFound', 'seerr', 'seerr is not configured', {
             remedy: 'Add a services.seerr block to config.yaml and restart. Requests live in Seerr, not in Radarr or Sonarr.'
@@ -43,7 +43,7 @@ const seerrAdapter = (adapters: readonly ServiceAdapter[]): ServiceAdapter & Req
  * as a bare 404.
  */
 async function findRequest(adapters: readonly ServiceAdapter[], id: string): Promise<MediaRequest> {
-    const adapter = adapters.find(a => a.id === 'seerr');
+    const adapter = adapters.find(a => a.type === 'seerr');
     if (adapter === undefined || !hasRequests(adapter)) {
         throw new ServiceError('NotFound', 'seerr', 'seerr is not configured', {
             remedy: 'Add a services.seerr block to config.yaml and restart.'
@@ -70,7 +70,7 @@ async function findRequest(adapters: readonly ServiceAdapter[], id: string): Pro
  * quietly presenting a bare id as though that were the whole story.
  */
 async function describe(adapters: readonly ServiceAdapter[], request: MediaRequest): Promise<string> {
-    const adapter = adapters.find(a => a.id === 'seerr');
+    const adapter = adapters.find(a => a.type === 'seerr');
     const media =
         adapter !== undefined && hasRequestManage(adapter)
             ? await adapter.describeRequestMedia(request)

--- a/src/tools/register.ts
+++ b/src/tools/register.ts
@@ -106,7 +106,7 @@ export function registerAllTools(server: McpServer, context: ToolContext): void 
     registerDiagnose(server, { adapters, library });
     registerStackHealth(server, adapters);
     registerGetIndexers(server, adapters.find(hasIndexers));
-    registerGetSubtitles(server, adapters.find(hasSubtitles));
+    registerGetSubtitles(server, adapters.filter(hasSubtitles));
     registerGetQueue(server, adapters);
     registerGetCalendar(server, adapters);
     registerGetPlayback(server, jellyfin, jellyfinIdentity);

--- a/src/tools/removeQueueItem.ts
+++ b/src/tools/removeQueueItem.ts
@@ -1,3 +1,4 @@
+import { INSTANCE_PARAM_DESCRIPTION, resolveInstance } from './resolveInstance.ts';
 import type { McpServer } from '@modelcontextprotocol/server';
 import * as z from 'zod/v4';
 import { ServiceIdSchema, type ServiceId } from '../config/schema.ts';
@@ -16,13 +17,8 @@ import { registerWriteTool, type WriteContext, type WritePlan } from './write.ts
  * mysteriously never grabs.
  */
 
-const findAdapter = (adapters: readonly ServiceAdapter[], service: ServiceId) => {
-    const adapter = adapters.find(a => a.id === service);
-    if (adapter === undefined) {
-        throw new ServiceError('NotFound', service, `${service} is not configured`, {
-            remedy: `Add a services.${service} block to config.yaml and restart, or name a configured service.`
-        });
-    }
+const findAdapter = (adapters: readonly ServiceAdapter[], service: ServiceId, instance?: string) => {
+    const adapter = resolveInstance(adapters, service, instance);
     if (!hasQueueRemove(adapter)) {
         throw new ServiceError('NotFound', service, `${service} has no download queue`, {
             remedy: 'Queue items live on radarr, sonarr, sabnzbd and transmission. Take a service and id from get_queue.'
@@ -42,6 +38,7 @@ export function registerRemoveQueueItem(
             'Removes one item from a download queue — the stuck-at-0%, wrong-release, or stalled download. Works against Radarr, Sonarr, SABnzbd and Transmission; take `service` and `id` from get_queue. Optionally deletes partial data and, on Radarr and Sonarr only, blocklists the release so it will not be grabbed again. Previews by default — call again with the returned `confirm` token to actually remove it.',
         inputSchema: z.object({
             service: ServiceIdSchema.describe('radarr, sonarr, sabnzbd or transmission.'),
+            instance: z.string().optional().describe(INSTANCE_PARAM_DESCRIPTION),
             id: z.string().min(1).describe('The queue item id, exactly as get_queue reported it.'),
             remove_from_client: z
                 .boolean()
@@ -56,12 +53,15 @@ export function registerRemoveQueueItem(
                     'Blocklist the release so it is not grabbed again. Radarr and Sonarr only; ignored elsewhere. Defaults to false.'
                 )
         }),
-        service: ({ service }) => service,
+        // The resolved instance id, not the bare type: permissions are granted per
+        // instance, so checking `radarr` against a config that only grants
+        // `radarr/hd` would deny a permitted write — or worse, the reverse.
+        service: ({ service, instance }) => findAdapter(adapters, service, instance).id,
         operation: 'remove_queue_item',
         tier: 'destructive',
 
-        async plan({ service, id, remove_from_client, blocklist }): Promise<WritePlan> {
-            const adapter = findAdapter(adapters, service);
+        async plan({ service, instance, id, remove_from_client, blocklist }): Promise<WritePlan> {
+            const adapter = findAdapter(adapters, service, instance);
 
             // Read the live queue so the preview names the release rather than
             // an opaque id, and so an id that has already finished downloading
@@ -110,8 +110,8 @@ export function registerRemoveQueueItem(
             };
         },
 
-        async apply(_plan, { service, id, remove_from_client, blocklist }) {
-            const adapter = findAdapter(adapters, service);
+        async apply(_plan, { service, instance, id, remove_from_client, blocklist }) {
+            const adapter = findAdapter(adapters, service, instance);
             await adapter.removeQueueItem(id, {
                 removeFromClient: remove_from_client,
                 blocklist: blocklist && adapter.supportsBlocklist

--- a/src/tools/resolveInstance.ts
+++ b/src/tools/resolveInstance.ts
@@ -1,0 +1,85 @@
+import type { ServiceId } from '../config/schema.ts';
+import { ServiceError } from '../core/errors.ts';
+import type { ServiceAdapter } from '../services/types.ts';
+
+/**
+ * Which configured instance of a service a call means.
+ *
+ * Six tools open-coded `adapters.find(a => a.id === service)`, which was exactly
+ * right while `id` and service type were the same string. With two Radarrs they
+ * are not, and that lookup matches *neither* — so this replaces all six rather
+ * than being added beside them.
+ *
+ * The rule that matters is the last one: **several instances and none named is a
+ * refusal, not a coin toss.** That is already this codebase's answer to
+ * ambiguity, and it was written after a real incident — an ambiguous quality
+ * profile match sent a film to 1080p against an explicit 2160p request, and it
+ * was only discovered once the download finished (see `addMedia.ts`). Guessing
+ * which Radarr receives a 4K release is the same failure with a worse blast
+ * radius: the wrong library, the wrong disk, and no error anywhere.
+ *
+ * Every refusal names the alternatives. A refusal that does not say what to pass
+ * instead leaves the model to guess a second time.
+ */
+export function resolveInstance(
+    adapters: readonly ServiceAdapter[],
+    type: ServiceId,
+    instance?: string | undefined
+): ServiceAdapter {
+    // `.type`, never `.id` — `id` is `radarr/4k` for a named instance, so
+    // matching on it is what broke.
+    const candidates = adapters.filter(a => a.type === type);
+
+    if (candidates.length === 0) {
+        throw new ServiceError('NotFound', type, `${type} is not configured`, {
+            remedy: `Add a services.${type} block to config.yaml, or name a configured service.`
+        });
+    }
+
+    if (instance !== undefined && instance !== '') {
+        const wanted = instance.toLowerCase();
+        const found = candidates.find(a => (a.instance ?? '').toLowerCase() === wanted);
+        if (found !== undefined) return found;
+
+        throw new ServiceError('NotFound', type, `${type} has no instance named "${instance}"`, {
+            remedy: `Configured ${type} instances: ${nameList(candidates)}.`
+        });
+    }
+
+    if (candidates.length === 1) return candidates[0] as ServiceAdapter;
+
+    throw new ServiceError(
+        'NotFound',
+        type,
+        `${type} has ${candidates.length} instances configured, so "${type}" alone does not say which`,
+        {
+            remedy: `Pass instance with one of: ${nameList(candidates)}. Guessing risks acting on the wrong library.`
+        }
+    );
+}
+
+/** The names as the caller would pass them — bare, not qualified, because
+ *  `instance` takes `4k` rather than `radarr/4k`. */
+const nameList = (adapters: readonly ServiceAdapter[]): string =>
+    adapters
+        .map(a => (a.instance === undefined ? '(unnamed)' : `"${a.instance}"`))
+        .sort()
+        .join(', ');
+
+/**
+ * Every instance of a service, for reads that span them.
+ *
+ * Someone runs a 4K Radarr so that their library is the union of both. A read
+ * that demanded to know which half to look in would have defeated the point, so
+ * reads fan out and only writes name one.
+ */
+export const instancesOfType = (adapters: readonly ServiceAdapter[], type: ServiceId): ServiceAdapter[] =>
+    adapters.filter(a => a.type === type);
+
+/**
+ * The `instance` parameter's description, shared so all six tools word it the
+ * same way. The model reads these, and three phrasings of one concept is three
+ * chances to conclude they mean different things.
+ */
+export const INSTANCE_PARAM_DESCRIPTION =
+    'Which instance, when several of this service are configured — for example "4k" or "hd". Omit it when there is only one. If several are configured and you omit it, the call is refused and the names are listed.';

--- a/src/tools/triggerSearch.ts
+++ b/src/tools/triggerSearch.ts
@@ -1,3 +1,4 @@
+import { INSTANCE_PARAM_DESCRIPTION, resolveInstance } from './resolveInstance.ts';
 import type { McpServer } from '@modelcontextprotocol/server';
 import * as z from 'zod/v4';
 import { ServiceIdSchema, type ServiceId } from '../config/schema.ts';
@@ -16,13 +17,8 @@ import { registerWriteTool, type WriteContext, type WritePlan } from './write.ts
  * user could have seen before the write, not one this tool invented.
  */
 
-const findAdapter = (adapters: readonly ServiceAdapter[], service: ServiceId) => {
-    const adapter = adapters.find(a => a.id === service);
-    if (adapter === undefined) {
-        throw new ServiceError('NotFound', service, `${service} is not configured`, {
-            remedy: `Add a services.${service} block to config.yaml and restart, or name a configured service.`
-        });
-    }
+const findAdapter = (adapters: readonly ServiceAdapter[], service: ServiceId, instance?: string) => {
+    const adapter = resolveInstance(adapters, service, instance);
     if (!hasSearchTrigger(adapter)) {
         throw new ServiceError('NotFound', service, `${service} cannot be told to search`, {
             remedy: 'Only radarr and sonarr support trigger_search.'
@@ -42,16 +38,20 @@ export function registerTriggerSearch(
             'Asks Radarr or Sonarr to go looking for releases for one item it already tracks — the "it never downloaded, try again" action. Takes `service` and `id`, deliberately not a title: get those from get_media_details or get_library first. This queues a search and returns immediately; it does not wait for a release to be found, and finding one is not guaranteed. Previews by default — call again with the returned `confirm` token to actually run it.',
         inputSchema: z.object({
             service: ServiceIdSchema.describe('radarr or sonarr.'),
+            instance: z.string().optional().describe(INSTANCE_PARAM_DESCRIPTION),
             id: z.string().min(1).describe("The item's id within that service, as an integer string.")
         }),
         // The permission check follows the argument, so enabling `safe_write`
         // on Radarr does not quietly enable it on Sonarr.
-        service: ({ service }) => service,
+        // The resolved instance id, not the bare type: permissions are granted per
+        // instance, so checking `radarr` against a config that only grants
+        // `radarr/hd` would deny a permitted write — or worse, the reverse.
+        service: ({ service, instance }) => findAdapter(adapters, service, instance).id,
         operation: 'trigger_search',
         tier: 'safe',
 
-        async plan({ service, id }): Promise<WritePlan> {
-            const adapter = findAdapter(adapters, service);
+        async plan({ service, instance, id }): Promise<WritePlan> {
+            const adapter = findAdapter(adapters, service, instance);
 
             // A read before the write, for two reasons: it fails early and
             // legibly if the id does not exist ("Radarr has no movie 9999"
@@ -89,8 +89,8 @@ export function registerTriggerSearch(
             };
         },
 
-        async apply(_plan, { service, id }) {
-            return findAdapter(adapters, service).triggerSearch(id);
+        async apply(_plan, { service, instance, id }) {
+            return findAdapter(adapters, service, instance).triggerSearch(id);
         }
     });
 }

--- a/src/tools/write.ts
+++ b/src/tools/write.ts
@@ -1,6 +1,5 @@
 import type { McpServer } from '@modelcontextprotocol/server';
 import * as z from 'zod/v4';
-import type { ServiceId } from '../config/schema.ts';
 import type { WriteAudit } from '../core/audit.ts';
 import type { ConfirmTokens, WriteIntent } from '../core/confirm.ts';
 import { ServiceError } from '../core/errors.ts';
@@ -65,7 +64,7 @@ export type WriteToolSpec<Schema extends z.ZodObject> = {
      * it would check Sonarr writes against Radarr's `permissions` block, so
      * enabling one service would quietly enable the other.
      */
-    service: ServiceId | ((args: z.infer<Schema>) => ServiceId);
+    service: string | ((args: z.infer<Schema>) => string);
     /** The adapter-level verb, e.g. `delete_movie`; one tool may reach several. */
     operation: string;
     tier: WriteTier;
@@ -99,7 +98,7 @@ export type WriteToolResult = {
     applied: boolean;
     dry_run: boolean;
     tool: string;
-    service: ServiceId;
+    service: string;
     operation: string;
     tier: WriteTier;
     target: string;

--- a/test/addMedia.test.ts
+++ b/test/addMedia.test.ts
@@ -1,3 +1,4 @@
+import type { ServiceInstance } from '../src/config/instances.ts';
 import { instancesOf } from './helpers/instances.ts';
 import { describe, expect, it, vi } from 'vitest';
 import * as z from 'zod/v4';
@@ -88,6 +89,8 @@ type Call = (args: Record<string, unknown>) => Promise<{
 function harness(
     opts: Parameters<typeof stack>[0] & {
         permissions?: Partial<Record<ServiceId, AnyServiceConfig>>;
+        /** Named instances, for the tests that are about which instance a write hits. */
+        instances?: ServiceInstance[];
         adapters?: ServiceAdapter[];
     } = {}
 ) {
@@ -106,7 +109,9 @@ function harness(
     registerAddMedia(
         server as never,
         {
-            permissions: permissionSourceFrom(instancesOf(opts.permissions ?? { radarr: tiered(true), sonarr: tiered(true) })),
+            permissions: permissionSourceFrom(
+                opts.instances ?? instancesOf(opts.permissions ?? { radarr: tiered(true), sonarr: tiered(true) })
+            ),
             confirm: new ConfirmTokens(),
             audit,
             library: { invalidate } as unknown as LibraryLoader
@@ -479,5 +484,75 @@ describe('add_media on Sonarr', () => {
         await expect(h.call({ service: 'radarr', external_id: '999999999', dry_run: true })).rejects.toThrow(
             /Radarr takes TMDB, Sonarr takes TVDB/
         );
+    });
+});
+
+/**
+ * Permissions are granted per instance, and the write gate has to look up the
+ * *resolved* instance id rather than the bare service type.
+ *
+ * This is unit-tested rather than verified against a live server because
+ * `registerWriteTool` runs `plan()` before `checkPermission` — `plan` reads
+ * quality profiles and root folders from the service, so against an unreachable
+ * host the call fails at the network before the permission gate is ever
+ * reached. A live check therefore cannot see this, and getting it wrong would
+ * mean either denying a permitted write or, far worse, permitting a denied one.
+ */
+describe('add_media across two Radarr instances', () => {
+    const bothInstances = (hdSafeWrite: boolean, fourKSafeWrite: boolean): ServiceInstance[] => [
+        { id: 'radarr/hd', type: 'radarr', name: 'hd', config: tiered(hdSafeWrite) },
+        { id: 'radarr/4k', type: 'radarr', name: '4k', config: tiered(fourKSafeWrite) }
+    ];
+
+    const twoRadarrs = (impl: typeof fetch): ServiceAdapter[] => [
+        new RadarrAdapter({ ...keyed(7878), name: 'hd' }, impl),
+        new RadarrAdapter({ ...keyed(7879), name: '4k' }, impl)
+    ];
+
+    it('refuses to guess which Radarr, and names both', async () => {
+        const s = stack();
+        const h = harness({ adapters: twoRadarrs(s.impl), instances: bothInstances(true, true) });
+
+        await expect(h.call({ service: 'radarr', external_id: '550' })).rejects.toThrow(/2 instances/);
+    });
+
+    it('checks the permission of the instance actually named, not the service', async () => {
+        const s = stack();
+        const opts = { adapters: twoRadarrs(s.impl), instances: bothInstances(true, false) };
+
+        const allowed = await harness(opts).call({ service: 'radarr', instance: 'hd', external_id: '550' });
+        expect(allowed.structuredContent.permission.allowed).toBe(true);
+        expect(allowed.structuredContent.service).toBe('radarr/hd');
+
+        // A denied live write throws rather than returning a verdict — the
+        // refusal is the result.
+        await expect(
+            harness(opts).call({ service: 'radarr', instance: '4k', external_id: '550', confirm: 'x' })
+        ).rejects.toThrow(/disabled for radarr\/4k/);
+    });
+
+    /**
+     * `services.radarr/4k.permissions` is the string an id-shaped remedy builds,
+     * and it names a key that cannot exist — a named instance lives inside a
+     * list. Someone following it would edit nothing, the write would stay
+     * refused, and the remedy would look broken rather than misread.
+     */
+    it('points at a YAML path that exists for a named instance', async () => {
+        const s = stack();
+        const opts = { adapters: twoRadarrs(s.impl), instances: bothInstances(true, false) };
+
+        await expect(
+            harness(opts).call({ service: 'radarr', instance: '4k', external_id: '550', confirm: 'x' })
+        ).rejects.toThrow(/`name: 4k` entry under `services.radarr`/);
+    });
+
+    it('names the instance in the audit row, so two Radarrs stay distinguishable', async () => {
+        const s = stack();
+        const h = harness({ adapters: twoRadarrs(s.impl), instances: bothInstances(true, true) });
+
+        await h.call({ service: 'radarr', instance: '4k', external_id: '550' });
+
+        const [row] = h.audit.recent(1) as { service: string }[];
+        expect(row?.service).toBe('radarr/4k');
     });
 });

--- a/test/getSubtitles.test.ts
+++ b/test/getSubtitles.test.ts
@@ -58,13 +58,13 @@ const adapter = (r: Record<string, unknown> = routes) => new BazarrAdapter(confi
 
 describe('get_subtitles', () => {
     it('returns movie and episode gaps together', async () => {
-        const result = await buildGetSubtitles(adapter(), { detail: 'full', limit: 50 });
+        const result = await buildGetSubtitles([adapter()], { detail: 'full', limit: 50 });
         expect(result.items.map(i => i.kind).sort()).toEqual(['episode', 'movie']);
         expect(result.total).toBe(2);
     });
 
     it('maps a movie gap field for field', async () => {
-        const result = await buildGetSubtitles(adapter(), { detail: 'full', limit: 50 });
+        const result = await buildGetSubtitles([adapter()], { detail: 'full', limit: 50 });
         expect(result.items.find(i => i.kind === 'movie')).toMatchObject({
             service: 'bazarr',
             kind: 'movie',
@@ -74,14 +74,14 @@ describe('get_subtitles', () => {
     });
 
     it('maps an episode gap including season and episode numbers', async () => {
-        const result = await buildGetSubtitles(adapter(), { detail: 'full', limit: 50 });
+        const result = await buildGetSubtitles([adapter()], { detail: 'full', limit: 50 });
         const episode = result.items.find(i => i.kind === 'episode');
         expect(episode).toMatchObject({ id: 88, season: 1, episode: 1 });
         expect(episode?.missing[0]?.forced).toBe(true);
     });
 
     it('fences the release name, and a release name cannot escape its fence', async () => {
-        const result = await buildGetSubtitles(adapter(), { detail: 'full', limit: 50 });
+        const result = await buildGetSubtitles([adapter()], { detail: 'full', limit: 50 });
         const movie = result.items.find(i => i.kind === 'movie');
 
         expect(movie?.releaseName).toContain('<<untrusted:bazarr.sceneName>>');
@@ -89,19 +89,19 @@ describe('get_subtitles', () => {
     });
 
     it('fences titles too, because Bazarr echoes names from the *arr metadata', async () => {
-        const result = await buildGetSubtitles(adapter(), { detail: 'full', limit: 50 });
+        const result = await buildGetSubtitles([adapter()], { detail: 'full', limit: 50 });
         expect(result.items.every(i => i.title.startsWith('<<untrusted:bazarr.'))).toBe(true);
     });
 
     it('drops release names and per-language detail at detail: minimal', async () => {
-        const result = await buildGetSubtitles(adapter(), { detail: 'minimal', limit: 50 });
+        const result = await buildGetSubtitles([adapter()], { detail: 'minimal', limit: 50 });
         const movie = result.items.find(i => i.kind === 'movie');
         expect(movie?.releaseName).toBeUndefined();
         expect(movie?.missing).toEqual([]);
     });
 
     it('degrades when one endpoint is down', async () => {
-        const result = await buildGetSubtitles(adapter({ '/api/movies/wanted': MOVIES }), {
+        const result = await buildGetSubtitles([adapter({ '/api/movies/wanted': MOVIES })], {
             detail: 'standard',
             limit: 50
         });
@@ -111,7 +111,7 @@ describe('get_subtitles', () => {
 
     it('reports truncation honestly', async () => {
         const many = { data: repeat(MOVIES.data[0]!, 300) };
-        const result = await buildGetSubtitles(adapter({ ...routes, '/api/movies/wanted': many }), {
+        const result = await buildGetSubtitles([adapter({ ...routes, '/api/movies/wanted': many })], {
             detail: 'standard',
             limit: 50
         });
@@ -119,7 +119,7 @@ describe('get_subtitles', () => {
     });
 
     it('returns an empty result when Bazarr is not configured', async () => {
-        expect(await buildGetSubtitles(undefined, { detail: 'standard', limit: 50 })).toMatchObject({
+        expect(await buildGetSubtitles([], { detail: 'standard', limit: 50 })).toMatchObject({
             items: [],
             total: 0,
             degraded: []
@@ -127,7 +127,7 @@ describe('get_subtitles', () => {
     });
 
     it('reports provider state, which is what explains why subtitles are missing', async () => {
-        const result = await buildGetSubtitles(adapter(), { detail: 'standard', limit: 50 });
+        const result = await buildGetSubtitles([adapter()], { detail: 'standard', limit: 50 });
         expect(result.providers).toEqual([
             { service: 'bazarr', name: 'opensubtitlescom', healthy: true },
             {
@@ -141,18 +141,18 @@ describe('get_subtitles', () => {
     });
 
     it('treats "End of information" as no retry time rather than a date', async () => {
-        const result = await buildGetSubtitles(adapter(), { detail: 'standard', limit: 50 });
+        const result = await buildGetSubtitles([adapter()], { detail: 'standard', limit: 50 });
         expect(result.providers?.[0]?.retryAt).toBeUndefined();
     });
 
     it('omits provider state at detail: minimal', async () => {
-        const result = await buildGetSubtitles(adapter(), { detail: 'minimal', limit: 50 });
+        const result = await buildGetSubtitles([adapter()], { detail: 'minimal', limit: 50 });
         expect(result.providers).toBeUndefined();
     });
 
     it('still returns subtitle gaps when the providers endpoint is unavailable', async () => {
         const noProviders = { '/api/movies/wanted': MOVIES, '/api/episodes/wanted': EPISODES };
-        const result = await buildGetSubtitles(adapter(noProviders), { detail: 'standard', limit: 50 });
+        const result = await buildGetSubtitles([adapter(noProviders)], { detail: 'standard', limit: 50 });
 
         expect(result.items).toHaveLength(2);
         expect(result.providers).toBeUndefined();
@@ -163,7 +163,7 @@ describe('get_subtitles', () => {
         // 500 missing subtitles is realistic for a large library, unlike 500
         // indexers — so the default level is the one that has to be cheap.
         const many = { data: repeat(MOVIES.data[0]!, 500) };
-        const result = await buildGetSubtitles(adapter({ ...routes, '/api/movies/wanted': many }), {
+        const result = await buildGetSubtitles([adapter({ ...routes, '/api/movies/wanted': many })], {
             detail: 'standard',
             limit: 500
         });
@@ -176,7 +176,7 @@ describe('get_subtitles', () => {
         // inherent to §11 and is the reason `standard` is the default; this
         // ceiling exists to catch a regression, not to bless the number.
         const many = { data: repeat(MOVIES.data[0]!, 500) };
-        const result = await buildGetSubtitles(adapter({ ...routes, '/api/movies/wanted': many }), {
+        const result = await buildGetSubtitles([adapter({ ...routes, '/api/movies/wanted': many })], {
             detail: 'full',
             limit: 500
         });

--- a/test/resolveInstance.test.ts
+++ b/test/resolveInstance.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { ConfigSchema } from '../src/config/schema.ts';
+import { ServiceError } from '../src/core/errors.ts';
+import { buildAdapters } from '../src/services/registry.ts';
+import { instancesOfType, resolveInstance } from '../src/tools/resolveInstance.ts';
+
+/**
+ * Which instance a call means, and — more importantly — when it refuses to
+ * guess.
+ *
+ * Every refusal here is asserted to *name the alternatives*. A refusal that does
+ * not say what to pass instead is a dead end: the model has no way to recover
+ * except by guessing a second time.
+ */
+
+const AUTH = { bearer_token: 'a'.repeat(64), username: 'admin', allowed_hosts: [] };
+
+const adaptersFor = (services: unknown) => buildAdapters(ConfigSchema.parse({ auth: AUTH, services }));
+
+const one = { url: 'http://192.0.2.10:7878', api_key: 'k' };
+const named = (name: string, port: number) => ({ name, url: `http://192.0.2.10:${port}`, api_key: 'k' });
+
+const twoRadarrs = () => adaptersFor({ radarr: [named('hd', 7878), named('4k', 7879)] });
+
+describe('resolving an instance', () => {
+    it('uses the only instance when none is named — every config that exists today', () => {
+        const adapters = adaptersFor({ radarr: one });
+        expect(resolveInstance(adapters, 'radarr').id).toBe('radarr');
+    });
+
+    it('uses a named sole instance without being asked for the name', () => {
+        const adapters = adaptersFor({ radarr: [named('main', 7878)] });
+        expect(resolveInstance(adapters, 'radarr').id).toBe('radarr/main');
+    });
+
+    it('picks the named one out of several', () => {
+        expect(resolveInstance(twoRadarrs(), 'radarr', '4k').id).toBe('radarr/4k');
+        expect(resolveInstance(twoRadarrs(), 'radarr', 'hd').id).toBe('radarr/hd');
+    });
+
+    it('matches the name case-insensitively, because 4K and 4k are never two things', () => {
+        expect(resolveInstance(twoRadarrs(), 'radarr', '4K').id).toBe('radarr/4k');
+    });
+
+    it('keys on the service type, not the id — the lookup that broke with two Radarrs', () => {
+        // `adapters.find(a => a.id === 'radarr')` matches neither `radarr/hd`
+        // nor `radarr/4k`. This is the regression that PR 1 created and this
+        // resolver exists to close.
+        expect(twoRadarrs().some(a => a.id === 'radarr')).toBe(false);
+        expect(resolveInstance(twoRadarrs(), 'radarr', 'hd').type).toBe('radarr');
+    });
+});
+
+describe('refusing to guess', () => {
+    /**
+     * The decision this whole design turns on. It is already house style: an
+     * ambiguous quality profile match once sent a film to 1080p against an
+     * explicit 2160p request, discovered only when the download finished.
+     * Choosing between two Radarrs is that failure with a worse blast radius.
+     */
+    it('refuses when several are configured and none was named, and lists them', () => {
+        try {
+            resolveInstance(twoRadarrs(), 'radarr');
+            expect.unreachable('should have refused');
+        } catch (err) {
+            expect(err).toBeInstanceOf(ServiceError);
+            const message = (err as ServiceError).message;
+            expect(message).toMatch(/2 instances/);
+            expect(message).toContain('"4k"');
+            expect(message).toContain('"hd"');
+        }
+    });
+
+    it('refuses a name that is not configured, and lists the ones that are', () => {
+        try {
+            resolveInstance(twoRadarrs(), 'radarr', 'uhd');
+            expect.unreachable('should have refused');
+        } catch (err) {
+            const message = (err as ServiceError).message;
+            expect(message).toMatch(/no instance named "uhd"/);
+            expect(message).toContain('"4k"');
+            expect(message).toContain('"hd"');
+        }
+    });
+
+    it('refuses a service with no instances at all, and says how to add one', () => {
+        try {
+            resolveInstance(adaptersFor({ radarr: one }), 'sonarr');
+            expect.unreachable('should have refused');
+        } catch (err) {
+            const message = (err as ServiceError).message;
+            expect(message).toMatch(/sonarr is not configured/);
+            expect(message).toMatch(/services\.sonarr/);
+        }
+    });
+
+    it('does not treat an empty string as a name', () => {
+        expect(resolveInstance(adaptersFor({ radarr: one }), 'radarr', '').id).toBe('radarr');
+    });
+});
+
+describe('reads span every instance', () => {
+    it('returns all instances of a type, so a read can merge them', () => {
+        expect(instancesOfType(twoRadarrs(), 'radarr').map(a => a.id)).toEqual(['radarr/4k', 'radarr/hd']);
+    });
+
+    it('returns nothing rather than throwing when the service is absent', () => {
+        expect(instancesOfType(adaptersFor({ radarr: one }), 'bazarr')).toEqual([]);
+    });
+});

--- a/test/triggerSearch.test.ts
+++ b/test/triggerSearch.test.ts
@@ -193,6 +193,7 @@ describe('trigger_search', () => {
         // refusals with two different remedies.
         const jellyfin = {
             id: 'jellyfin' as ServiceId,
+            type: 'jellyfin' as ServiceId,
             testConnection: () => Promise.reject(new Error('unused')),
             getVersion: () => Promise.resolve('10.8.0')
         } as unknown as ServiceAdapter;


### PR DESCRIPTION
**PR 2 of 3.** PR 1 gave every instance an identity; this teaches the tools to use it, and is where two Radarrs become usable.

> [!IMPORTANT]
> Still no release. **#65 stays unmerged** until PR 3 lands with `Release-As: 0.7.0`.

## The lookup that broke

`resolveInstance` replaces the six open-coded `adapters.find(a => a.id === service)` calls. Those were right while `id` and service type were the same string — with two Radarrs they aren't, and the lookup matched **neither**, which is why PR 1 alone left `add_media` answering *"radarr is not configured"*.

## Refusing beats guessing

Every tool taking `service` gains an optional `instance`:

| Situation | Result |
| --- | --- |
| Omitted, one instance | that one — **every config that exists today** |
| Omitted, several | refused, names listed |
| Named and present | that one |
| Named and absent | refused, names listed |

```
add_media { service: "radarr", external_id: "550" }
→ radarr has 2 instances configured, so "radarr" alone does not say which
  → Pass instance with one of: "4k", "hd".
```

This is already house style. An ambiguous quality-profile match once sent a film to 1080p against an explicit 2160p request, found only when the download finished. Picking between two Radarrs is that failure with a worse blast radius — wrong library, wrong disk, no error anywhere.

## Reads span instances, writes name one

You run a 4K Radarr so your library is the union of both; a read demanding to know which half to search defeats the point. `stack_health` and the library join already iterated. `get_subtitles` now reads **every** Bazarr and merges — Bazarr connects to a single Radarr and Sonarr, so a tiered pair implies one per stack. One Bazarr failing degrades to a named entry; the others still answer.

## Two things the write gate needed

**The permission key is the resolved instance id**, not the service type. Checking `radarr` against a config granting only `radarr/hd` would deny a permitted write — and the reverse would permit a denied one.

**The remedy named a YAML path that cannot exist.** `services.radarr/4k.permissions.safe_write` is what an id-shaped message builds, but a named instance lives inside a list. Someone following it edits nothing, the write stays refused, and the remedy looks broken rather than misread. It now points at the `name: 4k` entry under `services.radarr`.

## What I could and couldn't verify live

**Verified against a running server** with two Radarrs and one Sonarr: the ambiguity refusal, the unknown-instance refusal, and that a single-instance service still resolves untouched (reaches the network, fails only on the unreachable host).

**Could not verify live:** per-instance permission enforcement. `write.ts:155` runs `plan()` before `checkPermission`, and `plan` reads quality profiles from the service — so an unreachable host fails at the network before the gate. Unit-tested instead, deliberately, because getting it wrong in the permissive direction is the worst failure in this PR.

## Incidental

- `logs.services()` needed no change — it lists what actually logged, and adapters log their instance id.
- A test fake carried `id: 'jellyfin'` with no `type` and was cast past the interface, so it silently became "not configured" instead of "cannot be told to search". Fixed in the fixture.

1001 → 1005 tests. Lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
