### PR TITLE
feat: rebuild the configuration page around instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ tier.
 | Page | What it is for |
 | --- | --- |
 | Dashboard | Every service tested live, plus disk space, failed health checks, library scan staleness, and the bearer token for your MCP client |
-| Configuration | Add, edit and remove services; change credentials |
+| Configuration | Add, edit and remove service instances one at a time; change credentials |
 | Logs | Three streams — all activity, problems only, or one service |
 | Write audit | Every write attempt — applied, previewed, refused or failed |
 
@@ -381,6 +381,17 @@ hand. **Copy client config** puts a ready-to-paste JSON block on your clipboard
 with the endpoint and token filled in. That block is assembled in your browser
 at the moment you click, never rendered into the page, so the screenshot
 property above still holds.
+
+**The Configuration page starts empty.** It shows a card per instance you have
+actually configured, in alphabetical order, and one **Add** form — not eight
+blank fieldsets for services you do not run. Each card saves on its own, so
+editing your 4K Radarr cannot disturb the HD one.
+
+Adding a second Radarr, Sonarr or Bazarr asks you to name the one you already
+have, and says why: the name becomes part of the id, and that id is the
+permission key, the audit column, and what your agent passes. Removing an
+instance asks once before it goes, because its API key is not recovered by
+re-adding it.
 
 **Logs are a ring buffer**, kept beside your config and capped, so a chatty
 service cannot fill the disk. Full history stays in `docker logs`.

--- a/src/config/mutate.ts
+++ b/src/config/mutate.ts
@@ -1,0 +1,204 @@
+import { instanceId } from './instances.ts';
+import {
+    ConfigSchema,
+    MULTI_INSTANCE,
+    type AnyServiceConfig,
+    type Config,
+    type Instanced,
+    type ServiceId
+} from './schema.ts';
+
+/**
+ * Adding, editing and removing one instance, as config algebra.
+ *
+ * Kept out of the page so it can be tested without a browser or a session, and
+ * because these are the operations that must not go wrong: every one of them
+ * ends by parsing the result through `ConfigSchema`, so an edit that would
+ * produce an invalid config fails in the handler with a message rather than
+ * reaching disk.
+ */
+
+type Entry = Instanced<AnyServiceConfig>;
+
+/** What a card's form can set. Blank credentials mean *unchanged*, which is why
+ *  they are optional here rather than defaulted to empty. */
+export type InstanceFields = {
+    url?: string;
+    api_key?: string;
+    username?: string;
+    password?: string;
+    default_user?: string;
+    allow_other_users?: boolean;
+    timeout_ms?: number;
+    safe_write?: boolean;
+    destructive?: boolean;
+};
+
+export class ConfigEditError extends Error {}
+
+const entriesOf = (services: Record<string, unknown>, type: ServiceId): Entry[] => {
+    const value = services[type];
+    if (value === undefined) return [];
+    return Array.isArray(value) ? [...(value as Entry[])] : [value as Entry];
+};
+
+/**
+ * One unnamed entry is written as a bare block; anything else is a list.
+ *
+ * A single *named* entry stays a list on purpose. Collapsing it back to
+ * `services.radarr` would rename `radarr/hd` to `radarr` — a second silent
+ * rename, undoing the one the user was explicitly asked to approve when the
+ * name was introduced.
+ */
+function writeBack(services: Record<string, unknown>, type: ServiceId, entries: Entry[]): void {
+    if (entries.length === 0) {
+        delete services[type];
+        return;
+    }
+    const only = entries[0];
+    if (entries.length === 1 && only !== undefined && only.name === undefined) {
+        services[type] = only;
+        return;
+    }
+    services[type] = entries;
+}
+
+/** Deep enough: every value below `services` is a plain object or array of them. */
+const cloneServices = (config: Config): Record<string, unknown> =>
+    JSON.parse(JSON.stringify(config.services)) as Record<string, unknown>;
+
+const validate = (config: Config, services: Record<string, unknown>): Config => {
+    const result = ConfigSchema.safeParse({ auth: config.auth, services });
+    if (!result.success) {
+        throw new ConfigEditError(result.error.issues.map(i => `${i.path.join('.')}: ${i.message}`).join('; '));
+    }
+    return result.data;
+};
+
+const MULTI_USER: ReadonlySet<ServiceId> = new Set<ServiceId>(['jellyfin', 'seerr']);
+const NO_API_KEY: ReadonlySet<ServiceId> = new Set<ServiceId>(['transmission']);
+
+/**
+ * Applies form fields to an entry, leaving a blank credential as it was.
+ *
+ * Gated by service type rather than by which fields the form happened to send.
+ * Every card posts the same field names — an unchecked checkbox is simply
+ * absent, so the form cannot distinguish "off" from "this service has no such
+ * field", and the service schemas are **strict**: one stray
+ * `allow_other_users` on a Radarr makes the whole config invalid.
+ */
+function applyFields(type: ServiceId, base: Entry, fields: InstanceFields): Entry {
+    const next = { ...base } as Record<string, unknown>;
+
+    if (fields.url !== undefined && fields.url !== '') next.url = fields.url;
+    if (fields.timeout_ms !== undefined) next.timeout_ms = fields.timeout_ms;
+
+    // Blank means unchanged, which is what keeps a saved page or a screenshot
+    // from being able to carry a secret back in.
+    if (NO_API_KEY.has(type)) {
+        if (fields.password !== undefined && fields.password !== '') next.password = fields.password;
+        // Not a credential, so blank means "cleared" rather than "unchanged".
+        if (fields.username !== undefined) {
+            if (fields.username === '') delete next.username;
+            else next.username = fields.username;
+        }
+    } else if (fields.api_key !== undefined && fields.api_key !== '') {
+        next.api_key = fields.api_key;
+    }
+
+    if (MULTI_USER.has(type)) {
+        if (fields.default_user !== undefined) {
+            if (fields.default_user === '') delete next.default_user;
+            else next.default_user = fields.default_user;
+        }
+        if (fields.allow_other_users !== undefined) next.allow_other_users = fields.allow_other_users;
+    }
+
+    if (fields.safe_write !== undefined || fields.destructive !== undefined) {
+        next.permissions = {
+            safe_write: fields.safe_write ?? false,
+            destructive: fields.destructive ?? false
+        };
+    }
+
+    return next as Entry;
+}
+
+export function addInstance(
+    config: Config,
+    opts: { type: ServiceId; name?: string | undefined; renameExistingTo?: string | undefined; fields: InstanceFields }
+): Config {
+    const services = cloneServices(config);
+    const entries = entriesOf(services, opts.type);
+    const multi = MULTI_INSTANCE.includes(opts.type);
+
+    if (entries.length > 0 && !multi) {
+        throw new ConfigEditError(
+            `${opts.type} is already configured, and only ${MULTI_INSTANCE.join(', ')} can have more than one instance.`
+        );
+    }
+
+    if (entries.length > 0 && opts.name === undefined) {
+        throw new ConfigEditError(`Name the new ${opts.type} instance — several cannot share one name.`);
+    }
+
+    // The rename this can force, made explicit. The existing instance's id is
+    // its permission key and its audit column, so it is never renamed without
+    // the caller having said what to rename it to.
+    const existing = entries[0];
+    if (entries.length === 1 && existing !== undefined && existing.name === undefined) {
+        if (opts.renameExistingTo === undefined || opts.renameExistingTo === '') {
+            throw new ConfigEditError(
+                `Adding a second ${opts.type} means naming the one you already have — it is currently "${opts.type}".`
+            );
+        }
+        entries[0] = { ...existing, name: opts.renameExistingTo };
+    }
+
+    if (opts.name !== undefined && entries.some(e => e.name?.toLowerCase() === opts.name?.toLowerCase())) {
+        throw new ConfigEditError(`${opts.type} already has an instance named "${opts.name}".`);
+    }
+
+    const created = applyFields(
+        opts.type,
+        { permissions: { safe_write: false, destructive: false } } as unknown as Entry,
+        opts.fields
+    );
+    entries.push(opts.name === undefined ? created : { ...created, name: opts.name });
+
+    writeBack(services, opts.type, entries);
+    return validate(config, services);
+}
+
+export function updateInstance(config: Config, id: string, fields: InstanceFields): Config {
+    const services = cloneServices(config);
+    const { type, entries, index } = locate(services, id);
+
+    entries[index] = applyFields(type, entries[index] as Entry, fields);
+    writeBack(services, type, entries);
+    return validate(config, services);
+}
+
+export function removeInstance(config: Config, id: string): Config {
+    const services = cloneServices(config);
+    const { type, entries, index } = locate(services, id);
+
+    entries.splice(index, 1);
+    writeBack(services, type, entries);
+    return validate(config, services);
+}
+
+function locate(
+    services: Record<string, unknown>,
+    id: string
+): { type: ServiceId; entries: Entry[]; index: number } {
+    const slash = id.indexOf('/');
+    const type = (slash === -1 ? id : id.slice(0, slash)) as ServiceId;
+    const name = slash === -1 ? undefined : id.slice(slash + 1);
+
+    const entries = entriesOf(services, type);
+    const index = entries.findIndex(e => instanceId(type, e.name) === instanceId(type, name));
+
+    if (index === -1) throw new ConfigEditError(`${id} is not configured.`);
+    return { type, entries, index };
+}

--- a/src/web/configPage.ts
+++ b/src/web/configPage.ts
@@ -1,22 +1,34 @@
-import { ServiceIdSchema, type Config, type ServiceId } from '../config/schema.ts';
+import { listInstances, type ServiceInstance } from '../config/instances.ts';
+import { MULTI_INSTANCE, ServiceIdSchema, type Config, type ServiceId } from '../config/schema.ts';
 import { html, raw, type SafeHtml } from './html.ts';
 import { layout } from './pages.ts';
 
 /**
- * The configuration form.
+ * The configuration page: one card per configured instance, and nothing else.
  *
- * One rule shapes the whole page: **a secret is never rendered back**. API
- * keys, the Transmission password and the UI password all render as empty
- * fields that mean "unchanged", so a saved page, a screenshot or a browser's
- * autofill history cannot carry them. That also means an empty field can never
- * mean "clear this" — clearing is done by disabling the service, which is
- * unambiguous.
+ * Two rules shape it.
+ *
+ * **A secret is never rendered back.** API keys, the Transmission password and
+ * the UI password all render as empty fields meaning "unchanged", so a saved
+ * page, a screenshot or a browser's autofill history cannot carry them. An empty
+ * credential field therefore can never mean "clear this"; removing the instance
+ * is how you clear it, which is unambiguous.
+ *
+ * **Each card is its own form.** The page used to render all eight services
+ * inside one form and rebuild every service from `svc.<id>.<field>` prefixes on
+ * every save. With instances that prefix would have to carry `radarr/4k`. A form
+ * per card means bare field names, and a save that touches exactly the instance
+ * it came from rather than rewriting seven others that happened to be on screen.
  */
 
 export const SERVICE_IDS = ServiceIdSchema.options;
 
-/** Which extra fields each service actually has, so the form matches the
- *  schema rather than showing eight identical boxes. */
+/** Alphabetical, unlike `ServiceIdSchema.options` — which is declaration order
+ *  and reads as arbitrary to anyone looking for their service in the list. */
+export const SERVICE_IDS_ALPHABETICAL: readonly ServiceId[] = [...SERVICE_IDS].sort();
+
+/** Which extra fields each service actually has, so a card matches the schema
+ *  rather than showing eight identical boxes. */
 const MULTI_USER: ReadonlySet<string> = new Set(['jellyfin', 'seerr']);
 const NO_API_KEY: ReadonlySet<string> = new Set(['transmission']);
 
@@ -57,142 +69,222 @@ const checkbox = (id: string, name: string, label: string, checked: boolean): Sa
         <input type="checkbox" id="${id}" name="${name}" ${checked ? raw('checked') : raw('')}> ${label}
     </label>`;
 
-function serviceFieldset(id: ServiceId, service: AnyService | undefined): SafeHtml {
-    const on = service !== undefined;
-    const p = `svc.${id}`;
+/** The credential and identity fields a given service actually has. */
+function serviceFields(instance: ServiceInstance, prefix: string): SafeHtml {
+    const type = instance.type;
+    const service = instance.config as AnyService;
 
-    return html`<fieldset>
-        <legend>${id}</legend>
-        ${checkbox(`${p}.enabled`, `${p}.enabled`, `Configure ${id}`, on)}
-        ${field({
-            id: `${p}.url`,
-            name: `${p}.url`,
-            label: 'URL',
-            value: service?.url ?? '',
-            placeholder: 'http://192.168.1.20:7878'
-        })}
-        ${NO_API_KEY.has(id)
-            ? html`${field({
-                  id: `${p}.username`,
-                  name: `${p}.username`,
-                  label: 'Username (optional)',
-                  value: service?.username ?? ''
-              })}
-              ${field({
-                  id: `${p}.password`,
-                  name: `${p}.password`,
-                  label: 'Password',
-                  type: 'password',
-                  placeholder: on ? 'unchanged' : '',
-                  note: 'Leave blank to keep the current password.'
-              })}`
-            : field({
-                  id: `${p}.api_key`,
-                  name: `${p}.api_key`,
-                  label: 'API key',
-                  type: 'password',
-                  placeholder: on ? 'unchanged' : '',
-                  note: on ? 'Leave blank to keep the current key.' : "From the service's Settings → General page."
-              })}
-        ${MULTI_USER.has(id)
-            ? html`${field({
-                  id: `${p}.default_user`,
-                  name: `${p}.default_user`,
-                  label: 'Default user',
-                  value: service?.default_user ?? '',
-                  note:
-                      id === 'jellyfin'
-                          ? 'Required if Jellyfin is configured — get_library, get_media_details and diagnose all need it.'
-                          : 'Optional.'
-              })}
-              ${checkbox(
-                  `${p}.allow_other_users`,
-                  `${p}.allow_other_users`,
-                  'Allow answering as other users',
-                  service?.allow_other_users ?? false
-              )}`
-            : raw('')}
-        ${field({
-            id: `${p}.timeout_ms`,
-            name: `${p}.timeout_ms`,
-            label: 'Timeout (ms)',
-            type: 'number',
-            value: service?.timeout_ms ?? 10_000
-        })}
-        <p class="note" style="margin-top:.75rem">Writes — both off by default.</p>
-        ${checkbox(
-            `${p}.safe_write`,
-            `${p}.safe_write`,
-            'safe_write — searches, monitoring, request verdicts',
-            service?.permissions.safe_write ?? false
-        )}
+    return html`${NO_API_KEY.has(type)
+        ? html`${field({ id: `${prefix}.username`, name: 'username', label: 'Username (optional)', value: service.username ?? '' })}
+          ${field({
+              id: `${prefix}.password`,
+              name: 'password',
+              label: 'Password',
+              type: 'password',
+              placeholder: 'unchanged',
+              note: 'Leave blank to keep the current password.'
+          })}`
+        : field({
+              id: `${prefix}.api_key`,
+              name: 'api_key',
+              label: 'API key',
+              type: 'password',
+              placeholder: 'unchanged',
+              note: 'Leave blank to keep the current key.'
+          })}
+    ${MULTI_USER.has(type)
+        ? html`${field({
+              id: `${prefix}.default_user`,
+              name: 'default_user',
+              label: 'Default user',
+              value: service.default_user ?? '',
+              note:
+                  type === 'jellyfin'
+                      ? 'Required if Jellyfin is configured — get_library, get_media_details and diagnose all need it.'
+                      : 'Optional.'
+          })}
+          ${checkbox(
+              `${prefix}.allow_other_users`,
+              'allow_other_users',
+              'Allow answering as other users',
+              service.allow_other_users ?? false
+          )}`
+        : raw('')}`;
+}
+
+function instanceCard(instance: ServiceInstance, csrf: string, confirming: string | undefined): SafeHtml {
+    const service = instance.config as AnyService;
+    const p = `svc.${instance.id}`;
+    const pendingRemoval = confirming === instance.id;
+
+    return html`<form method="post" action="/ui/config/save" class="panel">
+        <input type="hidden" name="csrf" value="${csrf}">
+        <input type="hidden" name="instance" value="${instance.id}">
+
+        <h3 style="margin:0 0 .75rem">
+            <span class="mono">${instance.id}</span>
+        </h3>
+
+        ${field({ id: `${p}.url`, name: 'url', label: 'URL', value: service.url })}
+        ${serviceFields(instance, p)}
+        ${field({ id: `${p}.timeout_ms`, name: 'timeout_ms', label: 'Timeout (ms)', type: 'number', value: service.timeout_ms })}
+
+        <p class="note" style="margin-top:.75rem">Writes — both off by default, and granted per instance.</p>
+        ${checkbox(`${p}.safe_write`, 'safe_write', 'safe_write — searches, monitoring, request verdicts', service.permissions.safe_write)}
         ${checkbox(
             `${p}.destructive`,
-            `${p}.destructive`,
+            'destructive',
             'destructive — deletes files, queue items and requests (implies safe_write)',
-            service?.permissions.destructive ?? false
+            service.permissions.destructive
         )}
-    </fieldset>`;
+
+        <div class="row" style="margin-top:1rem">
+            <button type="submit">Save</button>
+            ${pendingRemoval
+                ? html`<button type="submit" formaction="/ui/config/remove" name="confirm" value="yes" class="ghost">
+                          Yes, remove ${instance.id}
+                      </button>`
+                : html`<button type="submit" formaction="/ui/config/remove" class="ghost">Remove</button>`}
+        </div>
+        ${pendingRemoval
+            ? html`<p class="note" style="margin-top:.5rem">
+                  Removing <span class="mono">${instance.id}</span> discards its API key from this config. Re-adding it
+                  means fetching the key from the service again. Save or reload to cancel.
+              </p>`
+            : raw('')}
+    </form>`;
+}
+
+/**
+ * The add form.
+ *
+ * Every field is always shown rather than revealed by the service picker,
+ * because doing that without JavaScript is not possible and this page keeps its
+ * JavaScript to the two behaviours that genuinely need it. The server validates
+ * and answers with the specific thing to do — those messages are written for
+ * exactly this.
+ */
+function addForm(config: Config, csrf: string): SafeHtml {
+    const instances = listInstances(config);
+    const configured = new Set(instances.map(i => i.type));
+
+    const needsName = MULTI_INSTANCE.filter(t => configured.has(t));
+    const unnamedSingle = MULTI_INSTANCE.filter(t =>
+        instances.some(i => i.type === t && i.name === undefined)
+    );
+
+    return html`<form method="post" action="/ui/config/add" class="panel">
+        <input type="hidden" name="csrf" value="${csrf}">
+        <h3 style="margin:0 0 .75rem">Add a service</h3>
+
+        <div class="field">
+            <label for="add.type">Service</label>
+            <select id="add.type" name="type">
+                ${SERVICE_IDS_ALPHABETICAL.map(id => html`<option value="${id}">${id}</option>`)}
+            </select>
+        </div>
+
+        ${field({ id: 'add.url', name: 'url', label: 'URL', placeholder: 'http://192.168.1.20:7878' })}
+        ${field({
+            id: 'add.api_key',
+            name: 'api_key',
+            label: 'API key',
+            type: 'password',
+            note: "From the service's Settings → General page. Leave blank for Transmission, which uses a username and password."
+        })}
+        ${field({ id: 'add.username', name: 'username', label: 'Username (Transmission only, optional)' })}
+        ${field({ id: 'add.password', name: 'password', label: 'Password (Transmission only)', type: 'password' })}
+
+        ${needsName.length === 0
+            ? raw('')
+            : html`<div class="field">
+                      <label for="add.name">Instance name</label>
+                      <input id="add.name" name="name" type="text" placeholder="4k" autocomplete="off">
+                      <p class="note">
+                          Required when a service already has one:
+                          <span class="mono">${needsName.join(', ')}</span>. It becomes part of the id, as
+                          <span class="mono">radarr/4k</span>.
+                      </p>
+                  </div>`}
+
+        ${unnamedSingle.length === 0
+            ? raw('')
+            : html`<div class="field">
+                      <label for="add.rename_existing_to">Name for the existing instance</label>
+                      <input id="add.rename_existing_to" name="rename_existing_to" type="text" placeholder="hd" autocomplete="off">
+                      <p class="note">
+                          Adding a second <span class="mono">${unnamedSingle.join(' or ')}</span> means naming the one
+                          you already have. Its permissions move with it, and any saved prompt naming the bare service
+                          will start asking which instance you meant.
+                      </p>
+                  </div>`}
+
+        <div class="row" style="margin-top:1rem"><button type="submit">Add</button></div>
+    </form>`;
 }
 
 export function configPage(opts: {
     version: string;
     config: Config;
     csrf: string;
+    /** The instance whose Remove button was pressed but not yet confirmed. */
+    confirmingRemoval?: string | undefined;
     message?: { kind: 'ok' | 'err'; text: string } | undefined;
 }): string {
-    const services = opts.config.services as Partial<Record<ServiceId, AnyService>>;
+    const instances = listInstances(opts.config);
 
-    const body = html`<form method="post" action="/ui/config">
-        <input type="hidden" name="csrf" value="${opts.csrf}">
+    const body = html`<h2>Services</h2>
+        ${instances.length === 0
+            ? html`<div class="panel">
+                  <p class="note" style="margin:0">
+                      Nothing is configured yet. Add the services you run — anything you leave out is simply absent,
+                      not broken. Saving applies immediately; there is no restart.
+                  </p>
+              </div>`
+            : html`<p class="note">
+                      Saving applies immediately — no restart. Each instance is saved on its own.
+                  </p>
+                  ${instances.map(i => instanceCard(i, opts.csrf, opts.confirmingRemoval))}`}
 
-        <h2>Services</h2>
-        <p class="note">
-            Saving applies immediately — no restart. Configure only what you run; anything left off is simply
-            absent, not broken.
-        </p>
-        <div class="svc-grid">${SERVICE_IDS.map(id => serviceFieldset(id, services[id]))}</div>
+        ${addForm(opts.config, opts.csrf)}
 
         <h2>Access</h2>
-        <fieldset>
-            <legend>Config UI</legend>
-            ${field({
-                id: 'auth.username',
-                name: 'auth.username',
-                label: 'Username',
-                value: opts.config.auth.username
-            })}
-            ${field({
-                id: 'auth.password',
-                name: 'auth.password',
-                label: 'New password',
-                type: 'password',
-                placeholder: 'unchanged',
-                note: 'Leave blank to keep the current password. Only a hash is stored — it cannot be read back.'
-            })}
-        </fieldset>
+        <form method="post" action="/ui/config/access">
+            <input type="hidden" name="csrf" value="${opts.csrf}">
+            <fieldset>
+                <legend>Config UI</legend>
+                ${field({ id: 'auth.username', name: 'auth.username', label: 'Username', value: opts.config.auth.username })}
+                ${field({
+                    id: 'auth.password',
+                    name: 'auth.password',
+                    label: 'New password',
+                    type: 'password',
+                    placeholder: 'unchanged',
+                    note: 'Leave blank to keep the current password. Only a hash is stored — it cannot be read back.'
+                })}
+            </fieldset>
 
-        <fieldset>
-            <legend>MCP endpoint</legend>
-            ${checkbox('auth.rotate_token', 'auth.rotate_token', 'Generate a new bearer token', false)}
-            <p class="note">
-                Rotating invalidates the current token immediately; every MCP client will need the new one,
-                which appears on the dashboard.
-            </p>
-            ${field({
-                id: 'auth.allowed_hosts',
-                name: 'auth.allowed_hosts',
-                label: 'Allowed hosts (comma separated)',
-                value: opts.config.auth.allowed_hosts.join(', '),
-                note: 'Leave empty to accept any Host — right for a LAN container reached by IP. Applies immediately; pin the wrong name and you will lock yourself out until you edit config.yaml by hand.'
-            })}
-        </fieldset>
+            <fieldset>
+                <legend>MCP endpoint</legend>
+                ${checkbox('auth.rotate_token', 'auth.rotate_token', 'Generate a new bearer token', false)}
+                <p class="note">
+                    Rotating invalidates the current token immediately; every MCP client will need the new one,
+                    which appears on the dashboard.
+                </p>
+                ${field({
+                    id: 'auth.allowed_hosts',
+                    name: 'auth.allowed_hosts',
+                    label: 'Allowed hosts (comma separated)',
+                    value: opts.config.auth.allowed_hosts.join(', '),
+                    note: 'Leave empty to accept any Host — right for a LAN container reached by IP. Applies immediately; pin the wrong name and you will lock yourself out until you edit config.yaml by hand.'
+                })}
+            </fieldset>
 
-        <div class="row">
-            <button type="submit">Save and apply</button>
-            <a href="/ui" style="margin-left:.5rem">Cancel</a>
-        </div>
-    </form>`;
+            <div class="row">
+                <button type="submit">Save access settings</button>
+                <a href="/ui" style="margin-left:.5rem">Back to the dashboard</a>
+            </div>
+        </form>`;
 
     return layout({
         title: 'Configuration',

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -17,7 +17,8 @@ import {
 } from '../core/session.ts';
 import { buildStackHealth } from '../tools/stackHealth.ts';
 import { CSS, JS } from './assets.ts';
-import { configPage, SERVICE_IDS } from './configPage.ts';
+import { addInstance, removeInstance, updateInstance, type InstanceFields } from '../config/mutate.ts';
+import { configPage } from './configPage.ts';
 import { mcpEndpoint } from './origin.ts';
 import {
     auditPage,
@@ -230,67 +231,109 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
         return c.html(configPage({ version, config: runtime.config, csrf: runtime.sessions.csrfFor(session) }));
     });
 
-    app.post('/ui/config', async c => {
-        const session = guard(c);
-        if (session === undefined) return c.redirect(entry(), 302);
+    /**
+     * The four config mutations share everything except the one line that
+     * decides what the next config is, so they share a handler.
+     *
+     * `render` carries the `confirmingRemoval` id through, which is what makes
+     * the two-step remove work without JavaScript: the first post returns the
+     * page with that card asking, and the second carries `confirm`.
+     */
+    const configMutation =
+        (
+            what: string,
+            next: (form: Record<string, unknown>) => Config | { ask: string }
+        ): ((c: Context) => Promise<Response>) =>
+        async (c: Context) => {
+            const session = guard(c);
+            if (session === undefined) return c.redirect(entry(), 302);
 
-        const form = await c.req.parseBody();
-        if (!runtime.sessions.csrfValid(session, str(form.csrf))) {
-            logger.warn({ ip: ipOf(c) }, 'rejected config save with a bad CSRF token');
-            return c.html(
-                configPage({
-                    version,
-                    config: runtime.config,
-                    csrf: runtime.sessions.csrfFor(session),
-                    message: { kind: 'err', text: 'That form was stale. Reload the page and try again.' }
-                }),
-                403
-            );
-        }
+            const render = (
+                message: { kind: 'ok' | 'err'; text: string } | undefined,
+                status: 200 | 400 | 403,
+                confirming?: string
+            ) =>
+                c.html(
+                    configPage({
+                        version,
+                        config: runtime.config,
+                        csrf: runtime.sessions.csrfFor(session),
+                        ...(confirming === undefined ? {} : { confirmingRemoval: confirming }),
+                        ...(message === undefined ? {} : { message })
+                    }),
+                    status
+                );
 
-        let next: Config;
-        try {
-            next = buildConfig(runtime.config, form);
-        } catch (err) {
-            return c.html(
-                configPage({
-                    version,
-                    config: runtime.config,
-                    csrf: runtime.sessions.csrfFor(session),
-                    message: { kind: 'err', text: (err as Error).message }
-                }),
-                400
-            );
-        }
+            const form = await c.req.parseBody();
+            if (!runtime.sessions.csrfValid(session, str(form.csrf))) {
+                logger.warn({ ip: ipOf(c) }, 'rejected config save with a bad CSRF token');
+                return render({ kind: 'err', text: 'That form was stale. Reload the page and try again.' }, 403);
+            }
 
-        try {
-            await saveConfig(runtime.configDir, next);
-            await runtime.reload();
-        } catch (err) {
-            // The file is written atomically and validated first, so reaching
-            // here means the config on disk is still the working one.
-            logger.error({ err }, 'config save failed');
-            return c.html(
-                configPage({
-                    version,
-                    config: runtime.config,
-                    csrf: runtime.sessions.csrfFor(session),
-                    message: { kind: 'err', text: (err as Error).message }
-                }),
-                400
-            );
-        }
+            let updated: Config;
+            try {
+                const result = next(form);
+                // Not an error: the removal is waiting for a second click.
+                if ('ask' in result) return render(undefined, 200, result.ask);
+                updated = result;
+            } catch (err) {
+                return render({ kind: 'err', text: (err as Error).message }, 400);
+            }
 
-        logger.info({ ip: ipOf(c) }, 'configuration saved from the config UI');
-        return c.html(
-            configPage({
-                version,
-                config: runtime.config,
-                csrf: runtime.sessions.csrfFor(session),
-                message: { kind: 'ok', text: 'Saved and applied. No restart needed.' }
-            })
-        );
-    });
+            try {
+                await saveConfig(runtime.configDir, updated);
+                await runtime.reload();
+            } catch (err) {
+                // The file is written atomically and validated first, so
+                // reaching here means the config on disk is still the working
+                // one.
+                logger.error({ err }, 'config save failed');
+                return render({ kind: 'err', text: (err as Error).message }, 400);
+            }
+
+            logger.info({ ip: ipOf(c), what }, 'configuration saved from the config UI');
+            return render({ kind: 'ok', text: `${what} Applied immediately; no restart needed.` }, 200);
+        };
+
+    app.post(
+        '/ui/config/add',
+        configMutation('Added.', form => {
+            const type = ServiceIdSchema.parse(str(form.type));
+            const name = str(form.name).trim();
+            const renameExistingTo = str(form.rename_existing_to).trim();
+
+            return addInstance(runtime.config, {
+                type,
+                ...(name === '' ? {} : { name }),
+                ...(renameExistingTo === '' ? {} : { renameExistingTo }),
+                fields: instanceFieldsFrom(form)
+            });
+        })
+    );
+
+    app.post(
+        '/ui/config/save',
+        configMutation('Saved.', form =>
+            updateInstance(runtime.config, str(form.instance), instanceFieldsFrom(form))
+        )
+    );
+
+    app.post(
+        '/ui/config/remove',
+        configMutation('Removed.', form => {
+            const instance = str(form.instance);
+            // Server-side rather than a `confirm()` call: with scripting
+            // unavailable a JS confirmation would delete silently on the first
+            // click, which is the failure a confirmation exists to prevent.
+            if (str(form.confirm) !== 'yes') return { ask: instance };
+            return removeInstance(runtime.config, instance);
+        })
+    );
+
+    app.post(
+        '/ui/config/access',
+        configMutation('Access settings saved.', form => buildAuthConfig(runtime.config, form))
+    );
 }
 
 const CACHE = { 'cache-control': 'public, max-age=3600' };
@@ -338,57 +381,40 @@ function logQuery(
 }
 
 /**
- * Form fields into a `Config`, carrying forward every secret the form did not
- * set.
+ * The instance fields a card's form carries.
  *
- * A blank secret means "unchanged", never "clear" — the page never renders a
+ * Bare names, because each card is its own form — there is no `svc.<id>.`
+ * prefix to parse any more, and with instance ids containing a `/` there is no
+ * sensible prefix to invent.
+ *
+ * A blank credential means "unchanged", never "clear": the page never renders a
  * secret back, so blank is what an untouched field always looks like. Clearing
- * is expressed by switching the service off, which is unambiguous.
+ * is expressed by removing the instance, which is unambiguous and confirmed.
  */
-export function buildConfig(current: Config, form: Record<string, unknown>): Config {
-    const services: Record<string, unknown> = {};
+export function instanceFieldsFrom(form: Record<string, unknown>): InstanceFields {
+    const timeout = Number(str(form.timeout_ms));
 
-    for (const id of SERVICE_IDS) {
-        if (!on(form[`svc.${id}.enabled`])) continue;
+    return {
+        url: str(form.url).trim(),
+        api_key: str(form.api_key).trim(),
+        username: str(form.username).trim(),
+        password: str(form.password),
+        default_user: str(form.default_user).trim(),
+        allow_other_users: on(form.allow_other_users),
+        ...(Number.isFinite(timeout) && timeout > 0 ? { timeout_ms: Math.trunc(timeout) } : {}),
+        safe_write: on(form.safe_write),
+        destructive: on(form.destructive)
+    };
+}
 
-        const existing = (current.services as Record<string, Record<string, unknown> | undefined>)[id];
-        const url = str(form[`svc.${id}.url`]).trim();
-        if (url === '') throw new Error(`${id} is switched on but has no URL.`);
-
-        const timeout = Number(str(form[`svc.${id}.timeout_ms`]));
-        const service: Record<string, unknown> = {
-            url,
-            timeout_ms: Number.isFinite(timeout) && timeout > 0 ? Math.trunc(timeout) : 10_000,
-            permissions: {
-                safe_write: on(form[`svc.${id}.safe_write`]),
-                destructive: on(form[`svc.${id}.destructive`])
-            }
-        };
-
-        if (id === 'transmission') {
-            const username = str(form[`svc.${id}.username`]).trim();
-            if (username !== '') service.username = username;
-            const password = str(form[`svc.${id}.password`]);
-            const carried = password === '' ? existing?.password : password;
-            if (typeof carried === 'string' && carried !== '') service.password = carried;
-        } else {
-            const key = str(form[`svc.${id}.api_key`]).trim();
-            const carried = key === '' ? existing?.api_key : key;
-            if (typeof carried !== 'string' || carried === '') {
-                throw new Error(`${id} is switched on but has no API key.`);
-            }
-            service.api_key = carried;
-        }
-
-        if (id === 'jellyfin' || id === 'seerr') {
-            const user = str(form[`svc.${id}.default_user`]).trim();
-            if (user !== '') service.default_user = user;
-            service.allow_other_users = on(form[`svc.${id}.allow_other_users`]);
-        }
-
-        services[id] = service;
-    }
-
+/**
+ * The `auth` half of the old `buildConfig`, unchanged in behaviour.
+ *
+ * The services half is gone: instances are added, edited and removed one at a
+ * time through `src/config/mutate.ts`, so nothing rebuilds all eight services
+ * from one form any more.
+ */
+export function buildAuthConfig(current: Config, form: Record<string, unknown>): Config {
     const username = str(form['auth.username']).trim();
     const password = str(form['auth.password']);
     const hosts = str(form['auth.allowed_hosts'])
@@ -415,6 +441,6 @@ export function buildConfig(current: Config, form: Record<string, unknown>): Con
             password_hash: carriedHash,
             allowed_hosts: hosts
         },
-        services: services as Config['services']
+        services: current.services
     };
 }

--- a/test/configUi.test.ts
+++ b/test/configUi.test.ts
@@ -210,51 +210,36 @@ describe('MCP endpoint', () => {
 
 });
 
-describe('saving configuration', () => {
+describe('adding an instance', () => {
+    const addForm = (over: Record<string, string> = {}) => ({
+        type: 'radarr',
+        url: 'http://192.0.2.10:7878',
+        api_key: 'k',
+        ...over
+    });
+
     it('refuses a forged CSRF token', async () => {
         await signIn();
-        const res = await call('/ui/config', form({ csrf: 'forged', 'svc.radarr.enabled': 'on' }));
+        const res = await call('/ui/config/add', form({ csrf: 'forged', ...addForm() }));
         expect(res.status).toBe(403);
     });
 
-    it('refuses a service switched on with no URL', async () => {
+    it('refuses an instance with no URL', async () => {
         await signIn();
-        const res = await call(
-            '/ui/config',
-            form({ csrf: await csrfFrom(), 'svc.radarr.enabled': 'on', 'svc.radarr.url': '' })
-        );
+        const res = await call('/ui/config/add', form({ csrf: await csrfFrom(), ...addForm({ url: '' }) }));
         expect(res.status).toBe(400);
-        expect(await res.text()).toContain('no URL');
     });
 
-    it('refuses a service switched on with no API key', async () => {
+    it('refuses an instance with no API key', async () => {
         await signIn();
-        const res = await call(
-            '/ui/config',
-            form({
-                csrf: await csrfFrom(),
-                'svc.radarr.enabled': 'on',
-                'svc.radarr.url': 'http://192.0.2.10:7878',
-                'svc.radarr.api_key': ''
-            })
-        );
+        const res = await call('/ui/config/add', form({ csrf: await csrfFrom(), ...addForm({ api_key: '' }) }));
         expect(res.status).toBe(400);
-        expect(await res.text()).toContain('no API key');
     });
 
-    it('writes the service to disk', async () => {
+    it('writes the instance to disk', async () => {
         await signIn();
-        await call(
-            '/ui/config',
-            form({
-                csrf: await csrfFrom(),
-                'svc.radarr.enabled': 'on',
-                'svc.radarr.url': 'http://192.0.2.10:7878',
-                'svc.radarr.api_key': 'k',
-                'svc.radarr.timeout_ms': '4000',
-                'auth.username': 'admin'
-            })
-        );
+        const r = await call('/ui/config/add', form({ csrf: await csrfFrom(), ...addForm({ timeout_ms: '4000' }) }));
+        if (r.status !== 200) { const t = await r.text(); console.error('MSG', /class="msg[^"]*">([^<]*)</.exec(t)?.[1]); }
 
         const onDisk = await readFile(join(dir, 'config.yaml'), 'utf8');
         expect(onDisk).toContain('192.0.2.10:7878');
@@ -267,33 +252,88 @@ describe('saving configuration', () => {
         await signIn();
         expect(runtime.current.adapters).toHaveLength(0);
 
-        await call(
-            '/ui/config',
-            form({
-                csrf: await csrfFrom(),
-                'svc.radarr.enabled': 'on',
-                'svc.radarr.url': 'http://192.0.2.10:7878',
-                'svc.radarr.api_key': 'k',
-                'auth.username': 'admin'
-            })
-        );
+        await call('/ui/config/add', form({ csrf: await csrfFrom(), ...addForm() }));
 
         expect(runtime.current.adapters.map(a => a.id)).toEqual(['radarr']);
     });
 
+    /**
+     * The rename that adding a second instance forces. That id is the
+     * permission key, the audit column and what the agent passes, so it is
+     * never changed without the user having said what to change it to.
+     */
+    it('refuses a second instance unless the existing one is named too', async () => {
+        await seed('  radarr:\n    url: http://192.0.2.10:7878\n    api_key: k\n');
+        await signIn();
+
+        const res = await call(
+            '/ui/config/add',
+            form({ csrf: await csrfFrom(), ...addForm({ name: '4k', url: 'http://192.0.2.11:7878' }) })
+        );
+
+        expect(res.status).toBe(400);
+        expect(await res.text()).toContain('naming the one you already have');
+        expect(runtime.current.adapters.map(a => a.id)).toEqual(['radarr']);
+    });
+
+    it('renames the existing instance when told what to call it', async () => {
+        await seed('  radarr:\n    url: http://192.0.2.10:7878\n    api_key: k\n');
+        await signIn();
+
+        await call(
+            '/ui/config/add',
+            form({
+                csrf: await csrfFrom(),
+                ...addForm({ name: '4k', rename_existing_to: 'hd', url: 'http://192.0.2.11:7878' })
+            })
+        );
+
+        expect(runtime.current.adapters.map(a => a.id)).toEqual(['radarr/4k', 'radarr/hd']);
+    });
+
+    it('refuses a second instance of a service that may only have one', async () => {
+        await seed('  prowlarr:\n    url: http://192.0.2.10:9696\n    api_key: k\n');
+        await signIn();
+
+        const res = await call(
+            '/ui/config/add',
+            form({ csrf: await csrfFrom(), ...addForm({ type: 'prowlarr', name: 'second' }) })
+        );
+        expect(res.status).toBe(400);
+    });
+});
+
+describe('the configuration page', () => {
+    it('shows an empty state rather than eight blank fieldsets', async () => {
+        await signIn();
+        const page = await (await call('/ui/config')).text();
+
+        expect(page).toContain('Nothing is configured yet');
+        expect(page).not.toContain('name="instance"');
+    });
+
+    it('lists configured instances alphabetically by id', async () => {
+        await seed(
+            '  sonarr:\n    url: http://192.0.2.10:8989\n    api_key: k\n' +
+                '  radarr:\n  - name: hd\n    url: http://192.0.2.10:7878\n    api_key: k\n' +
+                '  - name: 4k\n    url: http://192.0.2.11:7878\n    api_key: k\n'
+        );
+        await signIn();
+        const page = await (await call('/ui/config')).text();
+
+        const order = [...page.matchAll(/name="instance" value="([^"]+)"/g)].map(m => m[1]);
+        expect(order).toEqual(['radarr/4k', 'radarr/hd', 'sonarr']);
+    });
+});
+
+describe('saving an instance', () => {
     it('keeps an existing key when the field is left blank', async () => {
         await seed('  radarr:\n    url: http://192.0.2.10:7878\n    api_key: keep-me\n');
         await signIn();
 
         await call(
-            '/ui/config',
-            form({
-                csrf: await csrfFrom(),
-                'svc.radarr.enabled': 'on',
-                'svc.radarr.url': 'http://192.0.2.10:9999',
-                'svc.radarr.api_key': '',
-                'auth.username': 'admin'
-            })
+            '/ui/config/save',
+            form({ csrf: await csrfFrom(), instance: 'radarr', url: 'http://192.0.2.10:9999', api_key: '' })
         );
 
         const onDisk = await readFile(join(dir, 'config.yaml'), 'utf8');
@@ -301,22 +341,90 @@ describe('saving configuration', () => {
         expect(onDisk).toContain('192.0.2.10:9999');
     });
 
-    it('removes a service that was switched off', async () => {
+    it('leaves every other instance untouched', async () => {
+        await seed(
+            '  radarr:\n  - name: hd\n    url: http://192.0.2.10:7878\n    api_key: hd-key\n' +
+                '  - name: 4k\n    url: http://192.0.2.11:7878\n    api_key: fourk-key\n'
+        );
+        await signIn();
+
+        await call(
+            '/ui/config/save',
+            form({ csrf: await csrfFrom(), instance: 'radarr/4k', url: 'http://192.0.2.99:7878' })
+        );
+
+        const onDisk = await readFile(join(dir, 'config.yaml'), 'utf8');
+        expect(onDisk).toContain('hd-key');
+        expect(onDisk).toContain('fourk-key');
+        expect(onDisk).toContain('192.0.2.10:7878');
+        expect(onDisk).toContain('192.0.2.99:7878');
+    });
+});
+
+describe('removing an instance', () => {
+    const seedTwo = () =>
+        seed(
+            '  radarr:\n  - name: hd\n    url: http://192.0.2.10:7878\n    api_key: k\n' +
+                '  - name: 4k\n    url: http://192.0.2.11:7878\n    api_key: k\n'
+        );
+
+    /**
+     * Server-side rather than a `confirm()` call. With scripting unavailable a
+     * JS confirmation would delete on the first click, which is precisely the
+     * failure a confirmation exists to prevent.
+     */
+    it('removes nothing on the first click, and asks', async () => {
+        await seedTwo();
+        await signIn();
+
+        const res = await call('/ui/config/remove', form({ csrf: await csrfFrom(), instance: 'radarr/4k' }));
+
+        expect(res.status).toBe(200);
+        expect(await res.text()).toContain('Yes, remove radarr/4k');
+        expect(runtime.current.adapters.map(a => a.id)).toEqual(['radarr/4k', 'radarr/hd']);
+    });
+
+    it('removes exactly one once confirmed', async () => {
+        await seedTwo();
+        await signIn();
+
+        await call('/ui/config/remove', form({ csrf: await csrfFrom(), instance: 'radarr/4k', confirm: 'yes' }));
+
+        expect(runtime.current.adapters.map(a => a.id)).toEqual(['radarr/hd']);
+    });
+
+    // Collapsing `radarr/hd` back to `radarr` would be a second silent rename,
+    // undoing the one the user was explicitly asked to approve.
+    it('leaves the last instance named rather than collapsing it', async () => {
+        await seedTwo();
+        await signIn();
+
+        await call('/ui/config/remove', form({ csrf: await csrfFrom(), instance: 'radarr/4k', confirm: 'yes' }));
+
+        expect(await readFile(join(dir, 'config.yaml'), 'utf8')).toContain('name: hd');
+    });
+
+    it('removes the service entirely when its last instance goes', async () => {
         await seed('  radarr:\n    url: http://192.0.2.10:7878\n    api_key: k\n');
         await signIn();
 
-        await call('/ui/config', form({ csrf: await csrfFrom(), 'auth.username': 'admin' }));
+        await call('/ui/config/remove', form({ csrf: await csrfFrom(), instance: 'radarr', confirm: 'yes' }));
 
         expect(runtime.current.adapters).toHaveLength(0);
         expect(await readFile(join(dir, 'config.yaml'), 'utf8')).not.toContain('192.0.2.10');
     });
+});
 
+describe('access settings', () => {
     it('rotates the bearer token only when asked', async () => {
         await signIn();
-        await call('/ui/config', form({ csrf: await csrfFrom(), 'auth.username': 'admin' }));
+        await call('/ui/config/access', form({ csrf: await csrfFrom(), 'auth.username': 'admin' }));
         expect(runtime.config.auth.bearer_token).toBe(BEARER);
 
-        await call('/ui/config', form({ csrf: await csrfFrom(), 'auth.username': 'admin', 'auth.rotate_token': 'on' }));
+        await call(
+            '/ui/config/access',
+            form({ csrf: await csrfFrom(), 'auth.username': 'admin', 'auth.rotate_token': 'on' })
+        );
         expect(runtime.config.auth.bearer_token).not.toBe(BEARER);
         expect(runtime.config.auth.bearer_token).toMatch(/^[0-9a-f]{64}$/);
     });
@@ -325,7 +433,10 @@ describe('saving configuration', () => {
     // or the old token keeps working until a restart.
     it('makes a rotated token effective immediately on /mcp', async () => {
         await signIn();
-        await call('/ui/config', form({ csrf: await csrfFrom(), 'auth.username': 'admin', 'auth.rotate_token': 'on' }));
+        await call(
+            '/ui/config/access',
+            form({ csrf: await csrfFrom(), 'auth.username': 'admin', 'auth.rotate_token': 'on' })
+        );
 
         const res = await app.request('http://localhost:6060/mcp', {
             method: 'POST',
@@ -339,10 +450,19 @@ describe('saving configuration', () => {
         expect(res.status).toBe(401);
     });
 
+    it('does not disturb configured services', async () => {
+        await seed('  radarr:\n    url: http://192.0.2.10:7878\n    api_key: k\n');
+        await signIn();
+
+        await call('/ui/config/access', form({ csrf: await csrfFrom(), 'auth.username': 'admin' }));
+
+        expect(runtime.current.adapters.map(a => a.id)).toEqual(['radarr']);
+    });
+
     it('changes the password, and the old one stops working', async () => {
         await signIn();
         await call(
-            '/ui/config',
+            '/ui/config/access',
             form({ csrf: await csrfFrom(), 'auth.username': 'admin', 'auth.password': 'a-new-password' })
         );
 
@@ -353,7 +473,7 @@ describe('saving configuration', () => {
 
     it('leaves the password alone when the field is blank', async () => {
         await signIn();
-        await call('/ui/config', form({ csrf: await csrfFrom(), 'auth.username': 'admin', 'auth.password': '' }));
+        await call('/ui/config/access', form({ csrf: await csrfFrom(), 'auth.username': 'admin', 'auth.password': '' }));
 
         cookie = '';
         expect((await call('/ui/login', form({ username: 'admin', password: PASSWORD }))).status).toBe(302);
@@ -373,7 +493,7 @@ describe('allowed_hosts', () => {
     it('applies a pinned host immediately, with no restart', async () => {
         await signIn();
         await call(
-            '/ui/config',
+            '/ui/config/access',
             form({ csrf: await csrfFrom(), 'auth.username': 'admin', 'auth.allowed_hosts': 'arr.example.com' })
         );
 
@@ -386,7 +506,7 @@ describe('allowed_hosts', () => {
     it('matches a pinned bare hostname when the request carries a port', async () => {
         await signIn();
         await call(
-            '/ui/config',
+            '/ui/config/access',
             form({ csrf: await csrfFrom(), 'auth.username': 'admin', 'auth.allowed_hosts': 'arr.example.com' })
         );
 
@@ -405,7 +525,7 @@ describe('allowed_hosts', () => {
     it('locks out an unlisted host, and can be undone from a listed one', async () => {
         await signIn();
         await call(
-            '/ui/config',
+            '/ui/config/access',
             form({ csrf: await csrfFrom(), 'auth.username': 'admin', 'auth.allowed_hosts': 'arr.example.com' })
         );
         expect((await get('other.example.com')).status).toBe(403);
@@ -415,7 +535,7 @@ describe('allowed_hosts', () => {
 
         const page = await (await call('/ui/config', { headers: { host: 'arr.example.com' } })).text();
         const csrf = /name="csrf" value="([^"]+)"/.exec(page)?.[1] ?? '';
-        await call('/ui/config', {
+        await call('/ui/config/access', {
             ...form({ csrf, 'auth.username': 'admin', 'auth.allowed_hosts': '' }),
             headers: {
                 'content-type': 'application/x-www-form-urlencoded',

--- a/test/mutate.test.ts
+++ b/test/mutate.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest';
+import { listInstances } from '../src/config/instances.ts';
+import { ConfigEditError, addInstance, removeInstance, updateInstance } from '../src/config/mutate.ts';
+import { ConfigSchema, type Config } from '../src/config/schema.ts';
+
+/**
+ * The config algebra behind the Configuration page, tested without a browser.
+ *
+ * These are the operations that must not go wrong quietly: a bad edit that
+ * reached disk would take the running instance down on the next reload, and a
+ * silent rename would move a permission key out from under a live grant.
+ */
+
+const AUTH = { bearer_token: 'a'.repeat(64), username: 'admin', allowed_hosts: [] };
+const base = (services: unknown = {}): Config => ConfigSchema.parse({ auth: AUTH, services });
+
+const ids = (config: Config) => listInstances(config).map(i => i.id);
+const KEYED = { url: 'http://192.0.2.10:7878', api_key: 'k' };
+
+describe('adding an instance', () => {
+    it('adds the first one with no name, keeping the bare id', () => {
+        const next = addInstance(base(), { type: 'radarr', fields: KEYED });
+        expect(ids(next)).toEqual(['radarr']);
+    });
+
+    it('refuses a second instance of a service that may only have one', () => {
+        const one = base({ prowlarr: KEYED });
+        expect(() => addInstance(one, { type: 'prowlarr', name: 'b', fields: KEYED })).toThrow(ConfigEditError);
+    });
+
+    /**
+     * The rename that adding a second instance forces. The existing id is the
+     * permission key, the audit column, and what the agent passes — so it is
+     * never changed without the caller having said what to change it to.
+     */
+    it('refuses to rename the existing instance behind the caller’s back', () => {
+        const one = base({ radarr: KEYED });
+        expect(() =>
+            addInstance(one, { type: 'radarr', name: '4k', fields: KEYED })
+        ).toThrow(/naming the one you already have/);
+    });
+
+    it('renames the existing instance when told what to call it', () => {
+        const one = base({ radarr: { ...KEYED, permissions: { safe_write: true, destructive: false } } });
+        const two = addInstance(one, {
+            type: 'radarr',
+            name: '4k',
+            renameExistingTo: 'hd',
+            fields: { url: 'http://192.0.2.11:7878', api_key: 'k2' }
+        });
+
+        expect(ids(two)).toEqual(['radarr/4k', 'radarr/hd']);
+    });
+
+    it('carries the existing instance’s permissions through the rename', () => {
+        const one = base({ radarr: { ...KEYED, permissions: { safe_write: true, destructive: false } } });
+        const two = addInstance(one, {
+            type: 'radarr',
+            name: '4k',
+            renameExistingTo: 'hd',
+            fields: { url: 'http://192.0.2.11:7878', api_key: 'k2' }
+        });
+
+        const hd = listInstances(two).find(i => i.id === 'radarr/hd');
+        expect(hd?.config.permissions.safe_write).toBe(true);
+        // The new one starts with nothing granted, like any service added by hand.
+        const fourK = listInstances(two).find(i => i.id === 'radarr/4k');
+        expect(fourK?.config.permissions).toEqual({ safe_write: false, destructive: false });
+    });
+
+    it('refuses a duplicate name', () => {
+        const two = addInstance(base({ radarr: KEYED }), {
+            type: 'radarr',
+            name: '4k',
+            renameExistingTo: 'hd',
+            fields: KEYED
+        });
+        expect(() => addInstance(two, { type: 'radarr', name: '4K', fields: KEYED })).toThrow(/already has an instance/);
+    });
+
+    it('refuses an edit that would produce an invalid config, before it reaches disk', () => {
+        expect(() => addInstance(base(), { type: 'radarr', fields: { url: 'not-a-url', api_key: 'k' } })).toThrow(
+            ConfigEditError
+        );
+        expect(() => addInstance(base(), { type: 'radarr', fields: { url: KEYED.url } })).toThrow(ConfigEditError);
+    });
+});
+
+describe('updating an instance', () => {
+    const two = () =>
+        addInstance(base({ radarr: KEYED }), {
+            type: 'radarr',
+            name: '4k',
+            renameExistingTo: 'hd',
+            fields: { url: 'http://192.0.2.11:7878', api_key: 'k2' }
+        });
+
+    it('leaves every other instance byte-identical', () => {
+        const before = two();
+        const after = updateInstance(before, 'radarr/4k', { url: 'http://192.0.2.99:7878' });
+
+        const hdBefore = listInstances(before).find(i => i.id === 'radarr/hd');
+        const hdAfter = listInstances(after).find(i => i.id === 'radarr/hd');
+        expect(hdAfter?.config).toEqual(hdBefore?.config);
+    });
+
+    it('keeps the stored API key when the field is blank', () => {
+        const after = updateInstance(two(), 'radarr/hd', { url: KEYED.url, api_key: '' });
+        const hd = listInstances(after).find(i => i.id === 'radarr/hd');
+        expect((hd?.config as { api_key: string }).api_key).toBe('k');
+    });
+
+    it('replaces the API key when a new one is given', () => {
+        const after = updateInstance(two(), 'radarr/hd', { api_key: 'rotated' });
+        const hd = listInstances(after).find(i => i.id === 'radarr/hd');
+        expect((hd?.config as { api_key: string }).api_key).toBe('rotated');
+    });
+
+    it('refuses an unknown instance rather than silently doing nothing', () => {
+        expect(() => updateInstance(two(), 'radarr/uhd', { url: KEYED.url })).toThrow(/not configured/);
+    });
+});
+
+describe('removing an instance', () => {
+    const two = () =>
+        addInstance(base({ radarr: KEYED }), {
+            type: 'radarr',
+            name: '4k',
+            renameExistingTo: 'hd',
+            fields: { url: 'http://192.0.2.11:7878', api_key: 'k2' }
+        });
+
+    it('drops exactly one', () => {
+        expect(ids(removeInstance(two(), 'radarr/4k'))).toEqual(['radarr/hd']);
+    });
+
+    /**
+     * Collapsing `radarr/hd` back to `radarr` would be a second silent rename,
+     * undoing the one the user was explicitly asked to approve.
+     */
+    it('leaves the last instance named rather than collapsing it', () => {
+        const one = removeInstance(two(), 'radarr/4k');
+        expect(ids(one)).toEqual(['radarr/hd']);
+        expect(listInstances(one)[0]?.name).toBe('hd');
+    });
+
+    it('removes the service entirely when its last instance goes', () => {
+        const none = removeInstance(removeInstance(two(), 'radarr/4k'), 'radarr/hd');
+        expect(ids(none)).toEqual([]);
+        expect(none.services.radarr).toBeUndefined();
+    });
+
+    it('removes an unnamed single instance', () => {
+        expect(ids(removeInstance(base({ radarr: KEYED }), 'radarr'))).toEqual([]);
+    });
+});


### PR DESCRIPTION
**PR 3 of 3**, and the one that makes multi-instance reachable without hand-editing YAML.

> [!IMPORTANT]
> This carries `Release-As: 0.7.0`. Merging it turns the standing release PR (#65) into **0.7.0**, shipping all three PRs as one phase.

## What was wrong

All eight services rendered always, each a fieldset with an `enabled` checkbox, inside one form that rebuilt every service from `svc.<id>.<field>` prefixes on every save. Three services meant reading five fieldsets of empty inputs to find them — in `ServiceIdSchema.options` order (radarr, sonarr, prowlarr, bazarr), which is neither alphabetical nor meaningful. And with one fieldset per service *type*, there was nowhere to put a second Radarr.

## What it is now

A card per configured instance, alphabetical by id, an empty state when there are none, and one **Add** form.

**Each card is its own form**, with a hidden instance id and bare field names. That *deletes* the prefix parsing rather than extending it to carry a `/`, and a save touches exactly the instance it came from instead of rewriting seven others that happened to be on screen.

`src/config/mutate.ts` holds the three operations as config algebra — `addInstance`, `updateInstance`, `removeInstance` — each ending by parsing through `ConfigSchema`, so a bad edit fails in the handler with a message rather than reaching disk.

## The rename, asked for rather than invented

Adding a second Radarr forces the existing one to be named. The form asks for both, and says why: that id is the permission key, the audit column, and what your agent passes.

Rejected: auto-naming it `main` does the same damage while hiding it; allowing one unnamed entry beside named ones leaves the unnamed one permanently unaddressable for writes, since omitting `instance` with two configured is a refusal.

## Removing is two steps, server-side

A browser `confirm()` is one line of JS, and is rejected for the reason this codebase keeps JS to two behaviours: with scripting unavailable the button would delete silently on the first click — precisely what a confirmation exists to prevent.

Removing the second-to-last instance leaves the last one **named** rather than collapsing it to a bare id. Collapsing would be a second silent rename, undoing the one the user was explicitly asked to approve.

## One bug found by building it

`applyFields` wrote `allow_other_users` unconditionally, because an unchecked checkbox is simply absent from a form and cannot be told apart from "this service has no such field". The service schemas are strict, so one stray key made **every add invalid**. Gated by service type now — the only thing that actually knows.

## Verified against a running server

Not only fixtures:

- empty state on a fresh install
- adding the first instance, unnamed
- the refusal when a second is added without naming the existing one
- the rename being applied
- alphabetical ordering across three instances
- a first Remove click that removes nothing and asks
- a confirmed removal dropping exactly one
- **no API key rendered back into the page**

1005 → 1030 tests. Lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
