### PR TITLE
feat: add from a dialog, test before saving, and stop the autofill

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,15 @@ Jellyfin. arr-mcp correlates them and gives you the causal chain.
   broken and what to do about it, and read the logs and the write audit — no
   hand-edited YAML, no restart.
 
-> ### Status: 0.6 — a config page that diagnoses
+> ### Status: 0.7 — one library across many instances
 >
-> Add your services from a browser and see what is broken and why: connection
-> tests report the same `kind`, `detail` and `remedy` the tools do, rather than
-> a red cross you then have to investigate. Saving applies immediately, with no
-> restart. Log streams and the write audit are on the same page. The writes
-> from 0.5 and the correlation from 0.4 are unchanged underneath.
+> Run an HD and a 4K Radarr and read them as one library, or name the instance
+> you mean and write to exactly that one. The configuration page is built around
+> instances to match: a card each, added from a dialog that asks only what the
+> service needs, and tested before you save rather than after. Connection tests
+> still report the same `kind`, `detail` and `remedy` the tools do, rather than a
+> red cross you then have to investigate. The writes from 0.5 and the
+> correlation from 0.4 are unchanged underneath.
 > See [the roadmap](#roadmap).
 
 ## Services
@@ -220,7 +222,7 @@ services:
 ```
 
 Tags are `X.Y.Z`, `X.Y`, `X` and `latest` for releases, plus `main` for
-bleeding edge. Pin a minor — `:0.6` — if you would rather approve each new tool
+bleeding edge. Pin a minor — `:0.7` — if you would rather approve each new tool
 surface yourself.
 
 ### First run
@@ -241,8 +243,8 @@ setup form rather than a sign-in: choose a username and a password of at least
 > home LAN that is a walk from the terminal to the browser; behind a port
 > forward it is a race with the internet.
 
-**3. Add your services** on the Configuration page: switch one on, paste its URL
-and API key, save. Saving applies immediately; there is no restart. Nothing is
+**3. Add your services** on the Configuration page: **Add a service**, pick it,
+paste its URL and API key, save. Saving applies immediately; there is no restart. Nothing is
 configured until you do this, and a fresh install with no services answers
 nothing — that is expected, not a fault.
 
@@ -357,7 +359,7 @@ tier.
 | Page | What it is for |
 | --- | --- |
 | Dashboard | Every service tested live, plus disk space, failed health checks, library scan staleness, and the bearer token for your MCP client |
-| Configuration | Add, edit and remove service instances one at a time; change credentials |
+| Configuration | Add, edit, test and remove service instances one at a time; change credentials |
 | Logs | Three streams — all activity, problems only, or one service |
 | Write audit | Every write attempt — applied, previewed, refused or failed |
 
@@ -374,6 +376,12 @@ password all render as empty fields meaning *unchanged*, so a saved page or a
 screenshot cannot carry them. The bearer token is the deliberate exception —
 handing it to your MCP client is the point — and it is masked until you ask.
 
+**Your password manager leaves the Configuration page alone.** None of its
+fields is a `password` input, because that is the one thing that makes a browser
+read a card as a login form and refill the URL and API key on every load. They
+are masked in CSS instead, and carry each manager's own opt-out attribute. The
+sign-in page is untouched — that one *should* be filled.
+
 **The dashboard gives you the whole MCP connection.** It shows the endpoint as
 an absolute URL, built from the address you reached the page on — so it is
 already correct behind a reverse proxy, and there is nothing to assemble by
@@ -383,9 +391,28 @@ at the moment you click, never rendered into the page, so the screenshot
 property above still holds.
 
 **The Configuration page starts empty.** It shows a card per instance you have
-actually configured, in alphabetical order, and one **Add** form — not eight
-blank fieldsets for services you do not run. Each card saves on its own, so
-editing your 4K Radarr cannot disturb the HD one.
+actually configured, in alphabetical order, and an **Add a service** button —
+not eight blank fieldsets for services you do not run. Each card saves on its
+own, so editing your 4K Radarr cannot disturb the HD one.
+
+**Add a service** opens a dialog that only asks what the service needs: pick
+Transmission and it wants a username and password, pick anything else and it
+wants an API key. Services that can only have one instance drop out of the list
+once you have that one, so the picker never offers a choice that ends in
+"already configured". With scripting off the dialog is the plain form it used to
+be, every field showing, and the server still refuses what does not make sense.
+
+**Test** on a card tries the URL and key *as they are on screen*, saved or not,
+and tells you what came back — reachable and how fast, or what is wrong and what
+to do about it. Nothing is written to disk, so it is safe to try a URL you are
+unsure of. A blank key still means unchanged, so testing a card you have not
+touched tests what is already configured.
+
+**Jellyfin and Seerr suggest their own users.** The default-user field is backed
+by the real list, fetched from the service when the page loads, so the name you
+save is one the service actually knows rather than one you typed from memory. If
+the service does not answer, the field stays a plain text box and says so — you
+can always configure a service that is currently down.
 
 Adding a second Radarr, Sonarr or Bazarr asks you to name the one you already
 have, and says why: the name becomes part of the id, and that id is the

--- a/src/web/assets.ts
+++ b/src/web/assets.ts
@@ -98,6 +98,19 @@ button:hover { filter: brightness(1.1); }
 fieldset { border: 1px solid var(--line); border-radius: 10px; padding: .9rem 1rem; margin: 0 0 1rem; }
 legend { padding: 0 .4rem; color: var(--dim); font-size: .85rem; }
 .svc-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: .75rem; }
+/* What type=password used to do, minus the part that made every password
+   manager fill the card as a login form. Chrome, Edge and Safari have had the
+   prefixed property for years; Firefox since 116. Where it is unsupported the
+   field is a plain text input, which is the honest failure — the server never
+   renders a secret into it, so nothing is ever on screen that was not just
+   typed. */
+.secret { -webkit-text-security: disc; }
+dialog {
+  background: var(--panel); color: var(--text); border: 1px solid var(--line);
+  border-radius: 10px; padding: 0; max-width: 560px; width: calc(100% - 2rem);
+}
+dialog::backdrop { background: rgba(0, 0, 0, .6); }
+dialog .panel { margin: 0; border: 0; border-radius: 10px; max-height: 82vh; overflow: auto; }
 .token { display: flex; gap: .5rem; align-items: center; margin-bottom: .5rem; }
 .token input { flex: 1; font-family: var(--mono); font-size: .8rem; }
 #mcp-config { width: 100%; margin-top: .6rem; font-size: .78rem; white-space: pre; }
@@ -188,6 +201,39 @@ document.addEventListener('click', (e) => {
   input.type = hidden ? 'text' : 'password';
   btn.textContent = hidden ? 'Hide' : 'Show';
 });
+
+// The add form: a dialog opened by a button, with fields that follow the
+// service picker. Both are enhancements — with scripting off the <noscript>
+// rule in pages.ts styles the dialog back into the page and every field shows,
+// which is the form exactly as it was before either of these existed.
+const addService = document.getElementById('add-service');
+if (addService) {
+  document.addEventListener('click', (e) => {
+    const btn = e.target.closest('[data-open]');
+    if (!btn) return;
+    const dialog = document.getElementById(btn.dataset.open);
+    if (dialog && !dialog.open) dialog.showModal();
+  });
+
+  // A refused add re-renders the page with the dialog open, which to a browser
+  // with no script means "inline". Reopen it as the modal it was when posted,
+  // so the error at the top and the form it is about are on screen together.
+  if (addService.open) {
+    addService.close();
+    addService.showModal();
+  }
+
+  const picker = document.getElementById('add.type');
+  if (picker) {
+    const follow = () => {
+      for (const el of addService.querySelectorAll('[data-only]')) {
+        el.hidden = !el.dataset.only.split(' ').includes(picker.value);
+      }
+    };
+    picker.addEventListener('change', follow);
+    follow();
+  }
+}
 
 // The log stream polls JSON and builds rows with textContent — never
 // innerHTML.

--- a/src/web/configPage.ts
+++ b/src/web/configPage.ts
@@ -1,12 +1,13 @@
 import { listInstances, type ServiceInstance } from '../config/instances.ts';
 import { MULTI_INSTANCE, ServiceIdSchema, type Config, type ServiceId } from '../config/schema.ts';
+import type { ConnectionDiagnosis } from '../services/types.ts';
 import { html, raw, type SafeHtml } from './html.ts';
 import { layout } from './pages.ts';
 
 /**
  * The configuration page: one card per configured instance, and nothing else.
  *
- * Two rules shape it.
+ * Three rules shape it.
  *
  * **A secret is never rendered back.** API keys, the Transmission password and
  * the UI password all render as empty fields meaning "unchanged", so a saved
@@ -19,6 +20,15 @@ import { layout } from './pages.ts';
  * every save. With instances that prefix would have to carry `radarr/4k`. A form
  * per card means bare field names, and a save that touches exactly the instance
  * it came from rather than rewriting seven others that happened to be on screen.
+ *
+ * **Nothing here is `type="password"`.** That one attribute is what makes a
+ * browser, and every password-manager extension, read a card as a login form:
+ * a text input for the username, a password input below it. They then filled
+ * the URL with a saved username and the key with a saved password on every
+ * single load, so editing a timeout meant re-pasting both. `autocomplete="off"`
+ * does not stop it — it is ignored for exactly these fields, deliberately. So
+ * the secrets are masked in CSS instead (`IGNORE`, and `.secret` in
+ * `assets.ts`), which leaves nothing for the heuristics to find.
  */
 
 export const SERVICE_IDS = ServiceIdSchema.options;
@@ -30,7 +40,8 @@ export const SERVICE_IDS_ALPHABETICAL: readonly ServiceId[] = [...SERVICE_IDS].s
 /** Which extra fields each service actually has, so a card matches the schema
  *  rather than showing eight identical boxes. */
 const MULTI_USER: ReadonlySet<string> = new Set(['jellyfin', 'seerr']);
-const NO_API_KEY: ReadonlySet<string> = new Set(['transmission']);
+const NO_API_KEY_IDS: readonly ServiceId[] = ['transmission'];
+const NO_API_KEY: ReadonlySet<string> = new Set(NO_API_KEY_IDS);
 
 type AnyService = {
     url: string;
@@ -43,6 +54,22 @@ type AnyService = {
     password?: string;
 };
 
+/**
+ * Every way of saying "do not fill this in" that anything actually reads.
+ *
+ * `autocomplete="off"` is first because it is the standard one, and last
+ * because on its own it does nothing here: Chrome and every major extension
+ * ignore it for fields they have decided are credentials. The rest are each
+ * vendor's own opt-out, which they do honour. Dashlane reads `data-form-type`
+ * off the form rather than the input, so that one is on the `<form>` tags.
+ */
+const IGNORE = raw(
+    'autocomplete="off" data-1p-ignore data-lpignore="true" data-bwignore data-protonpass-ignore'
+);
+
+/** Goes on every form on this page, alongside `IGNORE` on every input. */
+const IGNORE_FORM = raw('autocomplete="off" data-form-type="other"');
+
 const field = (opts: {
     id: string;
     name: string;
@@ -51,16 +78,34 @@ const field = (opts: {
     type?: string;
     placeholder?: string;
     note?: string;
-}): SafeHtml => html`<div class="field">
+    /** A credential: masked by `.secret` in CSS rather than by `type="password"`,
+     *  which is the attribute that invites the autofill in the first place. */
+    secret?: boolean;
+    /** The service types this field belongs to. The add dialog's picker hides it
+     *  for every other type; without scripting it simply stays visible. */
+    only?: readonly string[];
+    /** Suggestions from the service itself. A `<datalist>` rather than a
+     *  `<select>` on purpose: the service is often unreachable at exactly the
+     *  moment you are configuring it, and a dropdown with nothing in it would
+     *  make the field unfillable until it came back. */
+    suggestions?: readonly string[];
+}): SafeHtml => html`<div class="field"${
+    opts.only === undefined ? raw('') : html` data-only="${opts.only.join(' ')}"`
+}>
     <label for="${opts.id}">${opts.label}</label>
     <input
         id="${opts.id}"
-        name="${opts.name}"
-        type="${opts.type ?? 'text'}"
+        ${opts.secret === true ? raw('class="secret" ') : raw('')}name="${opts.name}"
+        type="${opts.secret === true ? 'text' : (opts.type ?? 'text')}"
         value="${opts.value ?? ''}"
         placeholder="${opts.placeholder ?? ''}"
-        autocomplete="off"
+        ${opts.suggestions === undefined ? raw('') : html`list="${opts.id}.options" `}${IGNORE}
     >
+    ${opts.suggestions === undefined
+        ? raw('')
+        : html`<datalist id="${opts.id}.options">
+              ${opts.suggestions.map(value => html`<option value="${value}"></option>`)}
+          </datalist>`}
     ${opts.note === undefined ? raw('') : html`<p class="note">${opts.note}</p>`}
 </div>`;
 
@@ -69,8 +114,33 @@ const checkbox = (id: string, name: string, label: string, checked: boolean): Sa
         <input type="checkbox" id="${id}" name="${name}" ${checked ? raw('checked') : raw('')}> ${label}
     </label>`;
 
+/**
+ * What to say about the default user, which depends on whether the service was
+ * able to tell us who its users are.
+ *
+ * `undefined` and `[]` are different answers: the first is "we could not ask",
+ * which is worth saying because the empty suggestion list is otherwise
+ * indistinguishable from a service with no users at all.
+ */
+function defaultUserNote(type: string, users: readonly string[] | undefined): string {
+    const purpose =
+        type === 'jellyfin'
+            ? 'Required if Jellyfin is configured — get_library, get_media_details and diagnose all need it.'
+            : 'Optional.';
+
+    if (users === undefined) {
+        return `${purpose} ${type} did not answer when asked who its users are, so there is nothing to pick from — type the name.`;
+    }
+    if (users.length === 0) return `${purpose} ${type} reports no users yet.`;
+    return `${purpose} Pick one of the ${users.length} users ${type} reported, or type another.`;
+}
+
 /** The credential and identity fields a given service actually has. */
-function serviceFields(instance: ServiceInstance, prefix: string): SafeHtml {
+function serviceFields(
+    instance: ServiceInstance,
+    prefix: string,
+    users: readonly string[] | undefined
+): SafeHtml {
     const type = instance.type;
     const service = instance.config as AnyService;
 
@@ -80,7 +150,7 @@ function serviceFields(instance: ServiceInstance, prefix: string): SafeHtml {
               id: `${prefix}.password`,
               name: 'password',
               label: 'Password',
-              type: 'password',
+              secret: true,
               placeholder: 'unchanged',
               note: 'Leave blank to keep the current password.'
           })}`
@@ -88,7 +158,7 @@ function serviceFields(instance: ServiceInstance, prefix: string): SafeHtml {
               id: `${prefix}.api_key`,
               name: 'api_key',
               label: 'API key',
-              type: 'password',
+              secret: true,
               placeholder: 'unchanged',
               note: 'Leave blank to keep the current key.'
           })}
@@ -98,10 +168,8 @@ function serviceFields(instance: ServiceInstance, prefix: string): SafeHtml {
               name: 'default_user',
               label: 'Default user',
               value: service.default_user ?? '',
-              note:
-                  type === 'jellyfin'
-                      ? 'Required if Jellyfin is configured — get_library, get_media_details and diagnose all need it.'
-                      : 'Optional.'
+              ...(users === undefined ? {} : { suggestions: users }),
+              note: defaultUserNote(type, users)
           })}
           ${checkbox(
               `${prefix}.allow_other_users`,
@@ -112,12 +180,38 @@ function serviceFields(instance: ServiceInstance, prefix: string): SafeHtml {
         : raw('')}`;
 }
 
-function instanceCard(instance: ServiceInstance, csrf: string, confirming: string | undefined): SafeHtml {
+/**
+ * The result of a **Test**, in the card that asked for it.
+ *
+ * `testConnection` already returns kind, detail and remedy, which is why the
+ * dashboard shows a diagnosis rather than a tick — the same reasoning applies
+ * here, and more so: this is the page you are on *because* something is wrong.
+ */
+function testResult(d: ConnectionDiagnosis): SafeHtml {
+    if (d.ok) {
+        return html`<div class="msg ok" style="margin:.75rem 0 0">
+            Reachable in ${d.latency_ms} ms${d.version === undefined ? raw('') : html` — version ${d.version}`}. Not
+            saved yet: this tested the fields as they are on screen.
+        </div>`;
+    }
+
+    return html`<div class="msg err" style="margin:.75rem 0 0">
+        ${d.error?.detail ?? 'Unreachable.'}${d.error?.remedy === undefined ? raw('') : html`\n${d.error.remedy}`}
+    </div>`;
+}
+
+function instanceCard(
+    instance: ServiceInstance,
+    csrf: string,
+    confirming: string | undefined,
+    users: readonly string[] | undefined,
+    tested: ConnectionDiagnosis | undefined
+): SafeHtml {
     const service = instance.config as AnyService;
     const p = `svc.${instance.id}`;
     const pendingRemoval = confirming === instance.id;
 
-    return html`<form method="post" action="/ui/config/save" class="panel">
+    return html`<form method="post" action="/ui/config/save" class="panel" ${IGNORE_FORM}>
         <input type="hidden" name="csrf" value="${csrf}">
         <input type="hidden" name="instance" value="${instance.id}">
 
@@ -126,7 +220,7 @@ function instanceCard(instance: ServiceInstance, csrf: string, confirming: strin
         </h3>
 
         ${field({ id: `${p}.url`, name: 'url', label: 'URL', value: service.url })}
-        ${serviceFields(instance, p)}
+        ${serviceFields(instance, p, users)}
         ${field({ id: `${p}.timeout_ms`, name: 'timeout_ms', label: 'Timeout (ms)', type: 'number', value: service.timeout_ms })}
 
         <p class="note" style="margin-top:.75rem">Writes — both off by default, and granted per instance.</p>
@@ -140,6 +234,12 @@ function instanceCard(instance: ServiceInstance, csrf: string, confirming: strin
 
         <div class="row" style="margin-top:1rem">
             <button type="submit">Save</button>
+            <!-- Tests the fields as they stand, saved or not: the question this
+                 button answers is "is this URL and key right", which is worth
+                 asking *before* writing it to disk. A blank key still means
+                 unchanged, so testing a card you have not touched tests what is
+                 already configured. -->
+            <button type="submit" formaction="/ui/config/test" formnovalidate class="ghost">Test</button>
             ${pendingRemoval
                 ? html`<button type="submit" formaction="/ui/config/remove" name="confirm" value="yes" class="ghost">
                           Yes, remove ${instance.id}
@@ -152,75 +252,118 @@ function instanceCard(instance: ServiceInstance, csrf: string, confirming: strin
                   means fetching the key from the service again. Save or reload to cancel.
               </p>`
             : raw('')}
+        ${tested === undefined ? raw('') : testResult(tested)}
     </form>`;
 }
 
 /**
- * The add form.
+ * The add form, in a dialog behind a button.
  *
- * Every field is always shown rather than revealed by the service picker,
- * because doing that without JavaScript is not possible and this page keeps its
- * JavaScript to the two behaviours that genuinely need it. The server validates
- * and answers with the specific thing to do — those messages are written for
- * exactly this.
+ * It used to sit under the cards with every field showing at once, because
+ * following the service picker needs scripting and this page keeps its
+ * JavaScript to what genuinely needs it. That is still the rule — it is just no
+ * longer a reason to make everyone read four fields that do not apply to them.
+ * Both behaviours here are enhancements: `data-only` says which types a field
+ * belongs to and the picker hides the rest, and the dialog is opened by
+ * `showModal()`. With scripting off, a `<noscript>` rule in `layout` styles the
+ * dialog back into the page and every field shows — exactly the form as it was.
+ *
+ * The server still validates either way, and answers with the specific thing to
+ * do; those messages are written for a reader who saw everything at once.
  */
-function addForm(config: Config, csrf: string): SafeHtml {
+function addDialog(config: Config, csrf: string, open: boolean): SafeHtml {
     const instances = listInstances(config);
     const configured = new Set(instances.map(i => i.type));
 
+    /** A service that cannot have a second instance and already has one is not
+     *  a choice — offering it only to answer "already configured" wastes the
+     *  click. The three multi-instance types are always here, so this list is
+     *  never empty. */
+    const offerable = SERVICE_IDS_ALPHABETICAL.filter(
+        id => MULTI_INSTANCE.includes(id) || !configured.has(id)
+    );
+
+    const keyed = offerable.filter(id => !NO_API_KEY.has(id));
     const needsName = MULTI_INSTANCE.filter(t => configured.has(t));
     const unnamedSingle = MULTI_INSTANCE.filter(t =>
         instances.some(i => i.type === t && i.name === undefined)
     );
 
-    return html`<form method="post" action="/ui/config/add" class="panel">
-        <input type="hidden" name="csrf" value="${csrf}">
-        <h3 style="margin:0 0 .75rem">Add a service</h3>
+    return html`<dialog id="add-service"${open ? raw(' open') : raw('')}>
+        <form method="post" action="/ui/config/add" class="panel" ${IGNORE_FORM}>
+            <input type="hidden" name="csrf" value="${csrf}">
+            <h3 style="margin:0 0 .75rem">Add a service</h3>
 
-        <div class="field">
-            <label for="add.type">Service</label>
-            <select id="add.type" name="type">
-                ${SERVICE_IDS_ALPHABETICAL.map(id => html`<option value="${id}">${id}</option>`)}
-            </select>
-        </div>
+            <div class="field">
+                <label for="add.type">Service</label>
+                <select id="add.type" name="type">
+                    ${offerable.map(id => html`<option value="${id}">${id}</option>`)}
+                </select>
+                ${offerable.length === SERVICE_IDS.length
+                    ? raw('')
+                    : html`<p class="note">
+                          Already configured, and limited to one instance:
+                          <span class="mono">${SERVICE_IDS_ALPHABETICAL.filter(
+                              id => !offerable.includes(id)
+                          ).join(', ')}</span>. Edit those on the card above.
+                      </p>`}
+            </div>
 
-        ${field({ id: 'add.url', name: 'url', label: 'URL', placeholder: 'http://192.168.1.20:7878' })}
-        ${field({
-            id: 'add.api_key',
-            name: 'api_key',
-            label: 'API key',
-            type: 'password',
-            note: "From the service's Settings → General page. Leave blank for Transmission, which uses a username and password."
-        })}
-        ${field({ id: 'add.username', name: 'username', label: 'Username (Transmission only, optional)' })}
-        ${field({ id: 'add.password', name: 'password', label: 'Password (Transmission only)', type: 'password' })}
+            ${field({ id: 'add.url', name: 'url', label: 'URL', placeholder: 'http://192.168.1.20:7878' })}
+            ${field({
+                id: 'add.api_key',
+                name: 'api_key',
+                label: 'API key',
+                secret: true,
+                only: keyed,
+                note: "From the service's Settings → General page."
+            })}
+            ${offerable.length === keyed.length
+                ? raw('')
+                : html`${field({
+                      id: 'add.username',
+                      name: 'username',
+                      label: 'Username (optional)',
+                      only: NO_API_KEY_IDS
+                  })}
+                  ${field({
+                      id: 'add.password',
+                      name: 'password',
+                      label: 'Password',
+                      secret: true,
+                      only: NO_API_KEY_IDS
+                  })}`}
 
-        ${needsName.length === 0
-            ? raw('')
-            : html`<div class="field">
-                      <label for="add.name">Instance name</label>
-                      <input id="add.name" name="name" type="text" placeholder="4k" autocomplete="off">
-                      <p class="note">
-                          Required when a service already has one:
-                          <span class="mono">${needsName.join(', ')}</span>. It becomes part of the id, as
-                          <span class="mono">radarr/4k</span>.
-                      </p>
-                  </div>`}
+            ${needsName.length === 0
+                ? raw('')
+                : field({
+                      id: 'add.name',
+                      name: 'name',
+                      label: 'Instance name',
+                      placeholder: '4k',
+                      only: needsName,
+                      note: 'Required, because this service already has an instance. It becomes part of the id, as radarr/4k.'
+                  })}
 
-        ${unnamedSingle.length === 0
-            ? raw('')
-            : html`<div class="field">
-                      <label for="add.rename_existing_to">Name for the existing instance</label>
-                      <input id="add.rename_existing_to" name="rename_existing_to" type="text" placeholder="hd" autocomplete="off">
-                      <p class="note">
-                          Adding a second <span class="mono">${unnamedSingle.join(' or ')}</span> means naming the one
-                          you already have. Its permissions move with it, and any saved prompt naming the bare service
-                          will start asking which instance you meant.
-                      </p>
-                  </div>`}
+            ${unnamedSingle.length === 0
+                ? raw('')
+                : field({
+                      id: 'add.rename_existing_to',
+                      name: 'rename_existing_to',
+                      label: 'Name for the existing instance',
+                      placeholder: 'hd',
+                      only: unnamedSingle,
+                      note: 'Adding a second one means naming the one you already have. Its permissions move with it, and any saved prompt naming the bare service will start asking which instance you meant.'
+                  })}
 
-        <div class="row" style="margin-top:1rem"><button type="submit">Add</button></div>
-    </form>`;
+            <div class="row" style="margin-top:1rem">
+                <button type="submit">Add</button>
+                <!-- Native: closes the dialog without posting, no script involved.
+                     Hidden with scripting off, where the dialog is the page. -->
+                <button type="submit" formmethod="dialog" formnovalidate class="ghost close">Cancel</button>
+            </div>
+        </form>
+    </dialog>`;
 }
 
 export function configPage(opts: {
@@ -229,27 +372,41 @@ export function configPage(opts: {
     csrf: string;
     /** The instance whose Remove button was pressed but not yet confirmed. */
     confirmingRemoval?: string | undefined;
+    /** Set when an add was refused: the message and the form it is about have to
+     *  arrive together, or the dialog has swallowed the reason. */
+    openAdd?: boolean;
+    /** Per instance id, the users that instance reported. An absent id means it
+     *  was not asked or did not answer — which the card says out loud. */
+    users?: Record<string, readonly string[]>;
+    /** The one instance whose Test button was pressed, and what came back. */
+    tested?: { instance: string; diagnosis: ConnectionDiagnosis } | undefined;
     message?: { kind: 'ok' | 'err'; text: string } | undefined;
 }): string {
     const instances = listInstances(opts.config);
 
     const body = html`<h2>Services</h2>
-        ${instances.length === 0
-            ? html`<div class="panel">
-                  <p class="note" style="margin:0">
-                      Nothing is configured yet. Add the services you run — anything you leave out is simply absent,
-                      not broken. Saving applies immediately; there is no restart.
-                  </p>
-              </div>`
-            : html`<p class="note">
-                      Saving applies immediately — no restart. Each instance is saved on its own.
-                  </p>
-                  ${instances.map(i => instanceCard(i, opts.csrf, opts.confirmingRemoval))}`}
+        <div class="row" style="margin-bottom:1rem">
+            <button type="button" data-open="add-service">Add a service</button>
+            <span class="note" style="margin:0">
+                ${instances.length === 0
+                    ? raw('Nothing is configured yet — anything you leave out is simply absent, not broken.')
+                    : raw('Saving applies immediately — no restart. Each instance is saved on its own.')}
+            </span>
+        </div>
 
-        ${addForm(opts.config, opts.csrf)}
+        ${instances.map(i =>
+            instanceCard(
+                i,
+                opts.csrf,
+                opts.confirmingRemoval,
+                opts.users?.[i.id],
+                opts.tested?.instance === i.id ? opts.tested.diagnosis : undefined
+            )
+        )}
+        ${addDialog(opts.config, opts.csrf, opts.openAdd === true)}
 
         <h2>Access</h2>
-        <form method="post" action="/ui/config/access">
+        <form method="post" action="/ui/config/access" ${IGNORE_FORM}>
             <input type="hidden" name="csrf" value="${opts.csrf}">
             <fieldset>
                 <legend>Config UI</legend>
@@ -258,7 +415,7 @@ export function configPage(opts: {
                     id: 'auth.password',
                     name: 'auth.password',
                     label: 'New password',
-                    type: 'password',
+                    secret: true,
                     placeholder: 'unchanged',
                     note: 'Leave blank to keep the current password. Only a hash is stored — it cannot be read back.'
                 })}

--- a/src/web/pages.ts
+++ b/src/web/pages.ts
@@ -45,12 +45,24 @@ export function layout(opts: {
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>${esc(opts.title)} · arr-mcp</title>
-<link rel="stylesheet" href="/ui/app.css">
+<!-- Version-stamped because the assets are served with an hour of cache: without
+     it, an upgrade leaves a browser holding the previous app.js against the new
+     page for up to an hour, which is how a button that opens a dialog becomes a
+     button that does nothing. -->
+<link rel="stylesheet" href="/ui/app.css?v=${encodeURIComponent(opts.version)}">
+<!-- The add form lives in a dialog element that app.js opens. With no script there is
+     nothing to open it, so it is styled back into the flow as the plain panel it
+     used to be: every field visible, the server still validating, and the two
+     controls that would need scripting taken away. -->
+<noscript><style>
+dialog { display: block; position: static; max-width: none; width: auto; margin: 0 0 1rem; }
+[data-open], dialog .close { display: none; }
+</style></noscript>
 </head>
 <body>
 <header><h1>arr-mcp <span>${esc(opts.version)}</span></h1>${nav}</header>
 <main>${message}${opts.body}</main>
-<script src="/ui/app.js" defer></script>
+<script src="/ui/app.js?v=${encodeURIComponent(opts.version)}" defer></script>
 </body>
 </html>`;
 }

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -15,6 +15,8 @@ import {
     SESSION_TTL_MS,
     verifyPassword
 } from '../core/session.ts';
+import { buildAdapters } from '../services/registry.ts';
+import { hasUserDirectory } from '../services/types.ts';
 import { buildStackHealth } from '../tools/stackHealth.ts';
 import { CSS, JS } from './assets.ts';
 import { addInstance, removeInstance, updateInstance, type InstanceFields } from '../config/mutate.ts';
@@ -225,10 +227,52 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
 
     // --- configuration --------------------------------------------------
 
-    app.get('/ui/config', c => {
+    /**
+     * Who each user-aware service says its users are, for the default-user
+     * field to suggest.
+     *
+     * Capped well below any service's own timeout on purpose. This is the page
+     * you open *because* something is unreachable, and a Jellyfin that is down
+     * must cost a moment, not the ten seconds its own client would wait. A
+     * service that misses the cap is simply absent from the result, which the
+     * card renders as a plain text field saying so — never as an empty dropdown
+     * that reads like "this service has no users".
+     */
+    const USER_LOOKUP_MS = 2500;
+
+    const usersByInstance = async (): Promise<Record<string, readonly string[]>> => {
+        const found: Record<string, readonly string[]> = {};
+
+        await Promise.all(
+            runtime.current.adapters.filter(hasUserDirectory).map(async adapter => {
+                try {
+                    const users = await Promise.race([
+                        adapter.listUsers(),
+                        new Promise<never>((_, reject) =>
+                            setTimeout(() => reject(new Error('timed out')), USER_LOOKUP_MS).unref()
+                        )
+                    ]);
+                    found[adapter.id] = users.map(u => u.name);
+                } catch (err) {
+                    logger.warn({ service: adapter.id, err }, 'could not list users for the configuration page');
+                }
+            })
+        );
+
+        return found;
+    };
+
+    app.get('/ui/config', async c => {
         const session = guard(c);
         if (session === undefined) return c.redirect(entry(), 302);
-        return c.html(configPage({ version, config: runtime.config, csrf: runtime.sessions.csrfFor(session) }));
+        return c.html(
+            configPage({
+                version,
+                config: runtime.config,
+                csrf: runtime.sessions.csrfFor(session),
+                users: await usersByInstance()
+            })
+        );
     });
 
     /**
@@ -242,13 +286,21 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
     const configMutation =
         (
             what: string,
-            next: (form: Record<string, unknown>) => Config | { ask: string }
+            next: (form: Record<string, unknown>) => Config | { ask: string },
+            /** The add form is a dialog, so a refusal has to bring it back — a
+             *  message about a form nobody can see explains nothing. */
+            reopensAdd = false
         ): ((c: Context) => Promise<Response>) =>
         async (c: Context) => {
             const session = guard(c);
             if (session === undefined) return c.redirect(entry(), 302);
 
-            const render = (
+            // Asks the services who their users are on the way out, the same as
+            // a plain page load: a save that dropped the suggestions would have
+            // the card claim the service went quiet when nothing of the sort
+            // happened, and a save that changed a Jellyfin key is exactly when
+            // the list is worth refreshing.
+            const render = async (
                 message: { kind: 'ok' | 'err'; text: string } | undefined,
                 status: 200 | 400 | 403,
                 confirming?: string
@@ -258,7 +310,9 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
                         version,
                         config: runtime.config,
                         csrf: runtime.sessions.csrfFor(session),
+                        users: await usersByInstance(),
                         ...(confirming === undefined ? {} : { confirmingRemoval: confirming }),
+                        ...(reopensAdd && status !== 200 ? { openAdd: true } : {}),
                         ...(message === undefined ? {} : { message })
                     }),
                     status
@@ -308,7 +362,7 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
                 ...(renameExistingTo === '' ? {} : { renameExistingTo }),
                 fields: instanceFieldsFrom(form)
             });
-        })
+        }, true)
     );
 
     app.post(
@@ -334,6 +388,59 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
         '/ui/config/access',
         configMutation('Access settings saved.', form => buildAuthConfig(runtime.config, form))
     );
+
+    /**
+     * Test one instance — against the fields as they stand, not as they are
+     * saved.
+     *
+     * "Save it and see if the dashboard goes green" is the loop this replaces,
+     * and it is a bad one: it writes a URL you already suspect is wrong, and it
+     * answers on a different page. So the candidate config is built exactly as
+     * a save would build it, validated, and thrown away — nothing reaches disk,
+     * and a blank credential still means *unchanged*, so testing a card you
+     * have not touched tests what is already configured.
+     *
+     * Not a `configMutation`, despite the shape: that helper's whole contract
+     * is that it ends in `saveConfig`.
+     */
+    app.post('/ui/config/test', async c => {
+        const session = guard(c);
+        if (session === undefined) return c.redirect(entry(), 302);
+
+        const render = async (status: 200 | 400 | 403, extra: Partial<Parameters<typeof configPage>[0]>) =>
+            c.html(
+                configPage({
+                    version,
+                    config: runtime.config,
+                    csrf: runtime.sessions.csrfFor(session),
+                    users: await usersByInstance(),
+                    ...extra
+                }),
+                status
+            );
+
+        const form = await c.req.parseBody();
+        if (!runtime.sessions.csrfValid(session, str(form.csrf))) {
+            logger.warn({ ip: ipOf(c) }, 'rejected a connection test with a bad CSRF token');
+            return render(403, { message: { kind: 'err', text: 'That form was stale. Reload the page and try again.' } });
+        }
+
+        const id = str(form.instance);
+        try {
+            const candidate = updateInstance(runtime.config, id, instanceFieldsFrom(form));
+            const adapter = buildAdapters(candidate).find(a => a.id === id);
+            if (adapter === undefined) throw new Error(`${id} is not configured.`);
+
+            const diagnosis = await adapter.testConnection();
+            logger.info({ ip: ipOf(c), service: id, ok: diagnosis.ok }, 'connection tested from the config UI');
+            return render(200, { tested: { instance: id, diagnosis } });
+        } catch (err) {
+            // A config that will not even build — a URL that is not a URL, a
+            // timeout that is not a number. testConnection never gets to run,
+            // so the message is the validation one, which names the field.
+            return render(400, { message: { kind: 'err', text: (err as Error).message } });
+        }
+    });
 }
 
 const CACHE = { 'cache-control': 'public, max-age=3600' };

--- a/test/configUi.test.ts
+++ b/test/configUi.test.ts
@@ -178,6 +178,61 @@ describe('secrets', () => {
     });
 });
 
+/**
+ * Every field on this page already carried `autocomplete="off"`, and it made no
+ * difference: a card is a form holding a URL text input followed by a password
+ * input, which is exactly what browsers and manager extensions recognise as a
+ * login form — so on every load the URL field was overwritten with the saved
+ * username and the key field with the saved password. `autocomplete="off"` is
+ * ignored for credential fields on purpose, by all of them.
+ *
+ * The fix is structural rather than a request: this page has no password input
+ * for anything to recognise. These tests are the guard on that.
+ */
+describe('password managers', () => {
+    const BOTH_KINDS =
+        '  radarr:\n    url: http://192.0.2.10:7878\n    api_key: k\n' +
+        '  transmission:\n    url: http://192.0.2.11:9091\n    username: t\n    password: p\n';
+
+    it('renders no password input anywhere on the configuration page', async () => {
+        await seed(BOTH_KINDS);
+        await signIn();
+
+        expect(await (await call('/ui/config')).text()).not.toContain('type="password"');
+    });
+
+    it('masks the secret fields all the same', async () => {
+        await seed(BOTH_KINDS);
+        await signIn();
+        const page = await (await call('/ui/config')).text();
+
+        for (const name of ['api_key', 'password', 'auth.password']) {
+            expect(page).toMatch(new RegExp(`class="secret"[^>]*name="${name.replace('.', '\\.')}"`));
+        }
+    });
+
+    it('opts every field out for the managers that honour an attribute', async () => {
+        await seed(BOTH_KINDS);
+        await signIn();
+        const page = await (await call('/ui/config')).text();
+
+        for (const attr of ['data-1p-ignore', 'data-lpignore="true"', 'data-bwignore', 'data-protonpass-ignore']) {
+            expect(page).toContain(attr);
+        }
+        // Dashlane reads it off the form, so it has to be there too.
+        expect(page).toContain('data-form-type="other"');
+    });
+
+    /** The one form on the site a manager *should* fill, left alone. */
+    it('leaves the sign-in form fillable', async () => {
+        cookie = '';
+        const page = await (await call('/ui/login')).text();
+
+        expect(page).toContain('autocomplete="current-password"');
+        expect(page).toContain('type="password"');
+    });
+});
+
 describe('MCP endpoint', () => {
     it('shows the endpoint built from the host the browser reached it on', async () => {
         await signIn();
@@ -323,6 +378,249 @@ describe('the configuration page', () => {
 
         const order = [...page.matchAll(/name="instance" value="([^"]+)"/g)].map(m => m[1]);
         expect(order).toEqual(['radarr/4k', 'radarr/hd', 'sonarr']);
+    });
+});
+
+/**
+ * The add form is a dialog opened by a button, and its fields follow the picker
+ * — both of which need scripting. Neither may become a requirement: with
+ * scripting off the dialog is styled back into the flow and every field shows,
+ * which is exactly the page as it was before, and the server still refuses what
+ * does not make sense.
+ */
+describe('the add dialog', () => {
+    it('is opened by a button rather than sitting under the cards', async () => {
+        await signIn();
+        const page = await (await call('/ui/config')).text();
+
+        expect(page).toContain('data-open="add-service"');
+        expect(page).toContain('<dialog id="add-service"');
+        expect(page).toContain('action="/ui/config/add"');
+    });
+
+    it('falls back to an inline form when scripting is off', async () => {
+        await signIn();
+        const page = await (await call('/ui/config')).text();
+
+        expect(page).toContain('<noscript>');
+        expect(page).toMatch(/<noscript><style>[^<]*dialog\b/);
+    });
+
+    it('says which service each field belongs to, so the picker can hide the rest', async () => {
+        await signIn();
+        const page = await (await call('/ui/config')).text();
+
+        // Transmission is the one service with no API key, and the only one
+        // with a username and password.
+        const apiKey = /data-only="([^"]*)"[^>]*>\s*<label for="add\.api_key"/.exec(page)?.[1] ?? '';
+        expect(apiKey.split(' ')).not.toContain('transmission');
+        expect(apiKey.split(' ')).toContain('radarr');
+
+        for (const field of ['username', 'password']) {
+            const only = new RegExp(`data-only="([^"]*)"[^>]*>\\s*<label for="add\\.${field}"`).exec(page)?.[1];
+            expect(only).toBe('transmission');
+        }
+    });
+
+    /** Offering a service that can only have one instance, when it already has
+     *  one, is a click whose only outcome is "already configured". */
+    it('drops a configured single-instance service from the picker', async () => {
+        await seed(
+            '  prowlarr:\n    url: http://192.0.2.10:9696\n    api_key: k\n' +
+                '  radarr:\n    url: http://192.0.2.10:7878\n    api_key: k\n'
+        );
+        await signIn();
+        const page = await (await call('/ui/config')).text();
+
+        const offered = [...page.matchAll(/<option value="([^"]+)"/g)].map(m => m[1]);
+        expect(offered).not.toContain('prowlarr');
+        // Radarr takes more than one, so it stays.
+        expect(offered).toContain('radarr');
+        expect(page).toContain('Already configured, and limited to one instance');
+    });
+
+    it('offers a name only for the services that already have an instance', async () => {
+        await seed('  radarr:\n    url: http://192.0.2.10:7878\n    api_key: k\n');
+        await signIn();
+        const page = await (await call('/ui/config')).text();
+
+        const only = /data-only="([^"]*)"[^>]*>\s*<label for="add\.name"/.exec(page)?.[1];
+        expect(only).toBe('radarr');
+    });
+
+    /** A rejected add re-renders the page; the message and the form it is about
+     *  have to arrive together, or the dialog has swallowed the reason. */
+    it('comes back open when the add was refused', async () => {
+        await signIn();
+        const res = await call('/ui/config/add', form({ csrf: await csrfFrom(), type: 'radarr', url: '', api_key: 'k' }));
+
+        expect(res.status).toBe(400);
+        expect(await res.text()).toContain('<dialog id="add-service" open');
+    });
+
+    it('stays shut after a save that worked', async () => {
+        await signIn();
+        const res = await call(
+            '/ui/config/add',
+            form({ csrf: await csrfFrom(), type: 'radarr', url: 'http://192.0.2.10:7878', api_key: 'k' })
+        );
+
+        expect(res.status).toBe(200);
+        expect(await res.text()).not.toContain('<dialog id="add-service" open');
+    });
+});
+
+/**
+ * `default_user` is a name the service already knows, and typing it from memory
+ * is how you get a Jellyfin that answers every library question with "no such
+ * user". So the field suggests the real ones — as a datalist rather than a
+ * dropdown, because the service is often unreachable at exactly the moment you
+ * are configuring it and an empty dropdown would make the field unfillable.
+ */
+describe('the default user field', () => {
+    const JELLYFIN = '  jellyfin:\n    url: http://192.0.2.10:8096\n    api_key: k\n    default_user: me\n';
+
+    const withUsers = (names: string[]) => {
+        globalThis.fetch = (async (input: string | URL | Request) => {
+            if (String(input).includes('/Users')) {
+                return new Response(JSON.stringify(names.map((Name, i) => ({ Id: `id-${i}`, Name }))), {
+                    headers: { 'content-type': 'application/json' }
+                });
+            }
+            return new Response('{}', { headers: { 'content-type': 'application/json' } });
+        }) as typeof fetch;
+    };
+
+    const realFetch = globalThis.fetch;
+    afterEach(() => {
+        globalThis.fetch = realFetch;
+    });
+
+    // The mock goes in before `seed`, because that is when the adapters are
+    // built and each one captures the `fetch` it will use.
+    it('suggests the users the service reported', async () => {
+        withUsers(['bartus', 'guest']);
+        await seed(JELLYFIN);
+        await signIn();
+
+        const page = await (await call('/ui/config')).text();
+
+        expect(page).toContain('<datalist id="svc.jellyfin.default_user.options">');
+        expect(page).toContain('<option value="bartus">');
+        expect(page).toContain('<option value="guest">');
+        expect(page).toContain('Pick one of the 2 users jellyfin reported');
+    });
+
+    /** The field has to stay usable when the service is down — that is most of
+     *  why anyone opens this page. */
+    it('falls back to a typeable field when the service does not answer', async () => {
+        globalThis.fetch = (async () => {
+            throw new Error('connection refused');
+        }) as typeof fetch;
+        await seed(JELLYFIN);
+        await signIn();
+
+        const page = await (await call('/ui/config')).text();
+
+        expect(page).not.toContain('<datalist');
+        expect(page).toContain('did not answer when asked who its users are');
+        // Still an editable field holding what is configured.
+        expect(page).toContain('name="default_user"');
+        expect(page).toContain('value="me"');
+    });
+
+    it('says so when the service reports no users at all', async () => {
+        withUsers([]);
+        await seed(JELLYFIN);
+        await signIn();
+
+        expect(await (await call('/ui/config')).text()).toContain('jellyfin reports no users yet');
+    });
+});
+
+/**
+ * The loop this replaces is "save it and see if the dashboard goes green",
+ * which writes a URL you already suspect is wrong and answers on another page.
+ */
+describe('testing a connection', () => {
+    const RADARR = '  radarr:\n    url: http://192.0.2.10:7878\n    api_key: saved-key\n';
+    const realFetch = globalThis.fetch;
+
+    afterEach(() => {
+        globalThis.fetch = realFetch;
+    });
+
+    it('reports a service that answers', async () => {
+        await seed(RADARR);
+        globalThis.fetch = (async () =>
+            new Response(JSON.stringify({ version: '5.1.0' }), {
+                headers: { 'content-type': 'application/json' }
+            })) as typeof fetch;
+        await signIn();
+
+        const res = await call(
+            '/ui/config/test',
+            form({ csrf: await csrfFrom(), instance: 'radarr', url: 'http://192.0.2.10:7878', api_key: '' })
+        );
+
+        expect(res.status).toBe(200);
+        expect(await res.text()).toContain('Reachable in');
+    });
+
+    it('reports what is wrong, and what to do, when it does not', async () => {
+        await seed(RADARR);
+        globalThis.fetch = (async () => new Response('nope', { status: 401 })) as typeof fetch;
+        await signIn();
+
+        const res = await call(
+            '/ui/config/test',
+            form({ csrf: await csrfFrom(), instance: 'radarr', url: 'http://192.0.2.10:7878', api_key: 'wrong' })
+        );
+
+        expect(res.status).toBe(200);
+        expect(await res.text()).toContain('msg err');
+    });
+
+    /** The whole point: it must be safe to test a URL you have not committed to. */
+    it('writes nothing to disk, whatever the answer', async () => {
+        await seed(RADARR);
+        globalThis.fetch = (async () =>
+            new Response(JSON.stringify({ version: '5.1.0' }), {
+                headers: { 'content-type': 'application/json' }
+            })) as typeof fetch;
+        await signIn();
+
+        await call(
+            '/ui/config/test',
+            form({ csrf: await csrfFrom(), instance: 'radarr', url: 'http://192.0.2.99:7878', api_key: 'typed-key' })
+        );
+
+        const onDisk = await readFile(join(dir, 'config.yaml'), 'utf8');
+        expect(onDisk).toContain('192.0.2.10:7878');
+        expect(onDisk).not.toContain('192.0.2.99');
+        expect(onDisk).toContain('saved-key');
+        expect(onDisk).not.toContain('typed-key');
+    });
+
+    it('refuses a forged CSRF token', async () => {
+        await seed(RADARR);
+        await signIn();
+
+        const res = await call('/ui/config/test', form({ csrf: 'forged', instance: 'radarr' }));
+        expect(res.status).toBe(403);
+    });
+
+    it('answers with the validation message when the fields cannot even be built', async () => {
+        await seed(RADARR);
+        await signIn();
+
+        const res = await call(
+            '/ui/config/test',
+            form({ csrf: await csrfFrom(), instance: 'radarr', url: 'not-a-url' })
+        );
+
+        expect(res.status).toBe(400);
+        expect(await res.text()).toContain('msg err');
     });
 });
 


### PR DESCRIPTION
Four things about the configuration page, all of them things you hit while actually configuring a stack.

### Password managers filled the cards on every load

Editing a timeout meant re-pasting the URL and the API key. The cause was structural: a card is a `<form>` holding a URL text input followed by an `<input type="password">`, which is exactly what a browser and every manager extension read as a login form — so the URL got the saved username and the key got the saved password, every load. The `autocomplete="off"` already on those fields was never going to hold; it is ignored for credential fields on purpose.

The page now has **no password input at all**. Secrets are masked with `-webkit-text-security` (Chrome/Edge/Safari, Firefox 116+) and every field carries `data-1p-ignore`, `data-lpignore`, `data-bwignore`, `data-protonpass-ignore`, plus `data-form-type="other"` on each form. The sign-in page is untouched — that one *should* be filled.

### Adding a service is a dialog

Behind a button at the top, and it only asks what the chosen service has: Transmission its username and password, everything else an API key. Services that already have their one allowed instance drop out of the picker. A refused add comes back with the dialog open, so the message and the form arrive together.

Both behaviours are enhancements — with scripting off, a `<noscript>` rule styles the dialog back into the page with every field showing, which is the form exactly as it was.

### Test before saving

**Test** on a card runs `testConnection()` against the fields *as they stand*, saved or not: the candidate config is built the way a save builds it, validated, tested and thrown away. Nothing reaches disk, and a blank credential still means *unchanged*. This replaces "save it and see if the dashboard goes green", which wrote a URL you already suspected was wrong and answered on a different page.

### Jellyfin and Seerr suggest their own users

`default_user` is backed by the real list, fetched on page render. A `<datalist>` rather than a `<select>` because the service is often unreachable at exactly the moment you are configuring it and the field has to stay typeable. Capped at 2.5s so a dead service costs a moment rather than its own timeout, and the card says out loud when there was no answer.

### Also

The stylesheet and script URLs are version-stamped. They are served with an hour of cache, so without it an upgrade would leave a browser running the old `app.js` against the new page — an Add button that does nothing.

### Verification

- `npm run typecheck`, `npm run lint`, `npx vitest run` — 1049 passing, 24 of them new
- Driven live against a throwaway config: no `type="password"` in the rendered page, Test on an unreachable Radarr returned `no response from 192.0.2.10:7878 within the configured timeout` with `config.yaml` untouched, and a dead Jellyfin capped the page at 2584 ms and degraded to a plain field

Releases as **0.7.1** — a `feat:` on top of 0.7.0 under `bump-patch-for-minor-pre-major`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)