### PR TITLE
feat: test before adding, and one disk row per filesystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,12 @@ from the same code: is it reachable, is anything reporting a problem, is a disk
 filling up, and when did each library last finish a scan. A stale scan is the
 usual reason something downloaded is still not playable.
 
+**Disk space is listed per filesystem, not per mount.** Services in one stack are
+containers over the same host disks, so each of them reports the array, its own
+root and its config volume separately — ten rows to tell you about two disks. The
+dashboard groups them back together and names the instances that can see each
+one, emptiest first.
+
 **Secrets never come back out.** API keys, the Transmission password and the UI
 password all render as empty fields meaning *unchanged*, so a saved page or a
 screenshot cannot carry them. The bearer token is the deliberate exception —
@@ -402,11 +408,13 @@ once you have that one, so the picker never offers a choice that ends in
 "already configured". With scripting off the dialog is the plain form it used to
 be, every field showing, and the server still refuses what does not make sense.
 
-**Test** on a card tries the URL and key *as they are on screen*, saved or not,
-and tells you what came back — reachable and how fast, or what is wrong and what
-to do about it. Nothing is written to disk, so it is safe to try a URL you are
-unsure of. A blank key still means unchanged, so testing a card you have not
-touched tests what is already configured.
+**Test** tries the URL and key *as they are on screen*, saved or not, and tells
+you what came back — reachable and how fast, or what is wrong and what to do
+about it. Nothing is written to disk, so it is safe to try a URL you are unsure
+of. It sits in the **Add a service** dialog, where you can check a new service
+before it is added at all, and on every card, where a blank key still means
+unchanged — so testing a card you have not touched tests what is already
+configured.
 
 **Jellyfin and Seerr suggest their own users.** The default-user field is backed
 by the real list, fetched from the service when the page loads, so the name you

--- a/src/web/assets.ts
+++ b/src/web/assets.ts
@@ -233,6 +233,60 @@ if (addService) {
     picker.addEventListener('change', follow);
     follow();
   }
+
+  // Test, without leaving the dialog.
+  //
+  // The unscripted fallback posts this form and gets the page back with the
+  // dialog reopened and the fields blank — survivable for a refused Add, which
+  // you do once, but not for a test you repeat while fixing a URL. So the
+  // scripted path posts the same form to the same route and fills the result in
+  // place, which is also what keeps the typed API key off the wire twice and
+  // out of the rendered HTML entirely.
+  //
+  // textContent, never innerHTML: detail and remedy quote whatever the service
+  // said back, and this is the one path where that string is put on the page by
+  // the browser rather than through the server's escaping template.
+  const form = addService.querySelector('form');
+  const result = document.getElementById('add-test-result');
+  const testBtn = addService.querySelector('button[formaction="/ui/config/test"]');
+
+  if (form && result && testBtn) {
+    const say = (kind, text) => {
+      const box = document.createElement('div');
+      box.className = 'msg ' + kind;
+      box.style.margin = '.75rem 0 0';
+      box.textContent = text;
+      result.replaceChildren(box);
+    };
+
+    testBtn.addEventListener('click', async (e) => {
+      e.preventDefault();
+      testBtn.disabled = true;
+      say('ok', 'Testing…');
+
+      try {
+        const res = await fetch('/ui/config/test', {
+          method: 'POST',
+          headers: { accept: 'application/json' },
+          body: new FormData(form),
+        });
+        const d = await res.json();
+
+        if (d.ok) {
+          say('ok', 'Reachable in ' + d.latency_ms + ' ms' +
+            (d.version ? ' — version ' + d.version : '') +
+            '. Not added yet: this tested the fields as they are on screen.');
+        } else {
+          const err = d.error || d;
+          say('err', (err.detail || 'Unreachable.') + (err.remedy ? '\\n' + err.remedy : ''));
+        }
+      } catch {
+        say('err', 'Could not reach this server to run the test. Check that the page is still connected.');
+      } finally {
+        testBtn.disabled = false;
+      }
+    });
+  }
 }
 
 // The log stream polls JSON and builds rows with textContent — never

--- a/src/web/configPage.ts
+++ b/src/web/configPage.ts
@@ -271,7 +271,12 @@ function instanceCard(
  * The server still validates either way, and answers with the specific thing to
  * do; those messages are written for a reader who saw everything at once.
  */
-function addDialog(config: Config, csrf: string, open: boolean): SafeHtml {
+function addDialog(
+    config: Config,
+    csrf: string,
+    open: boolean,
+    tested: ConnectionDiagnosis | undefined
+): SafeHtml {
     const instances = listInstances(config);
     const configured = new Set(instances.map(i => i.type));
 
@@ -358,10 +363,23 @@ function addDialog(config: Config, csrf: string, open: boolean): SafeHtml {
 
             <div class="row" style="margin-top:1rem">
                 <button type="submit">Add</button>
+                <!-- The question this dialog exists to get wrong is "is this URL
+                     and this key right", and the cheapest place to answer it is
+                     before anything is written to config.yaml.
+
+                     Scripted, this posts through fetch and fills #add-test-result
+                     below without leaving the page — because a re-render would
+                     have to either clear the key you just typed or echo it back
+                     into the HTML, and this file does not echo secrets. With
+                     scripting off it is an ordinary submit: the server renders
+                     the page with the dialog open and the diagnosis on it, the
+                     fields blank, exactly as a refused Add already does. -->
+                <button type="submit" formaction="/ui/config/test" formnovalidate class="ghost">Test</button>
                 <!-- Native: closes the dialog without posting, no script involved.
                      Hidden with scripting off, where the dialog is the page. -->
                 <button type="submit" formmethod="dialog" formnovalidate class="ghost close">Cancel</button>
             </div>
+            <div id="add-test-result">${tested === undefined ? raw('') : testResult(tested)}</div>
         </form>
     </dialog>`;
 }
@@ -380,6 +398,10 @@ export function configPage(opts: {
     users?: Record<string, readonly string[]>;
     /** The one instance whose Test button was pressed, and what came back. */
     tested?: { instance: string; diagnosis: ConnectionDiagnosis } | undefined;
+    /** The add dialog's own Test, which has no instance id to key on because
+     *  the instance does not exist yet. Only the unscripted path reaches this —
+     *  with scripting the result is fetched and filled in client-side. */
+    testedAdd?: ConnectionDiagnosis | undefined;
     message?: { kind: 'ok' | 'err'; text: string } | undefined;
 }): string {
     const instances = listInstances(opts.config);
@@ -403,7 +425,7 @@ export function configPage(opts: {
                 opts.tested?.instance === i.id ? opts.tested.diagnosis : undefined
             )
         )}
-        ${addDialog(opts.config, opts.csrf, opts.openAdd === true)}
+        ${addDialog(opts.config, opts.csrf, opts.openAdd === true, opts.testedAdd)}
 
         <h2>Access</h2>
         <form method="post" action="/ui/config/access" ${IGNORE_FORM}>

--- a/src/web/pages.ts
+++ b/src/web/pages.ts
@@ -143,6 +143,57 @@ export function loginPage(opts: { version: string; error?: string | undefined })
     });
 }
 
+/** One filesystem, and every instance that can see it. */
+export type DiskGroup = { freeSpace: number; totalSpace?: number | undefined; services: string[] };
+
+/**
+ * Collapse the mounts every service reports down to the disks behind them.
+ *
+ * Services in a stack are containers over the same host filesystems, so the
+ * array that arrives here is mostly the same two or three disks repeated: the
+ * array volume once per *arr plus the download client, the container root once
+ * per service, `/config` again for each. Ten rows to say "you have two disks",
+ * which is a table nobody reads.
+ *
+ * Free bytes are the fingerprint. Two mounts of one filesystem agree on them
+ * exactly, and two genuinely different disks landing on the same byte count is
+ * a coincidence that does not happen at these sizes. Totals then guard against
+ * even that: a mount only joins a group whose total it does not contradict,
+ * which also folds in Transmission — it reports free space without a total, so
+ * it has nothing to contradict and lands on the disk it shares.
+ *
+ * Paths are dropped rather than listed. Knowing that one disk is `/storage` to
+ * Radarr and `/data` to SABnzbd is a container-mapping question; the question
+ * this table answers is whether anything is about to run out of room.
+ */
+export function groupDisks(disks: readonly DiskSpace[]): DiskGroup[] {
+    const groups: DiskGroup[] = [];
+
+    for (const disk of disks) {
+        const group = groups.find(
+            g =>
+                g.freeSpace === disk.freeSpace &&
+                (g.totalSpace === undefined || disk.totalSpace === undefined || g.totalSpace === disk.totalSpace)
+        );
+
+        if (group === undefined) {
+            groups.push({
+                freeSpace: disk.freeSpace,
+                ...(disk.totalSpace === undefined ? {} : { totalSpace: disk.totalSpace }),
+                services: [disk.service]
+            });
+            continue;
+        }
+
+        group.totalSpace ??= disk.totalSpace;
+        if (!group.services.includes(disk.service)) group.services.push(disk.service);
+    }
+
+    // Emptiest first: the disk about to cause a failed import is the one worth
+    // reading, and it is never the one with room to spare.
+    return groups.sort((a, b) => a.freeSpace - b.freeSpace);
+}
+
 const statusDot = (d: ConnectionDiagnosis): SafeHtml =>
     html`<span class="dot ${d.ok ? 'ok' : 'bad'}" title="${d.ok ? 'reachable' : 'unreachable'}"></span>`;
 
@@ -216,18 +267,18 @@ export function dashboardPage(opts: {
                   </tbody>
               </table>`;
 
+    const grouped = groupDisks(opts.disks);
     const disks =
-        opts.disks.length === 0
+        grouped.length === 0
             ? html`<p class="note">No service reported disk space.</p>`
             : html`<table>
-                  <thead><tr><th>Service</th><th>Location</th><th>Free</th><th>Total</th></tr></thead>
+                  <thead><tr><th>Free</th><th>Total</th><th>Seen by</th></tr></thead>
                   <tbody>
-                      ${opts.disks.map(
+                      ${grouped.map(
                           d => html`<tr>
-                              <td>${d.service}</td>
-                              <td class="mono">${d.path ?? d.label}</td>
                               <td>${humanBytes(d.freeSpace)}</td>
                               <td>${d.totalSpace === undefined ? '—' : humanBytes(d.totalSpace)}</td>
+                              <td>${d.services.join(', ')}</td>
                           </tr>`
                       )}
                   </tbody>
@@ -259,7 +310,13 @@ export function dashboardPage(opts: {
         <div class="panel">${problems}</div>
 
         <h2>Disk space</h2>
-        <div class="panel">${disks}</div>
+        <div class="panel">
+            <p class="note">
+                One row per filesystem, not per mount — services in one stack share the same disks, and
+                listing every path they see them through says the same thing several times over.
+            </p>
+            ${disks}
+        </div>
 
         <h2>Library scans</h2>
         <div class="panel">

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -15,6 +15,7 @@ import {
     SESSION_TTL_MS,
     verifyPassword
 } from '../core/session.ts';
+import { instanceId } from '../config/instances.ts';
 import { buildAdapters } from '../services/registry.ts';
 import { hasUserDirectory } from '../services/types.ts';
 import { buildStackHealth } from '../tools/stackHealth.ts';
@@ -351,18 +352,7 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
 
     app.post(
         '/ui/config/add',
-        configMutation('Added.', form => {
-            const type = ServiceIdSchema.parse(str(form.type));
-            const name = str(form.name).trim();
-            const renameExistingTo = str(form.rename_existing_to).trim();
-
-            return addInstance(runtime.config, {
-                type,
-                ...(name === '' ? {} : { name }),
-                ...(renameExistingTo === '' ? {} : { renameExistingTo }),
-                fields: instanceFieldsFrom(form)
-            });
-        }, true)
+        configMutation('Added.', form => addCandidateFrom(runtime.config, form).candidate, true)
     );
 
     app.post(
@@ -400,12 +390,32 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
      * and a blank credential still means *unchanged*, so testing a card you
      * have not touched tests what is already configured.
      *
+     * The add dialog posts here too, with no `instance` — there is not one yet.
+     * That candidate is built by `addInstance`, the same call Add itself makes,
+     * so a test that passes is a test that Add will accept. It inherits Add's
+     * validation along with it: testing a second radarr before naming it
+     * answers "name the new radarr instance" rather than a latency, which is
+     * the thing you needed to hear either way.
+     *
      * Not a `configMutation`, despite the shape: that helper's whole contract
      * is that it ends in `saveConfig`.
      */
     app.post('/ui/config/test', async c => {
         const session = guard(c);
         if (session === undefined) return c.redirect(entry(), 302);
+
+        const form = await c.req.parseBody();
+        const id = str(form.instance);
+        const isAdd = id === '';
+
+        // The dialog's Test is fetched rather than posted, so its result can
+        // land in a dialog that still holds what you typed. A page re-render
+        // could not: `addDialog` renders its fields blank, and filling them
+        // back in would mean writing the API key into the HTML — which is the
+        // one thing `configPage` is built never to do. The unscripted path
+        // falls through to the same render as everything else, blank fields
+        // and all, exactly as a refused Add already behaves.
+        const wantsJson = c.req.header('accept')?.includes('application/json') === true;
 
         const render = async (status: 200 | 400 | 403, extra: Partial<Parameters<typeof configPage>[0]>) =>
             c.html(
@@ -414,31 +424,38 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
                     config: runtime.config,
                     csrf: runtime.sessions.csrfFor(session),
                     users: await usersByInstance(),
+                    ...(isAdd ? { openAdd: true } : {}),
                     ...extra
                 }),
                 status
             );
 
-        const form = await c.req.parseBody();
+        const fail = async (status: 400 | 403, text: string) =>
+            wantsJson ? c.json({ ok: false, detail: text }, status) : render(status, { message: { kind: 'err', text } });
+
         if (!runtime.sessions.csrfValid(session, str(form.csrf))) {
             logger.warn({ ip: ipOf(c) }, 'rejected a connection test with a bad CSRF token');
-            return render(403, { message: { kind: 'err', text: 'That form was stale. Reload the page and try again.' } });
+            return fail(403, 'That form was stale. Reload the page and try again.');
         }
 
-        const id = str(form.instance);
         try {
-            const candidate = updateInstance(runtime.config, id, instanceFieldsFrom(form));
-            const adapter = buildAdapters(candidate).find(a => a.id === id);
-            if (adapter === undefined) throw new Error(`${id} is not configured.`);
+            const { candidate, target } = isAdd
+                ? addCandidateFrom(runtime.config, form)
+                : { candidate: updateInstance(runtime.config, id, instanceFieldsFrom(form)), target: id };
+
+            const adapter = buildAdapters(candidate).find(a => a.id === target);
+            if (adapter === undefined) throw new Error(`${target} is not configured.`);
 
             const diagnosis = await adapter.testConnection();
-            logger.info({ ip: ipOf(c), service: id, ok: diagnosis.ok }, 'connection tested from the config UI');
-            return render(200, { tested: { instance: id, diagnosis } });
+            logger.info({ ip: ipOf(c), service: target, ok: diagnosis.ok }, 'connection tested from the config UI');
+
+            if (wantsJson) return c.json(diagnosis, 200);
+            return render(200, isAdd ? { testedAdd: diagnosis } : { tested: { instance: target, diagnosis } });
         } catch (err) {
             // A config that will not even build — a URL that is not a URL, a
             // timeout that is not a number. testConnection never gets to run,
             // so the message is the validation one, which names the field.
-            return render(400, { message: { kind: 'err', text: (err as Error).message } });
+            return fail(400, (err as Error).message);
         }
     });
 }
@@ -511,6 +528,33 @@ export function instanceFieldsFrom(form: Record<string, unknown>): InstanceField
         ...(Number.isFinite(timeout) && timeout > 0 ? { timeout_ms: Math.trunc(timeout) } : {}),
         safe_write: on(form.safe_write),
         destructive: on(form.destructive)
+    };
+}
+
+/**
+ * What the add dialog describes: the config it would produce, and the id the
+ * new instance would take.
+ *
+ * Shared by `/ui/config/add` and the dialog's Test so the two cannot drift.
+ * A Test that builds its candidate any other way is a Test that can pass
+ * against something Add would then refuse.
+ */
+export function addCandidateFrom(
+    config: Config,
+    form: Record<string, unknown>
+): { candidate: Config; target: string } {
+    const type = ServiceIdSchema.parse(str(form.type));
+    const name = str(form.name).trim();
+    const renameExistingTo = str(form.rename_existing_to).trim();
+
+    return {
+        candidate: addInstance(config, {
+            type,
+            ...(name === '' ? {} : { name }),
+            ...(renameExistingTo === '' ? {} : { renameExistingTo }),
+            fields: instanceFieldsFrom(form)
+        }),
+        target: instanceId(type, name === '' ? undefined : name)
     };
 }
 

--- a/test/configUi.test.ts
+++ b/test/configUi.test.ts
@@ -624,6 +624,114 @@ describe('testing a connection', () => {
     });
 });
 
+/**
+ * The same route, driven by the add dialog, which has no instance to name
+ * because it is describing one that does not exist yet.
+ */
+describe('testing from the add dialog', () => {
+    const reachable = () => {
+        globalThis.fetch = (async () =>
+            new Response(JSON.stringify({ version: '5.1.0' }), {
+                headers: { 'content-type': 'application/json' }
+            })) as typeof fetch;
+    };
+
+    const json = (body: Record<string, string>): RequestInit => ({
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded', accept: 'application/json' },
+        body: new URLSearchParams(body).toString()
+    });
+
+    it('offers a Test button in the dialog', async () => {
+        await signIn();
+        const page = await (await call('/ui/config')).text();
+        const dialog = page.slice(page.indexOf('<dialog id="add-service"'));
+
+        expect(dialog).toContain('formaction="/ui/config/test"');
+        expect(dialog).toContain('id="add-test-result"');
+    });
+
+    it('tests a service that is not configured yet', async () => {
+        reachable();
+        await signIn();
+
+        const res = await call(
+            '/ui/config/test',
+            json({ csrf: await csrfFrom(), type: 'radarr', url: 'http://192.0.2.10:7878', api_key: 'typed-key' })
+        );
+
+        expect(res.status).toBe(200);
+        expect(await res.json()).toMatchObject({ ok: true, version: '5.1.0' });
+    });
+
+    it('adds nothing to the config, whatever the answer', async () => {
+        reachable();
+        await signIn();
+
+        await call(
+            '/ui/config/test',
+            json({ csrf: await csrfFrom(), type: 'radarr', url: 'http://192.0.2.10:7878', api_key: 'typed-key' })
+        );
+
+        const onDisk = await readFile(join(dir, 'config.yaml'), 'utf8');
+        expect(onDisk).not.toContain('192.0.2.10');
+        expect(onDisk).not.toContain('typed-key');
+    });
+
+    // The reason the scripted path exists at all: a re-render would have to put
+    // the key back in the HTML to keep the dialog usable, and this file never
+    // renders a secret back.
+    it('never echoes the typed key back, on either path', async () => {
+        globalThis.fetch = (async () => new Response('nope', { status: 401 })) as typeof fetch;
+        await signIn();
+        const csrf = await csrfFrom();
+        const fields = { csrf, type: 'radarr', url: 'http://192.0.2.10:7878', api_key: 'typed-key' };
+
+        expect(JSON.stringify(await (await call('/ui/config/test', json(fields))).json())).not.toContain('typed-key');
+        expect(await (await call('/ui/config/test', form(fields))).text()).not.toContain('typed-key');
+    });
+
+    // Unscripted, the answer has to come back on a page with the dialog open —
+    // a diagnosis behind a closed dialog is a diagnosis nobody reads.
+    it('reopens the dialog when it answers as a page', async () => {
+        reachable();
+        await signIn();
+
+        const res = await call(
+            '/ui/config/test',
+            form({ csrf: await csrfFrom(), type: 'radarr', url: 'http://192.0.2.10:7878', api_key: 'k' })
+        );
+
+        const page = await res.text();
+        expect(page).toContain('<dialog id="add-service" open>');
+        expect(page).toContain('Reachable in');
+    });
+
+    // It builds its candidate through `addInstance`, so it refuses exactly what
+    // Add would refuse — and says the same thing about it.
+    it('answers with the add validation message rather than a latency', async () => {
+        await seed('  radarr:\n    url: http://192.0.2.10:7878\n    api_key: saved-key\n');
+        reachable();
+        await signIn();
+
+        const res = await call(
+            '/ui/config/test',
+            json({ csrf: await csrfFrom(), type: 'radarr', url: 'http://192.0.2.20:7878', api_key: 'k' })
+        );
+
+        expect(res.status).toBe(400);
+        expect(await res.json()).toMatchObject({ ok: false, detail: expect.stringContaining('Name the new radarr') });
+    });
+
+    it('refuses a forged CSRF token as JSON when JSON was asked for', async () => {
+        await signIn();
+        const res = await call('/ui/config/test', json({ csrf: 'forged', type: 'radarr' }));
+
+        expect(res.status).toBe(403);
+        expect(await res.json()).toMatchObject({ ok: false });
+    });
+});
+
 describe('saving an instance', () => {
     it('keeps an existing key when the field is left blank', async () => {
         await seed('  radarr:\n    url: http://192.0.2.10:7878\n    api_key: keep-me\n');

--- a/test/webHtml.test.ts
+++ b/test/webHtml.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
+import type { DiskSpace } from '../src/services/types.ts';
+import { JS } from '../src/web/assets.ts';
 import { esc, html, humanBytes, raw, shortTime } from '../src/web/html.ts';
+import { groupDisks } from '../src/web/pages.ts';
 
 describe('escaping', () => {
     it('neutralises the characters that end a tag or an attribute', () => {
@@ -68,5 +71,98 @@ describe('formatting helpers', () => {
 
     it('shortens an ISO timestamp for a log table', () => {
         expect(shortTime('2026-08-06T12:11:18.123Z')).toBe('2026-08-06 12:11:18');
+    });
+});
+
+/**
+ * Ten rows to say "you have two disks" is the shape this collapses: a stack's
+ * services are containers over the same host filesystems, so the array that
+ * reaches the dashboard is mostly the same disks repeated.
+ */
+describe('grouping the disks a stack reports', () => {
+    const disk = (service: string, freeSpace: number, totalSpace?: number): DiskSpace => ({
+        service,
+        label: `${service} mount`,
+        freeSpace,
+        ...(totalSpace === undefined ? {} : { totalSpace })
+    });
+
+    it('collapses one filesystem seen through many mounts into one row', () => {
+        const groups = groupDisks([
+            disk('radarr', 5_000_000_000_000, 10_800_000_000_000),
+            disk('radarr', 5_000_000_000_000, 10_800_000_000_000),
+            disk('sonarr', 5_000_000_000_000, 10_800_000_000_000)
+        ]);
+
+        expect(groups).toHaveLength(1);
+        expect(groups[0]?.services).toEqual(['radarr', 'sonarr']);
+    });
+
+    // Transmission reports free space without a total, so it has nothing to
+    // contradict and belongs on the disk it shares rather than on a row of
+    // its own.
+    it('folds a total-less mount onto the disk it matches', () => {
+        const groups = groupDisks([
+            disk('sabnzbd', 5_000_000_000_000, 10_800_000_000_000),
+            disk('transmission', 5_000_000_000_000)
+        ]);
+
+        expect(groups).toHaveLength(1);
+        expect(groups[0]?.totalSpace).toBe(10_800_000_000_000);
+        expect(groups[0]?.services).toEqual(['sabnzbd', 'transmission']);
+    });
+
+    // Free bytes are the fingerprint, but a contradicting total outranks them:
+    // two disks that agree on free space and disagree on size are two disks.
+    it('keeps disks apart when their totals disagree', () => {
+        const groups = groupDisks([
+            disk('radarr', 140_000_000_000, 228_000_000_000),
+            disk('jellyfin', 140_000_000_000, 500_000_000_000)
+        ]);
+
+        expect(groups).toHaveLength(2);
+    });
+
+    it('names each instance once, however many mounts it reported', () => {
+        const groups = groupDisks([
+            disk('radarr/4k', 100, 200),
+            disk('radarr/4k', 100, 200),
+            disk('radarr/4k', 100, 200)
+        ]);
+
+        expect(groups[0]?.services).toEqual(['radarr/4k']);
+    });
+
+    // The disk about to cause a failed import is the one worth reading first.
+    it('puts the emptiest disk at the top', () => {
+        const groups = groupDisks([disk('a', 900), disk('b', 100), disk('c', 500)]);
+        expect(groups.map(g => g.freeSpace)).toEqual([100, 500, 900]);
+    });
+
+    it('has nothing to say about an empty list', () => {
+        expect(groupDisks([])).toEqual([]);
+    });
+});
+
+/**
+ * The client script is a template literal in a TypeScript file, which means a
+ * backtick or a `\n` written without escaping it twice is a syntax error in the
+ * *served* file and nothing at all in the source. Nothing else here parses it,
+ * so a broken build of it takes out the log stream, the copy buttons and the
+ * add dialog at once, silently, on a page the type checker calls fine.
+ *
+ * `new Function` compiles without running: enough to catch the mistake, and it
+ * never touches the `document` this expects.
+ */
+describe('the client script', () => {
+    it('is valid JavaScript once the template literal has been built', () => {
+        expect(() => new Function(JS)).not.toThrow();
+    });
+
+    // The specific one that got through: a remedy is printed under its detail,
+    // so the separator has to reach the browser as an escape sequence, not as
+    // the line break that ends the string it lives in.
+    it('emits its newline separator as an escape, not as a line break', () => {
+        expect(JS).toContain(String.raw`'\n' + err.remedy`);
     });
 });


### PR DESCRIPTION
Two things that were in the wrong place on the config UI and the dashboard.

## Test belongs in the Add dialog

The question **Test** answers — is this URL and this key right — is worth asking *before* anything is written to `config.yaml`, and adding a service is exactly when you don't know yet. It's now in the **Add a service** dialog as well as on every card.

The dialog posts it through `fetch` rather than as a form submit. A page re-render couldn't work here: `addDialog` renders its fields blank, so the result would come back over a cleared API key — and filling that back in would mean writing the key into the HTML, which is [the one thing `configPage` is built never to do](https://github.com/bardesss/arr-mcp/blob/main/src/web/configPage.ts#L12). With scripting off it stays an ordinary submit and the server returns the page with the dialog open and the diagnosis on it, exactly as a refused Add already behaves.

The candidate is built by `addInstance`, the same call Add makes, so a test that passes is a test Add will accept. It inherits Add's validation along with it: testing a second `radarr` before naming it answers *"Name the new radarr instance"* rather than a latency — which is the thing you needed to hear either way.

## Disk space, per filesystem instead of per mount

Services in one stack are containers over the same host disks, so each of them reports the array, its own root and its config volume separately. Ten rows to say "you have two disks". Rendered against a real stack's numbers:

**Before**

| Service | Location | Free | Total |
| --- | --- | --- | --- |
| sabnzbd | SABnzbd download | 4.6 TB | 10.8 TB |
| sabnzbd | SABnzbd secondary | 4.6 TB | 10.8 TB |
| transmission | /storage/downloads/complete | 4.6 TB | — |
| radarr | / | 140 GB | 228 GB |
| radarr | /config | 140 GB | 228 GB |
| radarr | /storage | 4.6 TB | 10.8 TB |
| sonarr | / | 140 GB | 228 GB |
| sonarr | /storage | 4.6 TB | 10.8 TB |
| sonarr | /config | 140 GB | 228 GB |

**After**

| Free | Total | Seen by |
| --- | --- | --- |
| 140 GB | 227 GB | radarr, sonarr |
| 4.6 TB | 10.8 TB | sabnzbd, transmission, radarr, sonarr |

Free bytes are the fingerprint — two mounts of one filesystem agree on them exactly. Totals guard against the coincidence: a mount only joins a group whose total it doesn't contradict, which folds in Transmission (it reports free space without a total, so it has nothing to contradict) and still splits two genuinely different disks that happen to share a free figure. Emptiest first, because the disk about to cause a failed import is the one worth reading. Paths are dropped: which mount is `/config` and which is `/` is a container-mapping question, not a running-out-of-room one.

## A bug this caught

`assets.ts` holds the client script as a template literal inside TypeScript, so a single-escaped `\n` in it is a real line break in the *served* file — a syntax error that takes out the log stream, the copy buttons and the add dialog at once, silently, with `tsc` clean. That happened during this change. Nothing in the suite parsed that file, so there's now a test that compiles it; reintroducing the bug fails it.

## Verification

- `npm test` — 1064 passed, 51 files
- `npm run typecheck`, `npm run lint` — clean
- Disk table rendered against the numbers above to confirm the grouping
- New tests: `groupDisks` merging, folding and splitting; the dialog's Test route on both the JSON and unscripted paths, including that neither echoes the typed key back

🤖 Generated with [Claude Code](https://claude.com/claude-code)
