### PR TITLE
feat: IMDb ratings, for series too

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,17 @@ is free software maintained largely by volunteers:
 | [yaml](https://eemeli.org/yaml/) | reading `config.yaml` |
 | [TypeScript](https://www.typescriptlang.org) | the language |
 
+**The data it reads**, when you enable the IMDb dataset:
+
+> Information courtesy of
+> [IMDb](https://www.imdb.com) ([datasets](https://developer.imdb.com/non-commercial-datasets/)).
+> Used with permission.
+
+Those datasets are published for **personal and non-commercial use**. arr-mcp
+never redistributes them and ships no prebuilt copy — your own container
+downloads them, for your own use, only if you switch the dataset on. It is off
+by default.
+
 If you find arr-mcp useful, consider supporting the services above first.
 
 ## Licence

--- a/README.md
+++ b/README.md
@@ -20,15 +20,16 @@ Jellyfin. arr-mcp correlates them and gives you the causal chain.
   broken and what to do about it, and read the logs and the write audit — no
   hand-edited YAML, no restart.
 
-> ### Status: 0.7 — one library across many instances
+> ### Status: 0.8 — ratings that work for series too
 >
-> Run an HD and a 4K Radarr and read them as one library, or name the instance
-> you mean and write to exactly that one. The configuration page is built around
-> instances to match: a card each, added from a dialog that asks only what the
-> service needs, and tested before you save rather than after. Connection tests
-> still report the same `kind`, `detail` and `remedy` the tools do, rather than a
-> red cross you then have to investigate. The writes from 0.5 and the
-> correlation from 0.4 are unchanged underneath.
+> No service in this stack can tell you a series' IMDb rating: Radarr returns a
+> per-source map, Sonarr returns one unlabelled number. Switch on IMDb's daily
+> dataset and every film and series gets one — including things you do not own
+> yet, so you can check a rating before deciding to add it. `get_library` gains
+> `sort`, because *"which unwatched series is best rated"* is a superlative and
+> a filter alone cannot answer one. Everything from 0.7 and earlier — many
+> instances read as one library, the writes, the correlation — is unchanged
+> underneath.
 > See [the roadmap](#roadmap).
 
 ## Services
@@ -69,10 +70,12 @@ one service can never silently hide another. `diagnose` takes a title, or an
 exact `service` plus `id`, and returns a verdict rather than a list — see
 below.
 
-`get_library`'s `quality` filter and its per-source rating filters are films
-only — a series has no series-level quality, and Sonarr carries one flat
-TVDB rating rather than per-source scores. Asking either of series returns a
-refusal explaining why, not an empty list.
+`get_library`'s `quality` filter is films only — a series has no series-level
+quality. Its rating filters are mostly films only too, because Sonarr carries
+one flat TVDB rating rather than per-source scores; the exception is `imdb`,
+which the [IMDb dataset](#imdb-ratings) supplies for series as well. Asking for
+a combination that cannot exist returns a refusal explaining why, not an empty
+list.
 
 The first thirteen are reads. The last six write, and are gated as described
 under [Writes](#writes) — off by default, previewed before they act, recorded
@@ -351,6 +354,54 @@ Only Radarr, Sonarr and Bazarr take a list. The other five are one each:
 Prowlarr feeds every *arr from one place, Seerr connects to your instances
 itself, and a second download client is a different kind of setup from a quality
 tier.
+
+### IMDb ratings
+
+Ratings across this stack are inconsistent, and for series they are absent.
+Radarr returns a per-source map, so a film can carry IMDb, TMDB, Rotten
+Tomatoes and Metacritic scores at once. Sonarr returns a single unlabelled
+number, which arr-mcp can only honestly record as TVDB's — so **no service here
+can tell you a series' IMDb rating**, and asking `get_library` for one used to
+be refused outright.
+
+Switching on IMDb's daily dataset fixes that:
+
+```yaml
+metadata:
+  imdb:
+    enabled: true
+```
+
+No account, no API key, nothing sent anywhere. Your container downloads three
+of IMDb's published files each day and keeps them in a local SQLite database
+beside the audit log. Films and series both get a rating, and so do things you
+do **not** own — `lookup_media` can rate something before you decide to add it.
+
+```
+get_library({ kind: "series", watched: false, rating_source: "imdb",
+              sort: "rating", limit: 10 })
+```
+
+> The ten best-rated series you have not watched.
+
+`sort` arrived with this, because a filter alone cannot answer a superlative:
+with more results than `limit`, the best-rated one may simply not be in the
+window returned, and an answer drawn from an arbitrary fifty looks exactly like
+a right one. Ordering happens before the limit is applied. Items the chosen
+source has no rating for are excluded rather than ranked as zero, and
+`ratingCoverage` says how many were set aside — a title nobody has rated is not
+a bad title.
+
+Two honest limits. The dataset keys on IMDb ids, and Radarr leads with TMDB
+ids, so titles carrying no IMDb id are never matched — they come back unrated,
+and counted. And the first ingest takes a while on a NAS; everything answers
+exactly as it did before until it lands, and the dashboard says when it has
+finished.
+
+`discover_media` also falls back to the dataset when Seerr is not configured,
+where it previously returned nothing. Seerr still answers whenever it is
+present — it knows what is trending and requestable, which a static catalogue
+does not.
 
 ## Config UI
 

--- a/src/config/save.ts
+++ b/src/config/save.ts
@@ -49,6 +49,15 @@ export async function saveConfig(configDir: string, next: Config): Promise<void>
     // then reject on the next start.
     doc.setIn(['services'], value.services);
 
+    // Deleted when absent rather than written as null, for the same reason as
+    // `password_hash` above: the schema is strict, and `metadata: null` would
+    // fail to parse on the next start — turning a save into an instance that
+    // will not boot. Until 0.8 this key was preserved only because nothing
+    // here touched it, which held right up until the config page could switch
+    // the dataset on.
+    if (value.metadata === undefined) doc.deleteIn(['metadata']);
+    else doc.setIn(['metadata'], value.metadata);
+
     const tmp = `${path}.tmp`;
     // 0o600 on the temp file too — it holds the same secrets for the moment it
     // exists, and a default-umask temp file is a readable one.

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -194,6 +194,29 @@ const ServicesSchema = z
     })
     .default({});
 
+/**
+ * Metadata sources that are not services (0.8 spec §3).
+ *
+ * Separate from `services` because nothing here is reachable, has a URL, or
+ * can be tested — an instance card would have nothing to put on it. It also
+ * holds no credential, so the no-echo rule that shapes the rest of the config
+ * page does not reach it.
+ *
+ * `.strict()` on both levels, and the reason is the same in each. The setting
+ * a user is most likely to invent is a refresh interval, and IMDb publishes
+ * daily — there is no second answer to choose between. A knob whose only
+ * sensible value is the default exists to be got wrong, and quietly ignoring
+ * one that was set is worse than refusing it: the user believes it took
+ * effect.
+ */
+export const MetadataSchema = z
+    .object({
+        imdb: z.object({ enabled: z.boolean().default(false) }).strict().optional()
+    })
+    .strict();
+
+export type MetadataConfig = z.infer<typeof MetadataSchema>;
+
 export const ConfigSchema = z.object({
     // Required, not optional: loadConfig always injects a generated token
     // before parsing, so the only way this is missing is a hand-edited file
@@ -226,6 +249,8 @@ export const ConfigSchema = z.object({
          */
         allowed_hosts: z.array(z.string()).default([])
     }),
-    services: ServicesSchema
+    services: ServicesSchema,
+    /** Absent means off, exactly like a service nobody configured. */
+    metadata: MetadataSchema.optional()
 });
 export type Config = z.infer<typeof ConfigSchema>;

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -1,5 +1,6 @@
 import { loadConfig } from '../config/load.ts';
 import type { Config } from '../config/schema.ts';
+import { IMDB_FILENAME, ImdbDataset } from '../metadata/imdbDataset.ts';
 import { buildAdapters } from '../services/registry.ts';
 import type { ServiceAdapter } from '../services/types.ts';
 import { buildToolContext, type ToolContext } from '../tools/register.ts';
@@ -30,6 +31,13 @@ export type RuntimeSnapshot = {
     tools: ToolContext;
 };
 
+/**
+ * What `fromConfig` uses when a test gives it no directory: a runtime that
+ * cannot reload, and must not write anything beside a config file it does not
+ * have.
+ */
+const NO_CONFIG_DIR = '';
+
 export class Runtime {
     #snapshot: RuntimeSnapshot;
     readonly #configDir: string;
@@ -48,12 +56,58 @@ export class Runtime {
     readonly confirm: ConfirmTokens;
     readonly sessions: Sessions;
 
+    /**
+     * The IMDb dataset, when `metadata.imdb.enabled` is on.
+     *
+     * Outside the snapshot for the same reason as the two above, and a
+     * stronger one: it is a database that can take twenty minutes to build,
+     * and rebuilding it because someone changed a timeout would be absurd. A
+     * reload only opens or closes it when the config's answer actually
+     * changed.
+     *
+     * Opening is all this class does. Keeping it *fresh* is `startRefresh`,
+     * which the entry point calls — so constructing a Runtime never reaches
+     * the network, and no test has to opt out of a download it did not ask
+     * for.
+     */
+    #dataset: ImdbDataset | undefined;
+
+    get dataset(): ImdbDataset | undefined {
+        return this.#dataset;
+    }
+
     private constructor(configDir: string, audit: WriteAudit, config: Config) {
         this.#configDir = configDir;
         this.#audit = audit;
         this.confirm = new ConfirmTokens();
         this.sessions = new Sessions();
         this.#snapshot = buildSnapshot(config, audit, this.confirm);
+        this.#syncDataset(config);
+    }
+
+    /**
+     * Open or close the dataset to match the config, and do nothing at all
+     * when the answer has not changed — which is the common case on reload.
+     *
+     * `ImdbDataset.open` touches the filesystem, so it is skipped entirely
+     * when there is no real config directory: `fromConfig`'s default is a
+     * placeholder, and a test that never asked for a dataset must not have one
+     * written beside it.
+     */
+    #syncDataset(config: Config): void {
+        const wanted = config.metadata?.imdb?.enabled === true && this.#configDir !== NO_CONFIG_DIR;
+
+        if (wanted && this.#dataset === undefined) {
+            this.#dataset = ImdbDataset.open(this.#configDir);
+            logger.info({ file: IMDB_FILENAME }, 'IMDb dataset opened');
+            return;
+        }
+
+        if (!wanted && this.#dataset !== undefined) {
+            this.#dataset.close();
+            this.#dataset = undefined;
+            logger.info('IMDb dataset closed — no longer enabled');
+        }
     }
 
     static async start(configDir: string, audit: WriteAudit): Promise<{ runtime: Runtime; created: boolean }> {
@@ -79,7 +133,7 @@ export class Runtime {
         audit: WriteAudit,
         opts: { configDir?: string; adapters?: readonly ServiceAdapter[] } = {}
     ): Runtime {
-        const runtime = new Runtime(opts.configDir ?? '', audit, config);
+        const runtime = new Runtime(opts.configDir ?? NO_CONFIG_DIR, audit, config);
         if (opts.adapters !== undefined) {
             runtime.#snapshot = {
                 config,
@@ -114,6 +168,7 @@ export class Runtime {
     async reload(): Promise<void> {
         const { config } = await loadConfig(this.#configDir);
         this.#snapshot = buildSnapshot(config, this.#audit, this.confirm);
+        this.#syncDataset(config);
         logger.info({ services: this.#snapshot.adapters.map(a => a.id) }, 'configuration reloaded');
     }
 

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -81,8 +81,10 @@ export class Runtime {
         this.#audit = audit;
         this.confirm = new ConfirmTokens();
         this.sessions = new Sessions();
-        this.#snapshot = buildSnapshot(config, audit, this.confirm);
+        // Before the snapshot, not after: the tool context closes over the
+        // dataset, so it has to exist by the time it is built.
         this.#syncDataset(config);
+        this.#snapshot = buildSnapshot(config, audit, this.confirm, this.#dataset);
     }
 
     /**
@@ -138,7 +140,7 @@ export class Runtime {
             runtime.#snapshot = {
                 config,
                 adapters: opts.adapters,
-                tools: buildToolContext(opts.adapters, config, audit, runtime.confirm)
+                tools: buildToolContext(opts.adapters, config, audit, runtime.confirm, runtime.dataset)
             };
         }
         return runtime;
@@ -167,14 +169,19 @@ export class Runtime {
      */
     async reload(): Promise<void> {
         const { config } = await loadConfig(this.#configDir);
-        this.#snapshot = buildSnapshot(config, this.#audit, this.confirm);
         this.#syncDataset(config);
+        this.#snapshot = buildSnapshot(config, this.#audit, this.confirm, this.#dataset);
         logger.info({ services: this.#snapshot.adapters.map(a => a.id) }, 'configuration reloaded');
     }
 
 }
 
-function buildSnapshot(config: Config, audit: WriteAudit, confirm: ConfirmTokens): RuntimeSnapshot {
+function buildSnapshot(
+    config: Config,
+    audit: WriteAudit,
+    confirm: ConfirmTokens,
+    dataset: ImdbDataset | undefined
+): RuntimeSnapshot {
     const adapters = buildAdapters(config);
-    return { config, adapters, tools: buildToolContext(adapters, config, audit, confirm) };
+    return { config, adapters, tools: buildToolContext(adapters, config, audit, confirm, dataset) };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { attachLogStore } from './core/logger.ts';
 import { logger } from './core/logger.ts';
 import { LogStore } from './core/logs.ts';
 import { Runtime } from './core/runtime.ts';
+import { startRefresh } from './metadata/refresh.ts';
 
 const CONFIG_DIR = process.env.ARR_MCP_CONFIG_DIR ?? '/config';
 const PORT = Number(process.env.ARR_MCP_PORT ?? 6060);
@@ -35,6 +36,15 @@ if (runtime.config.auth.password_hash === undefined) {
         { config: `${CONFIG_DIR}/config.yaml` },
         'no services configured — add them in the config UI, or edit config.yaml'
     );
+}
+
+// Deliberately not awaited. The first ingest downloads and parses on the order
+// of 10^7 rows, which on a NAS is minutes — and every tool answers exactly as
+// it did before until it lands, so blocking here would turn a slow cache warm
+// into a container that looks broken.
+if (runtime.dataset !== undefined) {
+    logger.info('IMDb dataset enabled — refreshing in the background; ratings appear once the first ingest finishes');
+    startRefresh(runtime.dataset);
 }
 
 serve({ fetch: buildApp({ runtime, audit, logs }).fetch, port: PORT, hostname: '0.0.0.0' }, info => {

--- a/src/metadata/enrich.ts
+++ b/src/metadata/enrich.ts
@@ -1,0 +1,69 @@
+import type { ImdbDataset } from './imdbDataset.ts';
+
+/**
+ * Filling IMDb ratings from the dataset (0.8 spec §4.1).
+ *
+ * Here rather than in `src/tools/` so nothing in the tool layer imports the
+ * store: `LibraryLoader` takes one function, not a database.
+ *
+ * **Never overwrites.** A service is the authority on its own data; the
+ * dataset fills gaps. An item with no IMDb id, or one the dataset does not
+ * know, comes back untouched and is counted as unrated downstream — a miss
+ * must never become a zero, which would rank an unknown title below one
+ * genuinely rated 1.0.
+ *
+ * **One batched query per page**, not one per item: enriching a 900-film
+ * library item by item is 900 statements for something SQLite answers in one.
+ */
+
+/**
+ * Everything this can fill, described by the two fields it actually needs.
+ *
+ * Structural rather than a union of the three named types, because they
+ * genuinely differ elsewhere: `MergedItem.ratings` is `MergedRatings`, while
+ * `SearchHit.ratings` and `MediaDetails.ratings` are `Record<string, number>`,
+ * and `IndexInput` is a `MergedItem` without `presence`. All four agree on the
+ * only part that matters here — an optional imdb id and an optional imdb
+ * rating — so one constraint covers them without asserting anything false
+ * about any of them.
+ */
+type Rateable = {
+    ids: { imdb?: string | undefined };
+    ratings?: { imdb?: number | undefined } | undefined;
+};
+
+/**
+ * Fill `ratings.imdb` wherever the dataset can and a service has not.
+ *
+ * For a series this is the only path that can populate it at all. Radarr
+ * returns a per-source ratings map, but Sonarr returns one flat value that
+ * `flattenSeriesRating` can only honestly record as `tvdb` — so before this,
+ * `MergedRatings.imdb` was unreachable for half the library.
+ *
+ * Returns the array it was given, unchanged and by identity, when there is
+ * nothing to do: no dataset, nothing joinable, or nothing found.
+ */
+export function enrichWithImdb<T extends Rateable>(items: T[], dataset: ImdbDataset | undefined): T[] {
+    if (dataset === undefined) return items;
+
+    const wanted: string[] = [];
+    for (const item of items) {
+        if (item.ids.imdb !== undefined && item.ratings?.imdb === undefined) wanted.push(item.ids.imdb);
+    }
+    if (wanted.length === 0) return items;
+
+    const found = dataset.ratingsFor(wanted);
+    if (found.size === 0) return items;
+
+    return items.map(item => {
+        if (item.ids.imdb === undefined || item.ratings?.imdb !== undefined) return item;
+
+        const rating = found.get(item.ids.imdb);
+        if (rating === undefined) return item;
+
+        // Copied, never mutated: `LibraryIndex` holds the same objects in both
+        // `all()` and its key map, and a caller that kept a reference must not
+        // see it change under them.
+        return { ...item, ratings: { ...item.ratings, imdb: rating } };
+    });
+}

--- a/src/metadata/imdbDataset.ts
+++ b/src/metadata/imdbDataset.ts
@@ -1,0 +1,273 @@
+import Database from 'better-sqlite3';
+import type { Database as Db } from 'better-sqlite3';
+import { join } from 'node:path';
+
+/**
+ * The IMDb dataset (0.8 spec §2), as a third SQLite database beside
+ * `audit.db` and `logs.db`.
+ *
+ * Its own file, and its own module, for the reason those two are separate
+ * from each other: three different retention stories. Write records survive
+ * forever, log lines are a ring buffer, and this is a cache that is wholly
+ * replaced every day and can be deleted at any moment without losing anything
+ * a user typed. Losing it costs a download, not data.
+ *
+ * **Nothing here touches the network.** Downloading lives in `refresh.ts` and
+ * parsing in `ingest.ts`, which is what lets every test of this file run
+ * against a real database in memory with no fixture server — the thing worth
+ * testing here is the SQL, and the SQL does not care where rows came from.
+ */
+
+export const IMDB_FILENAME = 'imdb.db';
+
+/**
+ * IMDb's title types, mapped onto the vocabulary the tools already speak.
+ *
+ * `tvMovie` counts as a film and `tvMiniSeries` as a series because that is
+ * how the *arrs treat them — a mini-series lives in Sonarr. Everything else
+ * IMDb publishes (shorts, video games, episodes as standalone rows) is
+ * deliberately unreachable: none of it is anything this stack manages, and
+ * offering it in discovery would return results nothing could then act on.
+ */
+const KIND_TO_IMDB: Record<'movie' | 'series', readonly string[]> = {
+    movie: ['movie', 'tvMovie'],
+    series: ['tvSeries', 'tvMiniSeries']
+};
+
+/**
+ * SQLite's compiled-in default variable limit, minus room to spare.
+ *
+ * A library larger than this cannot go into one `IN (...)`, and a 900-film
+ * library is ordinary — so the naive version fails on exactly the libraries
+ * this feature is most useful for.
+ */
+const VARIABLE_LIMIT = 900;
+
+export type RawTitle = {
+    tconst: string;
+    kind: string;
+    title: string;
+    year?: number | undefined;
+    runtime?: number | undefined;
+    genres?: string | undefined;
+};
+
+export type RawRating = { tconst: string; average: number; votes: number };
+
+export type RawEpisode = {
+    tconst: string;
+    parent: string;
+    season?: number | undefined;
+    episode?: number | undefined;
+};
+
+export type DatasetTitle = {
+    tconst: string;
+    title: string;
+    year?: number;
+    runtime?: number;
+    genres: string[];
+    rating?: number;
+    votes?: number;
+};
+
+export type DatasetStatus = { ingestedAt?: string; titles: number; ratings: number };
+
+const SCHEMA = `
+CREATE TABLE IF NOT EXISTS title (
+    tconst  TEXT PRIMARY KEY,
+    kind    TEXT    NOT NULL,
+    title   TEXT    NOT NULL,
+    year    INTEGER,
+    runtime INTEGER,
+    genres  TEXT
+);
+CREATE TABLE IF NOT EXISTS rating (
+    tconst  TEXT PRIMARY KEY,
+    average REAL    NOT NULL,
+    votes   INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS episode (
+    tconst  TEXT PRIMARY KEY,
+    parent  TEXT    NOT NULL,
+    season  INTEGER,
+    episode INTEGER
+);
+CREATE TABLE IF NOT EXISTS meta (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS episode_parent ON episode(parent);
+CREATE INDEX IF NOT EXISTS title_kind ON title(kind);
+`;
+
+export class ImdbDataset {
+    readonly #db: Db;
+
+    private constructor(db: Db) {
+        this.#db = db;
+        // WAL for the reason audit.ts uses it: the daily ingest writes while
+        // tool calls read, and a reader must never block on a twenty-minute
+        // rebuild.
+        this.#db.pragma('journal_mode = WAL');
+        this.#db.exec(SCHEMA);
+    }
+
+    static open(dir: string): ImdbDataset {
+        return new ImdbDataset(new Database(join(dir, IMDB_FILENAME)));
+    }
+
+    /** For tests: a real database, no file. */
+    static ephemeral(): ImdbDataset {
+        return new ImdbDataset(new Database(':memory:'));
+    }
+
+    close(): void {
+        this.#db.close();
+    }
+
+    /**
+     * Ratings for the tconsts asked for, and **only** those it holds one for.
+     *
+     * A miss is an absent key, never a zero. The caller counts misses as
+     * unrated, and a zero would rank a title IMDb has never heard of below one
+     * genuinely rated 1.0 — which is the difference between "we could not look
+     * this up" and "this is terrible".
+     */
+    ratingsFor(tconsts: readonly string[]): Map<string, number> {
+        const found = new Map<string, number>();
+        if (tconsts.length === 0) return found;
+
+        for (let i = 0; i < tconsts.length; i += VARIABLE_LIMIT) {
+            const chunk = tconsts.slice(i, i + VARIABLE_LIMIT);
+            const rows = this.#db
+                .prepare(`SELECT tconst, average FROM rating WHERE tconst IN (${chunk.map(() => '?').join(',')})`)
+                .all(...chunk) as { tconst: string; average: number }[];
+
+            for (const row of rows) found.set(row.tconst, row.average);
+        }
+
+        return found;
+    }
+
+    discover(q: {
+        kind: 'movie' | 'series';
+        genre?: string | undefined;
+        year?: number | undefined;
+        minRating?: number | undefined;
+        limit: number;
+    }): DatasetTitle[] {
+        const kinds = KIND_TO_IMDB[q.kind];
+        const where: string[] = [`t.kind IN (${kinds.map(() => '?').join(',')})`];
+        const args: (string | number)[] = [...kinds];
+
+        if (q.genre !== undefined) {
+            // Genres ship as one comma-separated string. The commas on both
+            // sides of the pattern are what stop "Drama" matching "Docudrama".
+            where.push(`(',' || LOWER(t.genres) || ',') LIKE ?`);
+            args.push(`%,${q.genre.toLowerCase()},%`);
+        }
+        if (q.year !== undefined) {
+            where.push('t.year = ?');
+            args.push(q.year);
+        }
+        if (q.minRating !== undefined) {
+            where.push('r.average >= ?');
+            args.push(q.minRating);
+        }
+
+        // INNER JOIN only when a rating is required: an unrated title cannot
+        // satisfy a minimum, but is a perfectly good answer without one.
+        const joinType = q.minRating === undefined ? 'LEFT JOIN' : 'JOIN';
+        args.push(q.limit);
+
+        const rows = this.#db
+            .prepare(
+                `SELECT t.tconst, t.title, t.year, t.runtime, t.genres, r.average, r.votes
+                   FROM title t ${joinType} rating r ON r.tconst = t.tconst
+                  WHERE ${where.join(' AND ')}
+               ORDER BY CASE WHEN r.average IS NULL THEN 1 ELSE 0 END, r.average DESC, t.year DESC
+                  LIMIT ?`
+            )
+            .all(...args) as {
+            tconst: string;
+            title: string;
+            year: number | null;
+            runtime: number | null;
+            genres: string | null;
+            average: number | null;
+            votes: number | null;
+        }[];
+
+        return rows.map(row => ({
+            tconst: row.tconst,
+            title: row.title,
+            ...(row.year === null ? {} : { year: row.year }),
+            ...(row.runtime === null ? {} : { runtime: row.runtime }),
+            genres: row.genres === null || row.genres === '' ? [] : row.genres.split(','),
+            ...(row.average === null ? {} : { rating: row.average }),
+            ...(row.votes === null ? {} : { votes: row.votes })
+        }));
+    }
+
+    /** What the dashboard needs to say whether this is working. */
+    status(): DatasetStatus {
+        const count = (table: string): number =>
+            (this.#db.prepare(`SELECT COUNT(*) AS n FROM ${table}`).get() as { n: number }).n;
+
+        const at = this.#db.prepare('SELECT value FROM meta WHERE key = ?').get('ingested_at') as
+            | { value: string }
+            | undefined;
+
+        return {
+            ...(at === undefined ? {} : { ingestedAt: at.value }),
+            titles: count('title'),
+            ratings: count('rating')
+        };
+    }
+
+    /**
+     * Replace the whole dataset in one transaction.
+     *
+     * A replace rather than a merge because the dumps are full daily
+     * snapshots — merging would accumulate titles IMDb has since withdrawn.
+     * One transaction because a half-applied replace is a dataset that answers
+     * confidently from a mixture of two days, and because it is what makes a
+     * download dying halfway leave yesterday's good data in place rather than
+     * a partial one nobody can tell is partial.
+     *
+     * The rows arrive as iterables and are consumed lazily inside the
+     * transaction: `title.basics` is on the order of 10⁷ rows, and this runs
+     * on a NAS.
+     */
+    replaceAll(rows: {
+        titles: Iterable<RawTitle>;
+        ratings: Iterable<RawRating>;
+        episodes: Iterable<RawEpisode>;
+    }): void {
+        const insertTitle = this.#db.prepare(
+            'INSERT OR REPLACE INTO title (tconst, kind, title, year, runtime, genres) VALUES (?, ?, ?, ?, ?, ?)'
+        );
+        const insertRating = this.#db.prepare(
+            'INSERT OR REPLACE INTO rating (tconst, average, votes) VALUES (?, ?, ?)'
+        );
+        const insertEpisode = this.#db.prepare(
+            'INSERT OR REPLACE INTO episode (tconst, parent, season, episode) VALUES (?, ?, ?, ?)'
+        );
+        const setMeta = this.#db.prepare('INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)');
+
+        this.#db.transaction(() => {
+            this.#db.exec('DELETE FROM title; DELETE FROM rating; DELETE FROM episode;');
+
+            for (const t of rows.titles) {
+                insertTitle.run(t.tconst, t.kind, t.title, t.year ?? null, t.runtime ?? null, t.genres ?? null);
+            }
+            for (const r of rows.ratings) insertRating.run(r.tconst, r.average, r.votes);
+            for (const e of rows.episodes) {
+                insertEpisode.run(e.tconst, e.parent, e.season ?? null, e.episode ?? null);
+            }
+
+            setMeta.run('ingested_at', new Date().toISOString());
+        })();
+    }
+}

--- a/src/metadata/ingest.ts
+++ b/src/metadata/ingest.ts
@@ -1,0 +1,111 @@
+import type { RawEpisode, RawRating, RawTitle } from './imdbDataset.ts';
+
+/**
+ * IMDb's dumps into rows (0.8 spec §1).
+ *
+ * **Generators, not arrays.** `title.basics` is on the order of 10⁷ rows, and
+ * materialising it costs a multiple of its own size in heap on a machine that
+ * is usually a NAS. `replaceAll` consumes these lazily inside one transaction,
+ * so peak memory is a row rather than a file.
+ *
+ * **No CSV library.** These are tab separated with no quoting and no escaping —
+ * the format guarantees a tab never appears inside a field — so `split` is both
+ * correct and far faster than a parser that has to consider quotes it will
+ * never meet.
+ */
+
+/** IMDb writes an absent value as this, in every column of every file. */
+export const NULL_MARKER = '\\N';
+
+const value = (raw: string | undefined): string | undefined =>
+    raw === undefined || raw === '' || raw === NULL_MARKER ? undefined : raw;
+
+/**
+ * A numeric column, or nothing.
+ *
+ * A non-numeric year is corrupt input, not a zero. Dropping the field keeps
+ * the row usable; coercing would assert something false about the title, and
+ * `Number('')` being `0` is exactly how that happens by accident.
+ */
+const number = (raw: string | undefined): number | undefined => {
+    const text = value(raw);
+    if (text === undefined) return undefined;
+    const parsed = Number(text);
+    return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+/**
+ * Every dump split the same way, header dropped.
+ *
+ * The header goes by **position**, not by matching the literal string
+ * `tconst`: content matching would silently start ingesting the header as data
+ * the day IMDb capitalises a column name.
+ */
+function* rows(lines: Iterable<string>): Generator<string[]> {
+    let first = true;
+
+    for (const line of lines) {
+        if (first) {
+            first = false;
+            continue;
+        }
+        if (line === '') continue;
+        yield line.split('\t');
+    }
+}
+
+/** `tconst titleType primaryTitle originalTitle isAdult startYear endYear runtimeMinutes genres` */
+export function* parseTitles(lines: Iterable<string>): Generator<RawTitle> {
+    for (const cols of rows(lines)) {
+        const tconst = value(cols[0]);
+        const kind = value(cols[1]);
+        const title = value(cols[2]);
+        // A row with no id, type or title cannot be matched, shown or ranked.
+        // Dropping it beats carrying a nameless entry into the library join.
+        if (tconst === undefined || kind === undefined || title === undefined) continue;
+
+        const year = number(cols[5]);
+        const runtime = number(cols[7]);
+        const genres = value(cols[8]);
+
+        yield {
+            tconst,
+            kind,
+            title,
+            ...(year === undefined ? {} : { year }),
+            ...(runtime === undefined ? {} : { runtime }),
+            ...(genres === undefined ? {} : { genres })
+        };
+    }
+}
+
+/** `tconst averageRating numVotes` */
+export function* parseRatings(lines: Iterable<string>): Generator<RawRating> {
+    for (const cols of rows(lines)) {
+        const tconst = value(cols[0]);
+        const average = number(cols[1]);
+        const votes = number(cols[2]);
+        if (tconst === undefined || average === undefined || votes === undefined) continue;
+
+        yield { tconst, average, votes };
+    }
+}
+
+/** `tconst parentTconst seasonNumber episodeNumber` */
+export function* parseEpisodes(lines: Iterable<string>): Generator<RawEpisode> {
+    for (const cols of rows(lines)) {
+        const tconst = value(cols[0]);
+        const parent = value(cols[1]);
+        if (tconst === undefined || parent === undefined) continue;
+
+        const season = number(cols[2]);
+        const episode = number(cols[3]);
+
+        yield {
+            tconst,
+            parent,
+            ...(season === undefined ? {} : { season }),
+            ...(episode === undefined ? {} : { episode })
+        };
+    }
+}

--- a/src/metadata/refresh.ts
+++ b/src/metadata/refresh.ts
@@ -1,0 +1,94 @@
+import { createInterface } from 'node:readline';
+import { Readable } from 'node:stream';
+import { createGunzip } from 'node:zlib';
+import { logger } from '../core/logger.ts';
+import type { ImdbDataset } from './imdbDataset.ts';
+import { parseEpisodes, parseRatings, parseTitles } from './ingest.ts';
+
+/**
+ * Fetching the dumps, and the daily schedule (0.8 spec §2).
+ *
+ * The only file in `src/metadata/` that touches the network, which is what
+ * lets the store and the parser be tested without one.
+ */
+
+export const IMDB_BASE_URL = 'https://datasets.imdbws.com';
+
+/** IMDb publishes daily. Spec §3 explains why this is not configurable: there
+ *  is no second sensible value, and a knob with one answer invites a wrong one. */
+export const REFRESH_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+/** Download one dump and yield its lines, decompressed. */
+async function* download(baseUrl: string, file: string): AsyncGenerator<string> {
+    const res = await fetch(`${baseUrl}/${file}`);
+    if (!res.ok || res.body === null) {
+        // Names the file: "HTTP 404" alone would not say which of the three,
+        // and they fail independently.
+        throw new Error(`could not fetch ${file}: HTTP ${res.status}`);
+    }
+
+    // Streamed rather than buffered — title.basics is on the order of 10⁷ rows
+    // and this runs on a NAS.
+    const body = Readable.fromWeb(res.body as Parameters<typeof Readable.fromWeb>[0]);
+    const lines = createInterface({ input: body.pipe(createGunzip()), crlfDelay: Infinity });
+
+    for await (const line of lines) yield line;
+}
+
+/**
+ * Fetch all three dumps, **then** replace.
+ *
+ * Buffering the parsed rows costs memory and is still the right trade: the
+ * failure it prevents is a download dying between file one and file three,
+ * leaving today's titles standing against yesterday's ratings. `replaceAll`
+ * is one transaction, so nothing is visible until all three arrived intact.
+ */
+export async function ingestOnce(dataset: ImdbDataset, opts: { baseUrl?: string } = {}): Promise<void> {
+    const baseUrl = opts.baseUrl ?? IMDB_BASE_URL;
+    const started = Date.now();
+
+    const collect = async <T>(file: string, parse: (lines: Iterable<string>) => Generator<T>): Promise<T[]> => {
+        const raw: string[] = [];
+        for await (const line of download(baseUrl, file)) raw.push(line);
+        return [...parse(raw)];
+    };
+
+    const titles = await collect('title.basics.tsv.gz', parseTitles);
+    const ratings = await collect('title.ratings.tsv.gz', parseRatings);
+    const episodes = await collect('title.episode.tsv.gz', parseEpisodes);
+
+    dataset.replaceAll({ titles, ratings, episodes });
+
+    logger.info(
+        { titles: titles.length, ratings: ratings.length, episodes: episodes.length, ms: Date.now() - started },
+        'IMDb dataset ingested'
+    );
+}
+
+/**
+ * Start the daily refresh, and return a function that stops it.
+ *
+ * **Startup never awaits this.** A first run that takes twenty minutes is
+ * twenty minutes of normal service, not twenty minutes of a container that
+ * looks broken — every tool answers exactly as it did before until the first
+ * ingest lands.
+ */
+export function startRefresh(dataset: ImdbDataset, opts: { baseUrl?: string } = {}): () => void {
+    const run = (): void => {
+        ingestOnce(dataset, opts).catch((err: unknown) => {
+            // A failed refresh keeps the previous dataset, so this is a
+            // degraded answer rather than an outage. It warns instead of
+            // becoming an unhandled rejection that would take the process
+            // down over a transient 503.
+            logger.warn({ err }, 'IMDb dataset refresh failed; keeping the previous one');
+        });
+    };
+
+    run();
+
+    const timer = setInterval(run, REFRESH_INTERVAL_MS);
+    // Unreffed so a pending refresh never holds the process open at shutdown.
+    timer.unref();
+
+    return () => clearInterval(timer);
+}

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -272,6 +272,17 @@ export type SearchHit = {
     title: string;
     year?: number;
     ids: { tmdb?: number; tvdb?: number; imdb?: string };
+    /**
+     * Ratings by source, on each source's native scale — the same shape and
+     * the same convention as `MediaDetails.ratings`, which this is the
+     * not-yet-owned counterpart to.
+     *
+     * Nothing an *arr's lookup endpoint returns populates this: their search
+     * payloads are shaped for *adding* a title, not describing one. It exists
+     * for the IMDb dataset (0.8 §4.1), which fills it for a hit carrying an
+     * imdb id.
+     */
+    ratings?: Record<string, number>;
     hasFile?: boolean;
     monitored?: boolean;
     indexer?: string;

--- a/src/tools/discoverMedia.ts
+++ b/src/tools/discoverMedia.ts
@@ -3,6 +3,9 @@ import * as z from 'zod/v4';
 import { logger } from '../core/logger.ts';
 import { DetailSchema, LimitSchema, applyLimit, type DetailLevel } from '../core/shape.ts';
 import type { SeerrAdapter } from '../services/seerr.ts';
+import { fenceText } from '../core/fence.ts';
+import { enrichWithImdb } from '../metadata/enrich.ts';
+import type { ImdbDataset } from '../metadata/imdbDataset.ts';
 import type { SearchHit } from '../services/types.ts';
 import type { GetSearchResult } from './searchMedia.ts';
 
@@ -22,10 +25,15 @@ export async function buildDiscoverMedia(
         minRating?: number;
         detail: DetailLevel;
         limit: number;
-    }
+    },
+    dataset?: ImdbDataset | undefined
 ): Promise<GetSearchResult> {
     if (adapter === undefined) {
-        return { items: [], total: 0, returned: 0, truncated: false, degraded: [], counts: {} };
+        // Without Seerr this used to return an empty result, which reads as
+        // "nothing matched" rather than "nobody could answer". The IMDb
+        // dataset can answer it: genre, year and a minimum rating are a join
+        // over two of its tables.
+        return fromDataset(opts, dataset);
     }
 
     let hits: SearchHit[];
@@ -41,21 +49,88 @@ export async function buildDiscoverMedia(
         return { items: [], total: 0, returned: 0, truncated: false, degraded: [adapter.id], counts: {} };
     }
 
+    // Enrichment applies whatever the source (§4.1). Seerr's discover is
+    // TMDB-backed, so a hit carrying an imdb id gains an IMDb rating beside
+    // the TMDB one it already had — source selection and enrichment are
+    // independent decisions.
     const shaped = applyLimit(hits, opts.limit);
+    const rated = enrichWithImdb(shaped.items, dataset);
+
     return {
         ...shaped,
-        items: shaped.items.map(h => project(h, opts.detail)),
+        items: rated.map(h => project(h, opts.detail)),
         degraded: [],
         counts: { seerr: hits.length }
     };
 }
 
-export function registerDiscoverMedia(server: McpServer, adapter: SeerrAdapter | undefined): void {
+/**
+ * Discovery from the local dataset, for a stack with no Seerr.
+ *
+ * **Seerr wins whenever it is configured** (spec §4.2). It knows what is
+ * trending, what is requestable and what you have already asked for; the
+ * dataset knows a year column. Merging two orderings that mean different
+ * things would produce a ranking that means neither.
+ *
+ * One deliberate difference the caller has to know about: `genre` is a TMDB
+ * genre *id* for Seerr and a genre *name* here, because that is what each
+ * source actually holds. A numeric id would match no IMDb genre, so it is
+ * rejected rather than silently returning nothing.
+ */
+function fromDataset(
+    opts: { mediaType: 'movie' | 'tv'; genre?: string; year?: number; minRating?: number; detail: DetailLevel; limit: number },
+    dataset: ImdbDataset | undefined
+): GetSearchResult {
+    const empty = { items: [], total: 0, returned: 0, truncated: false, degraded: [], counts: {} };
+    if (dataset === undefined) return empty;
+
+    if (opts.genre !== undefined && /^\d+$/.test(opts.genre)) {
+        throw new Error(
+            `genre "${opts.genre}" is a TMDB id, which only Seerr understands. Seerr is not configured, so discovery is answered from the IMDb dataset — pass a genre name such as "Crime" instead.`
+        );
+    }
+
+    const hits = dataset
+        .discover({
+            kind: opts.mediaType === 'movie' ? 'movie' : 'series',
+            ...(opts.genre === undefined ? {} : { genre: opts.genre }),
+            ...(opts.year === undefined ? {} : { year: opts.year }),
+            ...(opts.minRating === undefined ? {} : { minRating: opts.minRating }),
+            limit: opts.limit
+        })
+        .map(
+            (t): SearchHit => ({
+                service: 'imdb',
+                source: 'discover',
+                kind: opts.mediaType === 'movie' ? 'movie' : 'series',
+                id: t.tconst,
+                // Fenced like every other external string. A dataset row is no
+                // more trusted than an indexer's release name.
+                title: fenceText(t.title, { service: 'imdb', field: 'title' }),
+                ...(t.year === undefined ? {} : { year: t.year }),
+                ids: { imdb: t.tconst },
+                ...(t.rating === undefined ? {} : { ratings: { imdb: t.rating } })
+            })
+        );
+
+    // `discover` already applied the limit in SQL, so `total` is what came
+    // back rather than what exists — the dataset holds ~10^7 titles and
+    // counting the full match set would cost a second query to tell the caller
+    // a number they cannot page through anyway.
+    const shaped = applyLimit(hits, opts.limit);
+    return { ...shaped, items: shaped.items.map(h => project(h, opts.detail)), degraded: [], counts: {} };
+}
+
+export function registerDiscoverMedia(
+    server: McpServer,
+    adapter: SeerrAdapter | undefined,
+    dataset?: ImdbDataset | undefined
+): void {
     server.registerTool(
         'discover_media',
         {
             description:
-                'Browse what exists rather than what you have, through Seerr: films or series by genre, year and minimum rating. TMDB-backed, so the rating is TMDB’s. Nothing is requested or added.',
+                'Browse what exists rather than what you have: films or series by genre, year and minimum rating. Nothing is requested or added. Answered by Seerr when it is configured — TMDB-backed, so `genre` is a TMDB genre id and the rating is TMDB’s. With no Seerr it is answered from the local IMDb dataset instead, where `genre` is a name such as `Crime` and the rating is IMDb’s; passing a numeric id there is refused rather than silently matching nothing.',
             inputSchema: z.object({
                 media_type: z.enum(['movie', 'tv']).default('movie').describe('Films or series.'),
                 genre: z.string().optional().describe('TMDB genre id, e.g. 28 for Action.'),
@@ -73,7 +148,7 @@ export function registerDiscoverMedia(server: McpServer, adapter: SeerrAdapter |
                 ...(min_rating === undefined ? {} : { minRating: min_rating }),
                 detail,
                 limit
-            });
+            }, dataset);
             const summary =
                 result.degraded.length > 0
                     ? 'Seerr could not be reached; nothing to discover.'

--- a/src/tools/getLibrary.ts
+++ b/src/tools/getLibrary.ts
@@ -15,6 +15,20 @@ export type RatingSource = (typeof RATING_SOURCES)[number];
 const FILM_SOURCES: readonly RatingSource[] = ['imdb', 'tmdb', 'trakt', 'metacritic', 'rottenTomatoes'];
 
 /**
+ * What a series can actually carry.
+ *
+ * `tvdb` is Sonarr's own flat value. `imdb` arrives from the IMDb dataset
+ * (0.8 §4.1) and is reachable *only* through it — Sonarr has never reported
+ * one, and `flattenSeriesRating` can only honestly record its single unlabelled
+ * number as `tvdb`. So with the dataset off, asking for `imdb` on a series is
+ * accepted and simply finds nothing rated, which `ratingCoverage` then states.
+ * That is the right shape: "your dataset has not been built yet" is a different
+ * answer from "this filter is impossible", and only the second deserves a
+ * refusal.
+ */
+const SERIES_SOURCES: readonly RatingSource[] = ['tvdb', 'imdb'];
+
+/**
  * The scale each source's raw value arrives on. `min_rating` is documented as
  * 0–10 for every source, but Radarr/Sonarr pass Metacritic and Rotten Tomatoes
  * through on their own site's native 0–100 scale, and nothing upstream of
@@ -76,6 +90,13 @@ const ratingOf = (item: MergedItem, source: RatingSource): number | undefined =>
 /**
  * §5: "whichever source covers the most of the library". Ties break in the
  * declared order, so the same library always answers the same way.
+ *
+ * A series query stays on `tvdb` by default even though the IMDb dataset can
+ * now supply `imdb`, and the reason is compatibility rather than coverage:
+ * changing the default would silently re-scale every saved prompt's
+ * `min_rating` against a different source, which is exactly the kind of quiet
+ * break CONTRIBUTING calls out about the tool surface. `imdb` is one explicit
+ * `rating_source` away.
  */
 function bestCoveredSource(items: readonly MergedItem[], kind: LibraryQuery['kind']): RatingSource {
     if (kind === 'series') return 'tvdb';
@@ -106,9 +127,20 @@ function rejectImpossibleFilters(opts: LibraryQuery): void {
             'quality applies to films only — a series’ quality is per-episode, so a series-level value would be a fiction. Filter get_media_details at detail: full instead.'
         );
     }
-    if (opts.kind === 'series' && opts.rating_source !== undefined && opts.rating_source !== 'tvdb') {
+    // Was: a series may only ask for `tvdb`, because Sonarr's flat value was
+    // the only rating one could carry. The IMDb dataset (0.8) makes `imdb`
+    // reachable for a series too, so the refusal narrows to the sources that
+    // still have no path to one — and gains its mirror image, `tvdb` on a
+    // film, which Radarr never reports and which therefore used to match
+    // nothing at all, silently.
+    if (opts.kind === 'series' && opts.rating_source !== undefined && !SERIES_SOURCES.includes(opts.rating_source)) {
         throw new Error(
-            `rating_source "${opts.rating_source}" applies to films only — Sonarr holds one flat TVDB rating per series. Use rating_source: "tvdb", or drop it.`
+            `rating_source "${opts.rating_source}" applies to films only — a series carries Sonarr's flat TVDB rating, and an IMDb rating when the IMDb dataset is enabled. Use "tvdb" or "imdb", or drop it.`
+        );
+    }
+    if (opts.kind === 'movie' && opts.rating_source === 'tvdb') {
+        throw new Error(
+            'rating_source "tvdb" applies to series only — Radarr does not report a TVDB rating, so this would match nothing. Drop it, or use one of the per-source film ratings.'
         );
     }
 }
@@ -183,7 +215,7 @@ export function registerGetLibrary(server: McpServer, loader: LibraryLoader): vo
         'get_library',
         {
             description:
-                'Your library, joined across Radarr, Sonarr and Jellyfin on shared external ids. `presence` is what no single service can tell you — but only when the absent half’s service actually answered: `arr_only` with a file means Jellyfin *was reachable and* cannot see a file the *arr believes is on disk (a likely broken import); `jellyfin_only` means nothing here is managing it, read the same way — it assumes Radarr/Sonarr answered too, and (unlike `arr_only`) is not yet hedged against their own outage. If Jellyfin is degraded, an item Radarr/Sonarr manages reports `unknown` instead of `arr_only`, and the top-level `degraded` list names it. If Jellyfin is not configured at all, `unknown` fires the same way but `degraded` stays empty — there is nothing to name as degraded — so check whether `jellyfin` even appears in your config instead. Two limits: `quality` applies to films only (a series’ quality is per-episode), and series carry one flat TVDB rating rather than per-source ratings. A rating filter also reports how much of the library that source actually covers.',
+                'Your library, joined across Radarr, Sonarr and Jellyfin on shared external ids. `presence` is what no single service can tell you — but only when the absent half’s service actually answered: `arr_only` with a file means Jellyfin *was reachable and* cannot see a file the *arr believes is on disk (a likely broken import); `jellyfin_only` means nothing here is managing it, read the same way — it assumes Radarr/Sonarr answered too, and (unlike `arr_only`) is not yet hedged against their own outage. If Jellyfin is degraded, an item Radarr/Sonarr manages reports `unknown` instead of `arr_only`, and the top-level `degraded` list names it. If Jellyfin is not configured at all, `unknown` fires the same way but `degraded` stays empty — there is nothing to name as degraded — so check whether `jellyfin` even appears in your config instead. Two limits: `quality` applies to films only (a series’ quality is per-episode), and a series carries Sonarr’s one flat TVDB rating plus an IMDb rating when the IMDb dataset is enabled — `rating_source` still defaults to `tvdb` for a series, so ask for `imdb` explicitly. A rating filter also reports how much of the library that source actually covers.',
             inputSchema: z.object({
                 kind: z.enum(['movie', 'series']).optional().describe('Films or series. Omit for both.'),
                 year: z.number().int().optional(),

--- a/src/tools/getLibrary.ts
+++ b/src/tools/getLibrary.ts
@@ -60,9 +60,22 @@ const RATING_SCALE_MAX: Record<RatingSource, number> = {
  */
 const toTenPointScale = (source: RatingSource, value: number): number => (value / RATING_SCALE_MAX[source]) * 10;
 
+/**
+ * §4.3. A superlative cannot be answered by a filter: with more items than
+ * `limit`, the best-rated may simply not be in the window, and the model then
+ * answers confidently from whatever fifty it was handed.
+ *
+ * `added` is deliberately absent. `MergedItem` carries no added date, and a
+ * sort option that silently does nothing is worse than one that was never
+ * offered — it can be added later as a minor without breaking anything.
+ */
+export const SORT_FIELDS = ['rating', 'year', 'title'] as const;
+export type SortField = (typeof SORT_FIELDS)[number];
+
 export type LibraryQuery = {
     detail: DetailLevel;
     limit: number;
+    sort?: SortField;
     kind?: 'movie' | 'series';
     year?: number;
     genre?: string;
@@ -145,6 +158,31 @@ function rejectImpossibleFilters(opts: LibraryQuery): void {
     }
 }
 
+/**
+ * Ordering, applied **before** `applyLimit` — ordering after truncation is the
+ * same bug wearing a parameter.
+ *
+ * A rating sort assumes unrated items have already been removed by the caller,
+ * which is what `needsRating` below guarantees. They are excluded rather than
+ * ranked as zero: sorted to the bottom, an item nobody has rated is
+ * indistinguishable from one rated 0.4, and `ratingCoverage.unrated` is what
+ * states how many were set aside.
+ *
+ * `localeCompare` rather than `<`, so "Ålesund" sorts where a reader expects
+ * rather than after "Zulu", and `unfenced` because a title reaching here still
+ * carries its untrusted-value fence.
+ */
+function applySort(items: readonly MergedItem[], sort: SortField, source: RatingSource): MergedItem[] {
+    const sorted = [...items];
+
+    if (sort === 'title') return sorted.sort((a, b) => unfenced(a.title).localeCompare(unfenced(b.title)));
+    // Descending: the newest and the best rated are what a superlative asks
+    // for, and nobody asks for their worst film first.
+    if (sort === 'year') return sorted.sort((a, b) => (b.year ?? 0) - (a.year ?? 0));
+
+    return sorted.sort((a, b) => (ratingOf(b, source) ?? 0) - (ratingOf(a, source) ?? 0));
+}
+
 const project = (item: MergedItem, detail: DetailLevel): MergedItem => {
     if (detail === 'full') return item;
     if (detail === 'minimal') {
@@ -186,8 +224,21 @@ export async function buildGetLibrary(loader: LibraryLoader, opts: LibraryQuery)
         return true;
     });
 
-    if (opts.min_rating === undefined) {
-        const shaped = applyLimit(filtered, opts.limit);
+    /**
+     * A rating is in play for a `min_rating` filter *or* a `sort: 'rating'` —
+     * and the second is why this is not simply `min_rating !== undefined`.
+     * Sorting by rating drops unrated items, so it owes the caller the same
+     * coverage count a filter does. Without this, "the ten best rated" would
+     * quietly leave out everything unrated and report nothing about it, which
+     * is the exact silent omission `ratingCoverage` was built to prevent.
+     */
+    const needsRating = opts.min_rating !== undefined || opts.sort === 'rating';
+
+    if (!needsRating) {
+        // `bestCoveredSource` is never consulted here: no rating is read, so
+        // computing one would be work whose result is discarded.
+        const ordered = opts.sort === undefined ? filtered : applySort(filtered, opts.sort, 'imdb');
+        const shaped = applyLimit(ordered, opts.limit);
         return { ...shaped, items: shaped.items.map(i => project(i, opts.detail)), degraded, counts };
     }
 
@@ -196,11 +247,18 @@ export async function buildGetLibrary(loader: LibraryLoader, opts: LibraryQuery)
     // unrated" answer the question the caller actually asked.
     const source = opts.rating_source ?? bestCoveredSource(filtered, opts.kind);
     const rated = filtered.filter(i => ratingOf(i, source) !== undefined);
-    const matching = rated.filter(
-        i => toTenPointScale(source, ratingOf(i, source) as number) >= (opts.min_rating as number)
-    );
+    // Bound to a local so the narrowing survives into the closure — inside the
+    // callback, `opts.min_rating` is a property read TypeScript cannot prove
+    // has not changed.
+    const floor = opts.min_rating;
+    const matching =
+        floor === undefined
+            ? rated
+            : rated.filter(i => toTenPointScale(source, ratingOf(i, source) as number) >= floor);
 
-    const shaped = applyLimit(matching, opts.limit);
+    const ordered = opts.sort === undefined ? matching : applySort(matching, opts.sort, source);
+    const shaped = applyLimit(ordered, opts.limit);
+
     return {
         ...shaped,
         items: shaped.items.map(i => project(i, opts.detail)),
@@ -241,6 +299,12 @@ export function registerGetLibrary(server: McpServer, loader: LibraryLoader): vo
                     .optional()
                     .describe(
                         'both / arr_only (possible broken import) / jellyfin_only (unmanaged media) / unknown (Jellyfin degraded or unconfigured — arr_only cannot be asserted).'
+                    ),
+                sort: z
+                    .enum(SORT_FIELDS)
+                    .optional()
+                    .describe(
+                        'Order the results *before* `limit` is applied — which is what makes "the best rated" answerable at all, since a filter alone would leave the top item outside the returned window. `rating` is descending and uses `rating_source`, excluding items that source has no rating for and reporting them in `ratingCoverage`; `year` is descending; `title` ascending. Omit to keep the library\'s own order.'
                     ),
                 detail: DetailSchema,
                 limit: LimitSchema

--- a/src/tools/getMediaDetails.ts
+++ b/src/tools/getMediaDetails.ts
@@ -5,6 +5,8 @@ import { ServiceIdSchema, type ServiceId } from '../config/schema.ts';
 import { ServiceError } from '../core/errors.ts';
 import type { MergedItem } from '../core/resolver.ts';
 import { DetailSchema, LimitSchema, type DetailLevel } from '../core/shape.ts';
+import { enrichWithImdb } from '../metadata/enrich.ts';
+import type { ImdbDataset } from '../metadata/imdbDataset.ts';
 import { hasMediaDetails, type MediaDetails, type ServiceAdapter } from '../services/types.ts';
 import type { LibraryLoader } from './library.ts';
 
@@ -15,7 +17,8 @@ import type { LibraryLoader } from './library.ts';
  */
 export async function buildGetMediaDetails(
     adapters: readonly ServiceAdapter[],
-    opts: { service: ServiceId; instance?: string | undefined; id: string; detail: DetailLevel; limit: number }
+    opts: { service: ServiceId; instance?: string | undefined; id: string; detail: DetailLevel; limit: number },
+    dataset?: ImdbDataset | undefined
 ): Promise<MediaDetails> {
     const adapter = resolveInstance(adapters, opts.service, opts.instance);
     if (!hasMediaDetails(adapter)) {
@@ -24,10 +27,14 @@ export async function buildGetMediaDetails(
         });
     }
 
-    return adapter.getMediaDetails(opts.id, {
+    const details = await adapter.getMediaDetails(opts.id, {
         includeEpisodes: opts.detail === 'full',
         episodeLimit: opts.limit
     });
+
+    // A single-item array through the same function the library uses, so one
+    // title cannot get a different rating depending on which tool asked.
+    return enrichWithImdb([details], dataset)[0] as MediaDetails;
 }
 
 export type MediaDetailsQuery = {
@@ -77,7 +84,10 @@ export async function buildResolvedMediaDetails(loader: LibraryLoader, query: st
 export async function resolveMediaDetails(
     adapters: readonly ServiceAdapter[],
     loader: LibraryLoader,
-    opts: MediaDetailsQuery
+    opts: MediaDetailsQuery,
+    /** Only the by-id branch needs this. The by-title branch resolves through
+     *  the library index, which `LibraryLoader` has already enriched. */
+    dataset?: ImdbDataset | undefined
 ): Promise<MediaDetails | MergedItem> {
     // The explicit id wins when both are given: an id is unambiguous and a
     // title is not.
@@ -88,7 +98,7 @@ export async function resolveMediaDetails(
             id: opts.id,
             detail: opts.detail,
             limit: opts.limit
-        });
+        }, dataset);
     }
 
     if (opts.query === undefined) {
@@ -103,7 +113,8 @@ export async function resolveMediaDetails(
 export function registerGetMediaDetails(
     server: McpServer,
     adapters: readonly ServiceAdapter[],
-    loader: LibraryLoader
+    loader: LibraryLoader,
+    dataset?: ImdbDataset | undefined
 ): void {
     server.registerTool(
         'get_media_details',
@@ -127,7 +138,7 @@ export function registerGetMediaDetails(
                 ...(id === undefined ? {} : { id }),
                 detail,
                 limit
-            });
+            }, dataset);
 
             // `unknown` is not a place something is "present in" — it is the
             // absence of a confident answer (item 1 of the whole-phase

--- a/src/tools/library.ts
+++ b/src/tools/library.ts
@@ -5,6 +5,8 @@ import { gather, type Source } from '../core/gather.ts';
 import type { IdentityResolver } from '../core/identity.ts';
 import { logger } from '../core/logger.ts';
 import { LibraryIndex, type IndexInput } from '../core/resolver.ts';
+import { enrichWithImdb } from '../metadata/enrich.ts';
+import type { ImdbDataset } from '../metadata/imdbDataset.ts';
 import { hasLibrary, hasUserLibrary, type ServiceAdapter, type ServiceUser } from '../services/types.ts';
 
 export type LibrarySnapshot = {
@@ -24,15 +26,30 @@ export class LibraryLoader {
     readonly #adapters: readonly ServiceAdapter[];
     readonly #identity: IdentityResolver | undefined;
     readonly #cache: TtlCache;
+    readonly #dataset: ImdbDataset | undefined;
 
     constructor(
         adapters: readonly ServiceAdapter[],
         jellyfinIdentity: IdentityResolver | undefined,
-        cache: TtlCache = new TtlCache()
+        cache: TtlCache = new TtlCache(),
+        /**
+         * The IMDb dataset, when one is configured.
+         *
+         * Enrichment happens here rather than in each tool for the reason this
+         * class exists at all (§8: duplicating the join is how joins drift
+         * apart). `get_library`, `get_media_details` and `diagnose` all read
+         * this one cached snapshot, so they cannot disagree about a rating,
+         * and the dataset is queried once per cache TTL rather than once per
+         * tool call.
+         *
+         * Last and optional, so every existing call site keeps compiling.
+         */
+        dataset?: ImdbDataset | undefined
     ) {
         this.#adapters = adapters;
         this.#identity = jellyfinIdentity;
         this.#cache = cache;
+        this.#dataset = dataset;
     }
 
     async load(user?: string): Promise<LibrarySnapshot> {
@@ -151,6 +168,14 @@ export class LibraryLoader {
         // synthetic no-user-resolved rejection above alike).
         const jellyfinGathered = jellyfin !== undefined && !degraded.includes(jellyfin.id);
 
-        return { index: LibraryIndex.build(items, { jellyfinGathered }), degraded, counts };
+        // Enriched *before* the merge rather than after it, because the index
+        // hands the same objects to `all()` and to its key map — replacing
+        // them afterwards would have to keep both in step, while an input a
+        // service never rated is simply an input with a gap to fill. It also
+        // means Jellyfin-only media gets a rating, which nothing in the stack
+        // could otherwise give it.
+        const rated = enrichWithImdb(items, this.#dataset);
+
+        return { index: LibraryIndex.build(rated, { jellyfinGathered }), degraded, counts };
     }
 }

--- a/src/tools/lookupMedia.ts
+++ b/src/tools/lookupMedia.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/server';
 import * as z from 'zod/v4';
 import { DetailSchema, LimitSchema, type DetailLevel } from '../core/shape.ts';
+import type { ImdbDataset } from '../metadata/imdbDataset.ts';
 import type { ServiceAdapter } from '../services/types.ts';
 import { buildSearchMedia, type GetSearchResult } from './searchMedia.ts';
 
@@ -14,12 +15,17 @@ import { buildSearchMedia, type GetSearchResult } from './searchMedia.ts';
  */
 export async function buildLookupMedia(
     adapters: readonly ServiceAdapter[],
-    opts: { query: string; detail: DetailLevel; limit: number }
+    opts: { query: string; detail: DetailLevel; limit: number },
+    dataset?: ImdbDataset | undefined
 ): Promise<GetSearchResult> {
-    return buildSearchMedia(adapters, { ...opts, source: 'discover' });
+    return buildSearchMedia(adapters, { ...opts, source: 'discover' }, dataset);
 }
 
-export function registerLookupMedia(server: McpServer, adapters: readonly ServiceAdapter[]): void {
+export function registerLookupMedia(
+    server: McpServer,
+    adapters: readonly ServiceAdapter[],
+    dataset?: ImdbDataset | undefined
+): void {
     server.registerTool(
         'lookup_media',
         {
@@ -32,7 +38,7 @@ export function registerLookupMedia(server: McpServer, adapters: readonly Servic
             })
         },
         async ({ query, detail, limit }) => {
-            const result = await buildLookupMedia(adapters, { query, detail, limit });
+            const result = await buildLookupMedia(adapters, { query, detail, limit }, dataset);
             const summary =
                 result.total === 0
                     ? `Nothing found for "${query}".`

--- a/src/tools/register.ts
+++ b/src/tools/register.ts
@@ -130,7 +130,7 @@ export function registerAllTools(server: McpServer, context: ToolContext): void 
     registerGetLibrary(server, library);
     registerSearchMedia(server, adapters, dataset);
     registerLookupMedia(server, adapters, dataset);
-    registerDiscoverMedia(server, seerr);
+    registerDiscoverMedia(server, seerr, dataset);
 
     // Registered unconditionally like every read tool, and for the same §18
     // reason: the tool surface is the public API and must not depend on

--- a/src/tools/register.ts
+++ b/src/tools/register.ts
@@ -41,6 +41,16 @@ export type ToolContext = {
     seerrIdentity: IdentityResolver | undefined;
     library: LibraryLoader;
     /**
+     * The IMDb dataset, when configured.
+     *
+     * `library` already closes over it — the owned-library join happens there
+     * exactly once. This field is for the tools that answer about things you
+     * may *not* own, which never touch the library index: search, lookup and
+     * details. Spec §4.1 calls that the path that matters most, because a
+     * rating is usually wanted before deciding to add something.
+     */
+    dataset: ImdbDataset | undefined;
+    /**
      * The write half (§10). Built once alongside the resolvers rather than per
      * request: `ConfirmTokens` holds the signing key and the spent-token set,
      * and rebuilding it per request would make every confirmation token invalid
@@ -75,6 +85,7 @@ export function buildToolContext(
 
     return {
         adapters,
+        dataset,
         jellyfinIdentity,
         seerrIdentity:
             seerr !== undefined && config.services.seerr !== undefined
@@ -103,7 +114,7 @@ export function buildToolContext(
  * not find it missing after a config edit.
  */
 export function registerAllTools(server: McpServer, context: ToolContext): void {
-    const { adapters, jellyfinIdentity, seerrIdentity, library, write } = context;
+    const { adapters, dataset, jellyfinIdentity, seerrIdentity, library, write } = context;
     const jellyfin = adapters.find((a): a is JellyfinAdapter => a instanceof JellyfinAdapter);
     const seerr = adapters.find((a): a is SeerrAdapter => a instanceof SeerrAdapter);
 
@@ -115,10 +126,10 @@ export function registerAllTools(server: McpServer, context: ToolContext): void 
     registerGetCalendar(server, adapters);
     registerGetPlayback(server, jellyfin, jellyfinIdentity);
     registerGetRequests(server, seerr, seerrIdentity);
-    registerGetMediaDetails(server, adapters, library);
+    registerGetMediaDetails(server, adapters, library, dataset);
     registerGetLibrary(server, library);
-    registerSearchMedia(server, adapters);
-    registerLookupMedia(server, adapters);
+    registerSearchMedia(server, adapters, dataset);
+    registerLookupMedia(server, adapters, dataset);
     registerDiscoverMedia(server, seerr);
 
     // Registered unconditionally like every read tool, and for the same §18

--- a/src/tools/register.ts
+++ b/src/tools/register.ts
@@ -2,6 +2,7 @@ import { listInstances } from '../config/instances.ts';
 import type { McpServer } from '@modelcontextprotocol/server';
 import type { Config } from '../config/schema.ts';
 import type { WriteAudit } from '../core/audit.ts';
+import type { ImdbDataset } from '../metadata/imdbDataset.ts';
 import type { ConfirmTokens } from '../core/confirm.ts';
 import { IdentityResolver } from '../core/identity.ts';
 import { permissionSourceFrom } from '../core/permissions.ts';
@@ -57,7 +58,10 @@ export function buildToolContext(
     adapters: readonly ServiceAdapter[],
     config: Config,
     audit: WriteAudit,
-    confirm: ConfirmTokens
+    confirm: ConfirmTokens,
+    /** The IMDb dataset, when configured. Reaches the tools only through the
+     *  library loader, which is the one place the join happens. */
+    dataset?: ImdbDataset | undefined
 ): ToolContext {
     const jellyfin = adapters.find((a): a is JellyfinAdapter => a instanceof JellyfinAdapter);
     const seerr = adapters.find((a): a is SeerrAdapter => a instanceof SeerrAdapter);
@@ -67,7 +71,7 @@ export function buildToolContext(
             ? new IdentityResolver(jellyfin, config.services.jellyfin)
             : undefined;
 
-    const library = new LibraryLoader(adapters, jellyfinIdentity);
+    const library = new LibraryLoader(adapters, jellyfinIdentity, undefined, dataset);
 
     return {
         adapters,

--- a/src/tools/searchMedia.ts
+++ b/src/tools/searchMedia.ts
@@ -4,6 +4,8 @@ import type { ServiceId } from '../config/schema.ts';
 import { gather } from '../core/gather.ts';
 import { DetailSchema, LimitSchema, applyLimit, type DetailLevel } from '../core/shape.ts';
 import { rankTitle, unfenced } from '../core/titleMatch.ts';
+import { enrichWithImdb } from '../metadata/enrich.ts';
+import type { ImdbDataset } from '../metadata/imdbDataset.ts';
 import { hasSearch, type SearchHit, type SearchSource, type ServiceAdapter } from '../services/types.ts';
 
 export type GetSearchResult = {
@@ -26,7 +28,8 @@ const project = (h: SearchHit, detail: DetailLevel): SearchHit => {
 
 export async function buildSearchMedia(
     adapters: readonly ServiceAdapter[],
-    opts: { query: string; source: SearchSource; detail: DetailLevel; limit: number }
+    opts: { query: string; source: SearchSource; detail: DetailLevel; limit: number },
+    dataset?: ImdbDataset | undefined
 ): Promise<GetSearchResult> {
     const { items, degraded, counts } = await gather(
         adapters.filter(hasSearch).map(a => ({ id: a.id, fetch: () => a.search(opts.query, opts.source) }))
@@ -41,11 +44,20 @@ export async function buildSearchMedia(
             unfenced(a.title).localeCompare(unfenced(b.title))
     );
 
+    // Enriched after the limit, not before: only the page actually returned
+    // needs ratings, and an indexer search can produce hundreds of hits for a
+    // caller who asked for ten.
     const shaped = applyLimit(items, opts.limit);
-    return { ...shaped, items: shaped.items.map(h => project(h, opts.detail)), degraded, counts };
+    const rated = enrichWithImdb(shaped.items, dataset);
+
+    return { ...shaped, items: rated.map(h => project(h, opts.detail)), degraded, counts };
 }
 
-export function registerSearchMedia(server: McpServer, adapters: readonly ServiceAdapter[]): void {
+export function registerSearchMedia(
+    server: McpServer,
+    adapters: readonly ServiceAdapter[],
+    dataset?: ImdbDataset | undefined
+): void {
     server.registerTool(
         'search_media',
         {
@@ -64,7 +76,7 @@ export function registerSearchMedia(server: McpServer, adapters: readonly Servic
             })
         },
         async ({ query, source, detail, limit }) => {
-            const result = await buildSearchMedia(adapters, { query, source, detail, limit });
+            const result = await buildSearchMedia(adapters, { query, source, detail, limit }, dataset);
             const summary =
                 result.total === 0
                     ? `No ${source} results for "${query}".`

--- a/src/web/configPage.ts
+++ b/src/web/configPage.ts
@@ -444,6 +444,23 @@ export function configPage(opts: {
             </fieldset>
 
             <fieldset>
+                <legend>IMDb dataset</legend>
+                ${checkbox(
+                    'metadata.imdb',
+                    'metadata.imdb',
+                    'Download IMDb’s daily dataset for ratings',
+                    opts.config.metadata?.imdb?.enabled ?? false
+                )}
+                <p class="note">
+                    Gives every film <em>and</em> series an IMDb rating — including series, which no service
+                    here can report one for. Costs a daily download and some disk on this machine; nothing is
+                    sent anywhere, and there is no account or key. Switching it on starts the first ingest in
+                    the background, which takes a while: everything keeps working meanwhile, and the dashboard
+                    says when it has finished.
+                </p>
+            </fieldset>
+
+            <fieldset>
                 <legend>MCP endpoint</legend>
                 ${checkbox('auth.rotate_token', 'auth.rotate_token', 'Generate a new bearer token', false)}
                 <p class="note">

--- a/src/web/pages.ts
+++ b/src/web/pages.ts
@@ -1,4 +1,5 @@
 import type { LogRow } from '../core/logs.ts';
+import type { DatasetStatus } from '../metadata/imdbDataset.ts';
 import type { ConnectionDiagnosis, DiskSpace, HealthCheck, ScanState } from '../services/types.ts';
 import { esc, html, humanBytes, raw, shortTime, type SafeHtml } from './html.ts';
 
@@ -231,6 +232,38 @@ export function groupDisks(disks: readonly DiskSpace[]): DiskGroup[] {
     return groups.sort((a, b) => a.freeSpace - b.freeSpace);
 }
 
+/**
+ * The IMDb dataset's state, when one is configured.
+ *
+ * A background download with no visible state is one nobody can tell has
+ * failed — and the state that matters most is the middle one: enabled, but the
+ * first ingest has not finished. Saying nothing there is indistinguishable
+ * from a broken download, and the user would reasonably conclude the feature
+ * does not work.
+ */
+const imdbPanel = (status: DatasetStatus): SafeHtml => html`<h2>IMDb dataset</h2>
+    <div class="panel">
+        ${status.ingestedAt === undefined
+            ? html`<p class="note">
+                  Enabled, still downloading. Every tool answers exactly as it did before until the first
+                  ingest finishes — nothing is broken while this says so. It runs again daily.
+              </p>`
+            : html`<p class="note">
+                      Ratings for films <em>and</em> series, including the IMDb rating no service in your
+                      stack can report for a series. Refreshed daily; nothing here is sent anywhere.
+                  </p>
+                  <table>
+                      <thead><tr><th>Last ingested</th><th>Titles</th><th>Rated</th></tr></thead>
+                      <tbody>
+                          <tr>
+                              <td class="mono">${shortTime(status.ingestedAt)}</td>
+                              <td>${status.titles.toLocaleString('en')}</td>
+                              <td>${status.ratings.toLocaleString('en')}</td>
+                          </tr>
+                      </tbody>
+                  </table>`}
+    </div>`;
+
 const statusDot = (d: ConnectionDiagnosis): SafeHtml =>
     html`<span class="dot ${d.ok ? 'ok' : 'bad'}" title="${d.ok ? 'reachable' : 'unreachable'}"></span>`;
 
@@ -249,6 +282,9 @@ export function dashboardPage(opts: {
     /** Absent when the request carried no usable `Host` — see `origin.ts`. */
     mcpUrl?: string | undefined;
     writeCounts: { applied: number; denied: number; total: number };
+    /** Absent when the IMDb dataset is not configured — in which case the
+     *  panel is not rendered at all rather than rendered as "off". */
+    imdb?: DatasetStatus | undefined;
     disks: DiskSpace[];
     failures: HealthCheck[];
     scans: ScanState[];
@@ -345,6 +381,8 @@ export function dashboardPage(opts: {
 
         <h2>Problems</h2>
         <div class="panel">${problems}</div>
+
+        ${opts.imdb === undefined ? raw('') : imdbPanel(opts.imdb)}
 
         <h2>Disk space</h2>
         <div class="panel">

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -178,6 +178,7 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
                 configured: snapshot.adapters.map(a => a.id),
                 bearerToken: snapshot.config.auth.bearer_token,
                 mcpUrl: mcpEndpoint(c.req.url, c.req.header('x-forwarded-proto')),
+                ...(runtime.dataset === undefined ? {} : { imdb: runtime.dataset.status() }),
                 disks: health.disks.items,
                 failures: health.failures.items,
                 scans: health.scans,
@@ -566,6 +567,11 @@ export function addCandidateFrom(
  * from one form any more.
  */
 export function buildAuthConfig(current: Config, form: Record<string, unknown>): Config {
+    // The dataset toggle rides along with the access form because it is the
+    // only other thing on the page that is not an instance card. Off is
+    // expressed by dropping the block entirely rather than by `enabled: false`,
+    // so a config nobody touched stays exactly as clean as it started.
+    const imdb = on(form['metadata.imdb']);
     const username = str(form['auth.username']).trim();
     const password = str(form['auth.password']);
     const hosts = str(form['auth.allowed_hosts'])
@@ -592,6 +598,7 @@ export function buildAuthConfig(current: Config, form: Record<string, unknown>):
             password_hash: carriedHash,
             allowed_hosts: hosts
         },
-        services: current.services
+        services: current.services,
+        ...(imdb ? { metadata: { imdb: { enabled: true } } } : {})
     };
 }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -349,3 +349,78 @@ describe('loadConfig', () => {
         expect(single(config.services.radarr)?.permissions.destructive).toBe(false);
     });
 });
+
+/**
+ * The IMDb dataset's config block (0.8 spec §3).
+ *
+ * It holds no credential, which is why there is nothing here about secrets
+ * being echoed back — the rule the rest of the config page is shaped by does
+ * not apply to a boolean.
+ */
+describe('the metadata block', () => {
+    it('is absent by default, the same as any service nobody configured', () => {
+        const parsed = ConfigSchema.parse({ auth: AUTH, services: {} });
+        expect(parsed.metadata).toBeUndefined();
+    });
+
+    it('accepts the dataset being switched on', () => {
+        const parsed = ConfigSchema.parse({ auth: AUTH, services: {}, metadata: { imdb: { enabled: true } } });
+        expect(parsed.metadata?.imdb?.enabled).toBe(true);
+    });
+
+    it('defaults enabled to false, so a bare block does not start a download', () => {
+        const parsed = ConfigSchema.parse({ auth: AUTH, services: {}, metadata: { imdb: {} } });
+        expect(parsed.metadata?.imdb?.enabled).toBe(false);
+    });
+
+    /**
+     * IMDb publishes daily, so there is no second sensible interval to choose
+     * between. The setting a user is most likely to invent is therefore one
+     * that cannot mean anything — and silently ignoring it is worse than
+     * refusing it, because a user who sets it believes it took effect.
+     */
+    it('refuses a refresh interval, which is not a setting', () => {
+        expect(() =>
+            ConfigSchema.parse({
+                auth: AUTH,
+                services: {},
+                metadata: { imdb: { enabled: true, refresh: 'hourly' } }
+            })
+        ).toThrow();
+    });
+
+    it('refuses an unknown provider rather than ignoring it', () => {
+        expect(() =>
+            ConfigSchema.parse({ auth: AUTH, services: {}, metadata: { tmdb: { api_key: 'k' } } })
+        ).toThrow();
+    });
+});
+
+/**
+ * `saveConfig` edits an existing YAML document in place rather than
+ * re-serialising the parsed config, so a key it does not know about is
+ * preserved by omission rather than by design. That is worth a test: the
+ * config UI rewrites this file on every save, and a `metadata` block that
+ * vanished the first time someone changed a timeout would be a silent
+ * downgrade nobody would connect to the save that caused it.
+ */
+describe('the metadata block through a save', () => {
+    it('survives a save that was about something else entirely', async () => {
+        const dir = await freshDir();
+        const path = join(dir, 'config.yaml');
+        await writeFile(
+            path,
+            `auth:\n  bearer_token: ${'d'.repeat(64)}\n  password_hash: scrypt$00$11\nservices:\n  radarr:\n    url: http://192.0.2.10:7878\n    api_key: k\nmetadata:\n  imdb:\n    enabled: true\n`,
+            'utf8'
+        );
+
+        const { config } = await loadConfig(dir);
+        expect(config.metadata?.imdb?.enabled).toBe(true);
+
+        await saveConfig(dir, config);
+
+        const reloaded = await loadConfig(dir);
+        expect(reloaded.config.metadata?.imdb?.enabled).toBe(true);
+        expect(await readFile(path, 'utf8')).toContain('metadata:');
+    });
+});

--- a/test/configUi.test.ts
+++ b/test/configUi.test.ts
@@ -1116,3 +1116,68 @@ describe('logs and audit', () => {
         expect(await res.text()).toContain('Write audit');
     });
 });
+
+/**
+ * A background ingest with no visible state is one nobody can tell has failed.
+ * The state that matters most is the middle one — enabled, first ingest not
+ * finished — where silence is indistinguishable from a broken download.
+ */
+describe('the IMDb dataset in the config UI', () => {
+    const seedWithDataset = async () => {
+        await seed();
+        await writeFile(
+            join(dir, 'config.yaml'),
+            `auth:\n  bearer_token: ${BEARER}\n  username: admin\n  password_hash: ${hashPassword(PASSWORD)}\n  allowed_hosts: []\nservices: {}\nmetadata:\n  imdb:\n    enabled: true\n`,
+            'utf8'
+        );
+        await runtime.reload();
+    };
+
+    it('says nothing at all on the dashboard when the dataset is not configured', async () => {
+        await signIn();
+        expect(await (await call('/ui')).text()).not.toContain('IMDb dataset');
+    });
+
+    it('says the first ingest has not finished rather than staying silent', async () => {
+        await seedWithDataset();
+        await signIn();
+
+        const page = await (await call('/ui')).text();
+        expect(page).toContain('IMDb dataset');
+        expect(page).toContain('still downloading');
+    });
+
+    it('offers the toggle on the configuration page', async () => {
+        await signIn();
+        expect(await (await call('/ui/config')).text()).toContain('name="metadata.imdb"');
+    });
+
+    /** The toggle has to reach config.yaml — `saveConfig` edits the document in
+     *  place, so a key nothing writes is a key that silently never persists. */
+    it('writes the block to disk when switched on', async () => {
+        await signIn();
+        await call(
+            '/ui/config/access',
+            form({ csrf: await csrfFrom(), 'auth.username': 'admin', 'metadata.imdb': 'on' })
+        );
+
+        expect(await readFile(join(dir, 'config.yaml'), 'utf8')).toContain('metadata:');
+        expect(runtime.config.metadata?.imdb?.enabled).toBe(true);
+    });
+
+    /**
+     * Off is the block disappearing, not `enabled: false`. Written as null it
+     * would fail the strict schema on the next start — a save that produces an
+     * instance which will not boot.
+     */
+    it('removes the block entirely when switched off', async () => {
+        await seedWithDataset();
+        await signIn();
+        await call('/ui/config/access', form({ csrf: await csrfFrom(), 'auth.username': 'admin' }));
+
+        const onDisk = await readFile(join(dir, 'config.yaml'), 'utf8');
+        expect(onDisk).not.toContain('metadata:');
+        expect(onDisk).not.toContain('null');
+        expect(runtime.config.metadata).toBeUndefined();
+    });
+});

--- a/test/fixtures/imdb/title.basics.tsv
+++ b/test/fixtures/imdb/title.basics.tsv
@@ -1,0 +1,6 @@
+tconst	titleType	primaryTitle	originalTitle	isAdult	startYear	endYear	runtimeMinutes	genres
+tt0903747	tvSeries	Breaking Bad	Breaking Bad	0	2008	2013	49	Crime,Drama,Thriller
+tt0068646	movie	The Godfather	The Godfather	0	1972	\N	175	Crime,Drama
+tt0111161	movie	The Shawshank Redemption	The Shawshank Redemption	0	1994	\N	\N	Drama
+tt9999998	short	A Short	A Short	0	2001	\N	12	\N
+tt9999997	movie	\N	\N	0	2001	\N	90	Drama

--- a/test/fixtures/imdb/title.episode.tsv
+++ b/test/fixtures/imdb/title.episode.tsv
@@ -1,0 +1,3 @@
+tconst	parentTconst	seasonNumber	episodeNumber
+tt2081647	tt0903747	1	1
+tt2301451	tt0903747	\N	\N

--- a/test/fixtures/imdb/title.ratings.tsv
+++ b/test/fixtures/imdb/title.ratings.tsv
@@ -1,0 +1,3 @@
+tconst	averageRating	numVotes
+tt0903747	9.5	2200000
+tt0068646	9.2	2000000

--- a/test/getLibrary.test.ts
+++ b/test/getLibrary.test.ts
@@ -173,12 +173,22 @@ describe('get_library rating filtering', () => {
         expect((await buildGetLibrary(loaderOf(rated), base)).ratingCoverage).toBeUndefined();
     });
 
-    it('refuses a per-source rating filter on series', async () => {
-        // §21.2: Sonarr's rating is one flat TVDB value. Returning an empty
-        // list here would read as "no such series exist".
+    /**
+     * Was: *any* per-source filter on a series was refused, because §21.2's
+     * flat TVDB value was the only rating one could carry. 0.8's IMDb dataset
+     * makes `imdb` reachable for a series, so the refusal narrowed to the
+     * sources that still have no path to one. The reason it exists is
+     * unchanged — an empty list would read as "no such series exist".
+     */
+    it('refuses a per-source rating filter a series still cannot have', async () => {
         await expect(
-            buildGetLibrary(loaderOf([film()]), { ...base, kind: 'series', min_rating: 8, rating_source: 'imdb' })
-        ).rejects.toThrow(/flat TVDB/);
+            buildGetLibrary(loaderOf([film()]), {
+                ...base,
+                kind: 'series',
+                min_rating: 8,
+                rating_source: 'rottenTomatoes'
+            })
+        ).rejects.toThrow(/applies to films only/);
     });
 
     it('allows a tvdb-sourced rating filter on series', async () => {
@@ -306,5 +316,95 @@ describe('get_library shaping', () => {
         const many = repeat(film(), 500).map((f, i) => ({ ...f, ids: { tmdb: i + 1 } }));
         const result = await buildGetLibrary(loaderOf(many), { ...base, limit: 500 });
         expectWithinBudget(result, 60_000);
+    });
+});
+
+/**
+ * A series could not carry an IMDb rating before 0.8, and `get_library` said
+ * so in three places at once: the guard refused the filter, the default source
+ * was hard-coded to `tvdb`, and the tool description told the model series
+ * carry one flat TVDB rating. None of that was wrong — it accurately described
+ * a stack where Sonarr was the only possible source. The IMDb dataset is what
+ * makes it false.
+ */
+const series = (over: Partial<IndexInput> = {}): IndexInput =>
+    film({
+        kind: 'series',
+        title: 'Some Series',
+        ids: { tvdb: 81189, imdb: 'tt0903747' },
+        acquisition: { service: 'sonarr', monitored: true, hasFile: true },
+        ...over
+    });
+
+describe('series ratings, once the dataset can supply them', () => {
+    it('no longer refuses rating_source: imdb for a series', async () => {
+        await expect(
+            buildGetLibrary(loaderOf([series()], 'sonarr'), { ...base, kind: 'series', rating_source: 'imdb' })
+        ).resolves.toBeDefined();
+    });
+
+    /** The other documented limit is untouched: a series' quality really is
+     *  per-episode, and no dataset changes that. */
+    it('still refuses quality for a series', async () => {
+        await expect(
+            buildGetLibrary(loaderOf([series()], 'sonarr'), { ...base, kind: 'series', quality: 'bluray-1080p' })
+        ).rejects.toThrow('quality applies to films only');
+    });
+
+    it('still refuses a source a series genuinely cannot have', async () => {
+        await expect(
+            buildGetLibrary(loaderOf([series()], 'sonarr'), { ...base, kind: 'series', rating_source: 'metacritic' })
+        ).rejects.toThrow('applies to films only');
+    });
+
+    /** New, and the other half of the relaxed guard: Radarr never reports a
+     *  TVDB rating, so asking for one on a film matched nothing silently. */
+    it('refuses tvdb for a film', async () => {
+        await expect(
+            buildGetLibrary(loaderOf([film()]), { ...base, kind: 'movie', rating_source: 'tvdb' })
+        ).rejects.toThrow('applies to series only');
+    });
+
+    /**
+     * `tvdb` stays the default for a series even though `imdb` is now
+     * reachable. Changing it would silently re-scale every saved prompt's
+     * `min_rating` against a different source — the exact silent break
+     * CONTRIBUTING warns about for the tool surface.
+     */
+    it('still defaults a series query to tvdb', async () => {
+        const result = await buildGetLibrary(loaderOf([series({ ratings: { tvdb: 8.8 } })], 'sonarr'), {
+            ...base,
+            kind: 'series',
+            min_rating: 1
+        });
+        expect(result.ratingCoverage?.source).toBe('tvdb');
+    });
+
+    it('reports coverage against imdb when imdb was asked for', async () => {
+        const items = [
+            series({ ratings: { imdb: 9.5 } }),
+            series({ title: 'Unrated', ids: { tvdb: 1, imdb: 'tt0000001' } })
+        ];
+        const result = await buildGetLibrary(loaderOf(items, 'sonarr'), {
+            ...base,
+            kind: 'series',
+            rating_source: 'imdb',
+            min_rating: 1
+        });
+        expect(result.ratingCoverage).toMatchObject({ source: 'imdb', rated: 1, unrated: 1 });
+    });
+
+    it('filters a series by its IMDb rating', async () => {
+        const items = [
+            series({ title: 'Great', ratings: { imdb: 9.5 } }),
+            series({ title: 'Poor', ids: { tvdb: 2, imdb: 'tt0000002' }, ratings: { imdb: 4.0 } })
+        ];
+        const result = await buildGetLibrary(loaderOf(items, 'sonarr'), {
+            ...base,
+            kind: 'series',
+            rating_source: 'imdb',
+            min_rating: 8
+        });
+        expect(result.items.map(i => i.title)).toEqual(['Great']);
     });
 });

--- a/test/getLibrary.test.ts
+++ b/test/getLibrary.test.ts
@@ -408,3 +408,95 @@ describe('series ratings, once the dataset can supply them', () => {
         expect(result.items.map(i => i.title)).toEqual(['Great']);
     });
 });
+
+/**
+ * A superlative cannot be answered by a filter. With more items than `limit`,
+ * "the best rated" is answered from an arbitrary window — and the model then
+ * reports it confidently, wrong in a way that looks exactly like being right.
+ */
+const rated = (title: string, imdb: number, over: Partial<IndexInput> = {}): IndexInput =>
+    film({ title, ids: { tmdb: title.length * 977 + Math.round(imdb * 10) }, ratings: { imdb }, ...over });
+
+describe('ordering', () => {
+    it('orders before truncating, so the top result survives the limit', async () => {
+        const many = [
+            rated('Worst', 1.0),
+            ...Array.from({ length: 60 }, (_, i) => film({ title: `Mid ${i}`, ids: { tmdb: 90_000 + i }, ratings: { imdb: 5 } })),
+            rated('Best', 9.9)
+        ];
+
+        const result = await buildGetLibrary(loaderOf(many), {
+            ...base,
+            rating_source: 'imdb',
+            sort: 'rating',
+            limit: 10
+        });
+
+        expect(result.items[0]?.title).toBe('Best');
+        expect(result.returned).toBe(10);
+        expect(result.truncated).toBe(true);
+    });
+
+    /**
+     * An unrated item sorted to the bottom is indistinguishable from a badly
+     * rated one, so a rating sort drops them — and must then say how many, or
+     * it is exactly the silent omission `ratingCoverage` exists to prevent.
+     * Note there is no `min_rating` here: coverage has to appear for a sort
+     * alone.
+     */
+    it('excludes unrated items from a rating sort and reports how many', async () => {
+        const items = [rated('Rated', 8.0), film({ title: 'Unrated', ids: { tmdb: 999 } })];
+        const result = await buildGetLibrary(loaderOf(items), { ...base, rating_source: 'imdb', sort: 'rating' });
+
+        expect(result.items.map(i => i.title)).toEqual(['Rated']);
+        expect(result.ratingCoverage).toMatchObject({ source: 'imdb', rated: 1, unrated: 1 });
+    });
+
+    it('sorts title ascending and year descending', async () => {
+        const named = [film({ title: 'Zulu', ids: { tmdb: 1 } }), film({ title: 'Alien', ids: { tmdb: 2 } })];
+        expect((await buildGetLibrary(loaderOf(named), { ...base, sort: 'title' })).items.map(i => i.title)).toEqual([
+            'Alien',
+            'Zulu'
+        ]);
+
+        const years = [film({ year: 1979, ids: { tmdb: 3 } }), film({ year: 2015, ids: { tmdb: 4 } })];
+        expect((await buildGetLibrary(loaderOf(years), { ...base, sort: 'year' })).items.map(i => i.year)).toEqual([
+            2015, 1979
+        ]);
+    });
+
+    it('leaves order untouched when sort is not asked for', async () => {
+        const named = [film({ title: 'Zulu', ids: { tmdb: 1 } }), film({ title: 'Alien', ids: { tmdb: 2 } })];
+        const result = await buildGetLibrary(loaderOf(named), base);
+        expect(result.items.map(i => i.title)).toEqual(['Zulu', 'Alien']);
+    });
+
+    it('omits coverage for a sort that has nothing to do with ratings', async () => {
+        const named = [film({ title: 'Zulu', ids: { tmdb: 1 } })];
+        expect((await buildGetLibrary(loaderOf(named), { ...base, sort: 'title' })).ratingCoverage).toBeUndefined();
+    });
+
+    /** The acceptance test for the whole phase. */
+    it('answers "which unwatched series is best rated"', async () => {
+        const items = [
+            series({
+                title: 'Seen',
+                ids: { tvdb: 11, imdb: 'tt0000011' },
+                ratings: { imdb: 9.9 },
+                playback: { user: 'u1', watched: true }
+            }),
+            series({ title: 'Unseen', ids: { tvdb: 12, imdb: 'tt0000012' }, ratings: { imdb: 8.4 } })
+        ];
+
+        const result = await buildGetLibrary(loaderOf(items, 'sonarr'), {
+            ...base,
+            kind: 'series',
+            watched: false,
+            rating_source: 'imdb',
+            sort: 'rating',
+            limit: 10
+        });
+
+        expect(result.items.map(i => i.title)).toEqual(['Unseen']);
+    });
+});

--- a/test/imdbDataset.test.ts
+++ b/test/imdbDataset.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { ImdbDataset } from '../src/metadata/imdbDataset.ts';
+
+/**
+ * The dataset store, driven against a real SQLite database in memory.
+ *
+ * No fixture server and no network anywhere in this file, which is the point
+ * of keeping downloading in `refresh.ts` and parsing in `ingest.ts`: the thing
+ * most worth testing here is the SQL, and the SQL does not care where the rows
+ * came from.
+ */
+
+let db: ImdbDataset;
+afterEach(() => db?.close());
+
+const seed = (): ImdbDataset => {
+    db = ImdbDataset.ephemeral();
+    db.replaceAll({
+        titles: [
+            { tconst: 'tt0903747', kind: 'tvSeries', title: 'Breaking Bad', year: 2008, genres: 'Crime,Drama,Thriller' },
+            { tconst: 'tt0068646', kind: 'movie', title: 'The Godfather', year: 1972, runtime: 175, genres: 'Crime,Drama' },
+            { tconst: 'tt0111161', kind: 'movie', title: 'The Shawshank Redemption', year: 1994, genres: 'Drama' }
+        ],
+        ratings: [
+            { tconst: 'tt0903747', average: 9.5, votes: 2_200_000 },
+            { tconst: 'tt0068646', average: 9.2, votes: 2_000_000 }
+        ],
+        episodes: [{ tconst: 'tt2081647', parent: 'tt0903747', season: 1, episode: 1 }]
+    });
+    return db;
+};
+
+describe('reading ratings', () => {
+    it('returns a rating per tconst asked for', () => {
+        expect(seed().ratingsFor(['tt0903747', 'tt0068646'])).toEqual(
+            new Map([
+                ['tt0903747', 9.5],
+                ['tt0068646', 9.2]
+            ])
+        );
+    });
+
+    /**
+     * The join's hole, made explicit. A title the dataset holds but has no
+     * rating for, and a tconst IMDb has never heard of, are both simply absent
+     * from the map — never a zero, which would rank an unknown title below one
+     * genuinely rated 1.0.
+     */
+    it('omits a tconst it has no rating for rather than returning zero', () => {
+        expect(seed().ratingsFor(['tt0111161', 'tt9999999']).size).toBe(0);
+    });
+
+    it('handles an empty request', () => {
+        expect(seed().ratingsFor([])).toEqual(new Map());
+    });
+
+    /** A 900-item library exceeds SQLite's variable limit in one IN clause —
+     *  and a large library is exactly where this feature earns its keep. */
+    it('answers for more tconsts than SQLite allows variables in one statement', () => {
+        const store = seed();
+        const many = Array.from({ length: 5000 }, (_, i) => `tt${String(i).padStart(7, '0')}`);
+        expect(() => store.ratingsFor(many)).not.toThrow();
+        expect(store.ratingsFor([...many, 'tt0903747']).get('tt0903747')).toBe(9.5);
+    });
+});
+
+describe('discovering from the dataset', () => {
+    it('filters by kind, genre and minimum rating', () => {
+        const hits = seed().discover({ kind: 'movie', genre: 'Crime', minRating: 9, limit: 10 });
+        expect(hits.map(h => h.tconst)).toEqual(['tt0068646']);
+        expect(hits[0]?.genres).toEqual(['Crime', 'Drama']);
+    });
+
+    it('matches genre case-insensitively, as get_library documents', () => {
+        expect(seed().discover({ kind: 'movie', genre: 'crime', limit: 10 })).toHaveLength(1);
+    });
+
+    /** The commas on both sides are what stop "Drama" matching "Docudrama". */
+    it('does not match a genre that merely contains the one asked for', () => {
+        db = ImdbDataset.ephemeral();
+        db.replaceAll({
+            titles: [{ tconst: 'tt1', kind: 'movie', title: 'A Docudrama', genres: 'Docudrama' }],
+            ratings: [],
+            episodes: []
+        });
+        expect(db.discover({ kind: 'movie', genre: 'Drama', limit: 10 })).toHaveLength(0);
+    });
+
+    /** `series` is the vocabulary the tools use; `tvSeries` is IMDb's. */
+    it('maps the tool vocabulary onto IMDb title types', () => {
+        expect(seed().discover({ kind: 'series', limit: 10 }).map(h => h.title)).toEqual(['Breaking Bad']);
+    });
+
+    it('excludes unrated titles when a minimum rating is asked for', () => {
+        const hits = seed().discover({ kind: 'movie', minRating: 1, limit: 10 });
+        expect(hits.map(h => h.tconst)).not.toContain('tt0111161');
+    });
+
+    it('includes unrated titles when no minimum is asked for', () => {
+        const hits = seed().discover({ kind: 'movie', limit: 10 });
+        expect(hits.map(h => h.tconst)).toContain('tt0111161');
+    });
+
+    it('filters by year', () => {
+        expect(seed().discover({ kind: 'movie', year: 1972, limit: 10 }).map(h => h.title)).toEqual(['The Godfather']);
+    });
+
+    it('honours the limit', () => {
+        expect(seed().discover({ kind: 'movie', limit: 1 })).toHaveLength(1);
+    });
+});
+
+describe('status', () => {
+    it('reports what it holds, for the dashboard', () => {
+        const s = seed().status();
+        expect(s.titles).toBe(3);
+        expect(s.ratings).toBe(2);
+        expect(s.ingestedAt).toBeDefined();
+    });
+
+    /** Enabled but never ingested is a distinct state from absent, and the
+     *  dashboard has to be able to say so. */
+    it('reports an empty dataset as empty rather than failing', () => {
+        db = ImdbDataset.ephemeral();
+        expect(db.status()).toMatchObject({ titles: 0, ratings: 0 });
+        expect(db.status().ingestedAt).toBeUndefined();
+    });
+});
+
+describe('replacing the dataset', () => {
+    /** The dumps are full daily snapshots. A merge would accumulate titles
+     *  IMDb has since withdrawn. */
+    it('replaces rather than merges', () => {
+        const store = seed();
+        store.replaceAll({
+            titles: [{ tconst: 'tt5', kind: 'movie', title: 'Only This' }],
+            ratings: [],
+            episodes: []
+        });
+
+        expect(store.status().titles).toBe(1);
+        expect(store.ratingsFor(['tt0903747']).size).toBe(0);
+    });
+
+    /** The failure this exists to prevent: a truncated download replacing a
+     *  good dataset with a partial one, degrading answers silently. */
+    it('leaves the previous dataset intact when the rows throw mid-stream', () => {
+        const store = seed();
+
+        function* explodes(): Generator<never> {
+            yield* [];
+            throw new Error('connection reset');
+        }
+
+        expect(() => store.replaceAll({ titles: explodes(), ratings: [], episodes: [] })).toThrow('connection reset');
+        expect(store.status().titles).toBe(3);
+        expect(store.ratingsFor(['tt0903747']).get('tt0903747')).toBe(9.5);
+    });
+});

--- a/test/imdbEnrich.test.ts
+++ b/test/imdbEnrich.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import type { IndexInput, MergedItem } from '../src/core/resolver.ts';
+import { enrichWithImdb } from '../src/metadata/enrich.ts';
+import { ImdbDataset } from '../src/metadata/imdbDataset.ts';
+import type { ServiceAdapter, SearchHit } from '../src/services/types.ts';
+import { LibraryLoader } from '../src/tools/library.ts';
+
+let db: ImdbDataset;
+afterEach(() => db?.close());
+
+const dataset = (): ImdbDataset => {
+    db = ImdbDataset.ephemeral();
+    db.replaceAll({
+        titles: [{ tconst: 'tt0903747', kind: 'tvSeries', title: 'Breaking Bad' }],
+        ratings: [{ tconst: 'tt0903747', average: 9.5, votes: 2_200_000 }],
+        episodes: []
+    });
+    return db;
+};
+
+const series = (ids: MergedItem['ids'], ratings?: MergedItem['ratings']): MergedItem => ({
+    kind: 'series',
+    title: 'Breaking Bad',
+    ids,
+    presence: 'both',
+    ...(ratings === undefined ? {} : { ratings })
+});
+
+const hit = (ids: SearchHit['ids']): SearchHit => ({
+    service: 'sonarr',
+    source: 'discover',
+    kind: 'series',
+    id: '1',
+    title: 'Breaking Bad',
+    ids
+});
+
+describe('enriching merged library items', () => {
+    /**
+     * The whole point of the phase. Radarr returns a per-source ratings map,
+     * but Sonarr returns one flat value that flattenSeriesRating can only
+     * honestly record as tvdb — so `MergedRatings.imdb` was unreachable for a
+     * series by every path there was.
+     */
+    it('gives a series an IMDb rating, which no service in the stack can supply', () => {
+        const [item] = enrichWithImdb([series({ imdb: 'tt0903747' })], dataset());
+        expect(item?.ratings?.imdb).toBe(9.5);
+    });
+
+    /** A service is the authority on its own data. */
+    it('never overwrites a rating a service already supplied', () => {
+        const [item] = enrichWithImdb([series({ imdb: 'tt0903747' }, { imdb: 7.1 })], dataset());
+        expect(item?.ratings?.imdb).toBe(7.1);
+    });
+
+    it('leaves other sources alone', () => {
+        const [item] = enrichWithImdb([series({ imdb: 'tt0903747' }, { tvdb: 8.8 })], dataset());
+        expect(item?.ratings).toEqual({ tvdb: 8.8, imdb: 9.5 });
+    });
+
+    /** Spec §5's hole: Radarr leads with tmdbId, and the dataset holds no
+     *  tmdb→imdb mapping, so some items can never be joined. */
+    it('leaves an item with no IMDb id untouched', () => {
+        const [item] = enrichWithImdb([series({ tmdb: 1396 })], dataset());
+        expect(item?.ratings).toBeUndefined();
+    });
+
+    it('leaves an item the dataset has never heard of untouched', () => {
+        const [item] = enrichWithImdb([series({ imdb: 'tt9999999' })], dataset());
+        expect(item?.ratings).toBeUndefined();
+    });
+
+    it('is a no-op when no dataset is configured', () => {
+        const input = [series({ imdb: 'tt0903747' })];
+        expect(enrichWithImdb(input, undefined)).toBe(input);
+    });
+
+    it('does not mutate what it was given', () => {
+        const input = series({ imdb: 'tt0903747' });
+        enrichWithImdb([input], dataset());
+        expect(input.ratings).toBeUndefined();
+    });
+});
+
+/**
+ * The same function, over a different shape. `SearchHit.ratings` is a
+ * `Record<string, number>` where `MergedItem.ratings` is `MergedRatings`, and
+ * both satisfy the structural constraint without either being widened.
+ */
+describe('enriching search hits', () => {
+    /** The path that matters most: a rating is usually wanted for something
+     *  you have not got, which is lookup_media rather than get_library. */
+    it('rates a hit for something not in the library at all', () => {
+        const [rated] = enrichWithImdb([hit({ imdb: 'tt0903747' })], dataset());
+        expect(rated?.ratings?.imdb).toBe(9.5);
+    });
+
+    it('leaves a hit with only a tmdb id untouched', () => {
+        const [rated] = enrichWithImdb([hit({ tmdb: 1396 })], dataset());
+        expect(rated?.ratings).toBeUndefined();
+    });
+
+    it('is a no-op when no dataset is configured', () => {
+        const input = [hit({ imdb: 'tt0903747' })];
+        expect(enrichWithImdb(input, undefined)).toBe(input);
+    });
+});
+
+/**
+ * The wiring, end to end. The unit tests above prove the function; this
+ * proves it is actually reached — enrichment lives in `LibraryLoader` so
+ * `get_library`, `get_media_details` and `diagnose` cannot disagree about a
+ * rating, and that only holds if the loader really applies it.
+ */
+describe('through the library loader', () => {
+    const sonarrStub = (items: IndexInput[]): ServiceAdapter =>
+        ({
+            id: 'sonarr',
+            testConnection: async () => ({ ok: true, service: 'sonarr', latency_ms: 1 }),
+            getVersion: async () => '4.0.0',
+            listLibrary: async () => items
+        }) as unknown as ServiceAdapter;
+
+    const breakingBad: IndexInput = {
+        kind: 'series',
+        title: 'Breaking Bad',
+        ids: { tvdb: 81189, imdb: 'tt0903747' },
+        acquisition: { service: 'sonarr', monitored: true, hasFile: true }
+    };
+
+    it('rates a series that Sonarr could only ever report a TVDB number for', async () => {
+        const loader = new LibraryLoader([sonarrStub([breakingBad])], undefined, undefined, dataset());
+        const { index } = await loader.load();
+
+        expect(index.all()[0]?.ratings?.imdb).toBe(9.5);
+    });
+
+    it('leaves the library exactly as it was when no dataset is configured', async () => {
+        const loader = new LibraryLoader([sonarrStub([breakingBad])], undefined);
+        const { index } = await loader.load();
+
+        expect(index.all()[0]?.ratings).toBeUndefined();
+    });
+});

--- a/test/imdbIngest.test.ts
+++ b/test/imdbIngest.test.ts
@@ -1,0 +1,100 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { ImdbDataset } from '../src/metadata/imdbDataset.ts';
+import { parseEpisodes, parseRatings, parseTitles } from '../src/metadata/ingest.ts';
+
+/**
+ * Parsing IMDb's dumps, against hand-written fixtures in the real format —
+ * tab separated, `\N` for absent, a header row on top.
+ */
+
+const lines = (name: string): string[] =>
+    readFileSync(join(import.meta.dirname, 'fixtures/imdb', name), 'utf8')
+        .split('\n')
+        .filter(line => line !== '');
+
+const titles = () => [...parseTitles(lines('title.basics.tsv'))];
+
+let db: ImdbDataset;
+afterEach(() => db?.close());
+
+describe('parsing the dumps', () => {
+    /** Detected by position, not by matching the literal string `tconst` —
+     *  which would silently ingest the header the day IMDb capitalises it. */
+    it('skips the header row rather than ingesting it as a title', () => {
+        expect(titles().map(t => t.tconst)).not.toContain('tconst');
+    });
+
+    /**
+     * `\N` is IMDb's null marker in every column of every file. Storing it as
+     * written is how a library ends up holding a film released in the year
+     * "\N", and the string is truthy, so nothing downstream would catch it.
+     */
+    it('reads \\N as absent, never as a value', () => {
+        const shawshank = titles().find(t => t.tconst === 'tt0111161');
+        expect(shawshank?.runtime).toBeUndefined();
+        expect(shawshank?.year).toBe(1994);
+
+        const short = titles().find(t => t.tconst === 'tt9999998');
+        expect(short?.genres).toBeUndefined();
+    });
+
+    it('keeps exactly the columns the schema stores', () => {
+        expect(titles().find(t => t.tconst === 'tt0068646')).toEqual({
+            tconst: 'tt0068646',
+            kind: 'movie',
+            title: 'The Godfather',
+            year: 1972,
+            runtime: 175,
+            genres: 'Crime,Drama'
+        });
+    });
+
+    /** A row with no title cannot be shown, matched or ranked. Dropping it is
+     *  better than carrying a nameless entry into the library join. */
+    it('drops a row missing a field the schema requires', () => {
+        expect(titles().map(t => t.tconst)).not.toContain('tt9999997');
+    });
+
+    it('reads ratings as numbers, not strings', () => {
+        expect([...parseRatings(lines('title.ratings.tsv'))][0]).toEqual({
+            tconst: 'tt0903747',
+            average: 9.5,
+            votes: 2_200_000
+        });
+    });
+
+    it('reads an episode with no season or number as absent', () => {
+        const loose = [...parseEpisodes(lines('title.episode.tsv'))].find(e => e.tconst === 'tt2301451');
+        expect(loose).toEqual({ tconst: 'tt2301451', parent: 'tt0903747' });
+    });
+
+    it('yields nothing for a file that is only a header', () => {
+        expect([...parseTitles(['tconst\ttitleType\tprimaryTitle'])]).toEqual([]);
+    });
+
+    /** Generators, not arrays: title.basics is on the order of 10^7 rows and
+     *  this runs on a NAS. Materialising it costs a multiple of its own size. */
+    it('is lazy, so a whole dump never lands in memory at once', () => {
+        const parsed = parseTitles(lines('title.basics.tsv'));
+        expect(typeof (parsed as { next?: unknown }).next).toBe('function');
+    });
+});
+
+describe('loading a parsed dump', () => {
+    it('is queryable end to end', () => {
+        db = ImdbDataset.ephemeral();
+        db.replaceAll({
+            titles: parseTitles(lines('title.basics.tsv')),
+            ratings: parseRatings(lines('title.ratings.tsv')),
+            episodes: parseEpisodes(lines('title.episode.tsv'))
+        });
+
+        expect(db.ratingsFor(['tt0903747']).get('tt0903747')).toBe(9.5);
+        expect(db.status().titles).toBe(4);
+        expect(db.discover({ kind: 'movie', genre: 'Crime', limit: 10 }).map(h => h.title)).toEqual([
+            'The Godfather'
+        ]);
+    });
+});

--- a/test/imdbRefresh.test.ts
+++ b/test/imdbRefresh.test.ts
@@ -1,0 +1,90 @@
+import { createGzip } from 'node:zlib';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ImdbDataset } from '../src/metadata/imdbDataset.ts';
+import { ingestOnce } from '../src/metadata/refresh.ts';
+
+/**
+ * The one file that touches the network, driven against a stubbed `fetch`
+ * serving real gzipped TSV — so the streaming and decompression are exercised
+ * rather than mocked away.
+ */
+
+let db: ImdbDataset;
+afterEach(() => {
+    db?.close();
+    vi.unstubAllGlobals();
+});
+
+const gzipped = (text: string): Promise<Buffer> =>
+    new Promise(resolve => {
+        const chunks: Buffer[] = [];
+        const gz = createGzip();
+        gz.on('data', (c: Buffer) => chunks.push(c));
+        gz.on('end', () => resolve(Buffer.concat(chunks)));
+        gz.end(text);
+    });
+
+const serve = async (files: Record<string, string>): Promise<void> => {
+    const bodies: Record<string, Buffer> = {};
+    for (const [name, text] of Object.entries(files)) bodies[name] = await gzipped(text);
+
+    vi.stubGlobal('fetch', async (url: string | URL) => {
+        const name = String(url).split('/').pop() ?? '';
+        const body = bodies[name];
+        if (body === undefined) return new Response('not found', { status: 404 });
+        return new Response(new Uint8Array(body));
+    });
+};
+
+const BASICS =
+    'tconst\ttitleType\tprimaryTitle\toriginalTitle\tisAdult\tstartYear\tendYear\truntimeMinutes\tgenres\n' +
+    'tt0903747\ttvSeries\tBreaking Bad\tBreaking Bad\t0\t2008\t2013\t49\tCrime,Drama';
+const RATINGS = 'tconst\taverageRating\tnumVotes\ntt0903747\t9.5\t2200000';
+const EPISODES = 'tconst\tparentTconst\tseasonNumber\tepisodeNumber\ntt2081647\ttt0903747\t1\t1';
+
+const ALL = {
+    'title.basics.tsv.gz': BASICS,
+    'title.ratings.tsv.gz': RATINGS,
+    'title.episode.tsv.gz': EPISODES
+};
+
+const BASE = 'https://example.test';
+
+describe('ingesting from the published dumps', () => {
+    it('downloads, decompresses and loads all three files', async () => {
+        await serve(ALL);
+        db = ImdbDataset.ephemeral();
+
+        await ingestOnce(db, { baseUrl: BASE });
+
+        expect(db.status().titles).toBe(1);
+        expect(db.ratingsFor(['tt0903747']).get('tt0903747')).toBe(9.5);
+        expect(db.status().ingestedAt).toBeDefined();
+    });
+
+    /**
+     * The failure this ordering exists to prevent. A download that dies
+     * between the first file and the third would otherwise leave today's
+     * titles standing against yesterday's ratings — a dataset that answers
+     * confidently from a mixture of two days, with nothing to show it.
+     */
+    it('leaves the previous dataset intact when a later download fails', async () => {
+        await serve(ALL);
+        db = ImdbDataset.ephemeral();
+        await ingestOnce(db, { baseUrl: BASE });
+
+        // Ratings and episodes now 404.
+        await serve({ 'title.basics.tsv.gz': BASICS });
+
+        await expect(ingestOnce(db, { baseUrl: BASE })).rejects.toThrow();
+        expect(db.status().titles).toBe(1);
+        expect(db.ratingsFor(['tt0903747']).get('tt0903747')).toBe(9.5);
+    });
+
+    it('names the file it could not fetch, so a failure is diagnosable', async () => {
+        await serve({});
+        db = ImdbDataset.ephemeral();
+
+        await expect(ingestOnce(db, { baseUrl: BASE })).rejects.toThrow('title.basics.tsv.gz');
+    });
+});

--- a/test/searchTools.test.ts
+++ b/test/searchTools.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import type { KeyedServiceConfig, MultiUserServiceConfig } from '../src/config/schema.ts';
 import type { IdentityResolver } from '../src/core/identity.ts';
+import { ImdbDataset } from '../src/metadata/imdbDataset.ts';
 import type { ServiceAdapter } from '../src/services/types.ts';
 import { ProwlarrAdapter } from '../src/services/prowlarr.ts';
 import { RadarrAdapter } from '../src/services/radarr.ts';
@@ -557,5 +558,78 @@ describe('discover_media', () => {
         );
         const result = await buildDiscoverMedia(broken, { mediaType: 'movie', detail: 'full', limit: 50 });
         expect(result.degraded).toEqual(['seerr']);
+    });
+});
+
+/**
+ * Spec §4.1 calls this the path that matters most: a rating is usually wanted
+ * for something you have *not* got, which is `lookup_media` rather than
+ * `get_library`. The *arr lookup endpoints are shaped for adding a title, so
+ * nothing in them carries a rating at all.
+ */
+describe('IMDb ratings on the not-yet-owned paths', () => {
+    let db: ImdbDataset | undefined;
+    afterEach(() => {
+        db?.close();
+        db = undefined;
+    });
+
+    // tt0137523 is what the lookup fixture above returns.
+    const dataset = (): ImdbDataset => {
+        db = ImdbDataset.ephemeral();
+        db.replaceAll({
+            titles: [{ tconst: 'tt0137523', kind: 'movie', title: 'Some Film' }],
+            ratings: [{ tconst: 'tt0137523', average: 9.3, votes: 100 }],
+            episodes: []
+        });
+        return db;
+    };
+
+    const lookupRadarr = new RadarrAdapter(
+        keyed(7878),
+        serving({
+            '/api/v3/movie/lookup': [
+                { title: 'Some Film', year: 2026, tmdbId: 550, imdbId: 'tt0137523', hasFile: false, monitored: false }
+            ]
+        })
+    );
+
+    it('rates a lookup hit for something not in the library at all', async () => {
+        const result = await buildLookupMedia(
+            [lookupRadarr],
+            { query: 'some film', detail: 'standard', limit: 50 },
+            dataset()
+        );
+        expect(result.items[0]?.ratings?.imdb).toBe(9.3);
+    });
+
+    it('leaves lookup exactly as it was when no dataset is configured', async () => {
+        const result = await buildLookupMedia([lookupRadarr], { query: 'some film', detail: 'standard', limit: 50 });
+        expect(result.items[0]?.ratings).toBeUndefined();
+    });
+
+    /**
+     * The MOVIE fixture carries Radarr's own imdb rating of 8.8. A service is
+     * the authority on its own data, so the dataset's 9.3 must not displace
+     * it — and the two disagreeing is exactly when that rule earns its keep.
+     */
+    it('never displaces a rating the service itself reported', async () => {
+        const rated = {
+            id: 42,
+            title: 'Some Film',
+            year: 2026,
+            monitored: true,
+            hasFile: true,
+            tmdbId: 550,
+            imdbId: 'tt0137523',
+            ratings: { imdb: { value: 8.8, votes: 2_000_000 } }
+        };
+        const detailRadarr = new RadarrAdapter(keyed(7878), serving({ '/api/v3/movie/42': rated }));
+        const result = await buildGetMediaDetails(
+            [detailRadarr],
+            { service: 'radarr', id: '42', detail: 'standard', limit: 50 },
+            dataset()
+        );
+        expect(result.ratings?.imdb).toBe(8.8);
     });
 });

--- a/test/searchTools.test.ts
+++ b/test/searchTools.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import type { KeyedServiceConfig, MultiUserServiceConfig } from '../src/config/schema.ts';
 import type { IdentityResolver } from '../src/core/identity.ts';
+import { unfenced } from '../src/core/titleMatch.ts';
 import { ImdbDataset } from '../src/metadata/imdbDataset.ts';
 import type { ServiceAdapter } from '../src/services/types.ts';
 import { ProwlarrAdapter } from '../src/services/prowlarr.ts';
@@ -631,5 +632,74 @@ describe('IMDb ratings on the not-yet-owned paths', () => {
             dataset()
         );
         expect(result.ratings?.imdb).toBe(8.8);
+    });
+});
+
+/**
+ * Without Seerr, `discover_media` used to return an empty result — which reads
+ * as "nothing matched" rather than "nobody could answer". The dataset can
+ * answer it: genre, year and a minimum rating are a join over two of its
+ * tables.
+ */
+describe('discovering without Seerr', () => {
+    let db: ImdbDataset | undefined;
+    afterEach(() => {
+        db?.close();
+        db = undefined;
+    });
+
+    const dataset = (): ImdbDataset => {
+        db = ImdbDataset.ephemeral();
+        db.replaceAll({
+            titles: [
+                { tconst: 'tt0068646', kind: 'movie', title: 'The Godfather', year: 1972, genres: 'Crime,Drama' },
+                { tconst: 'tt0903747', kind: 'tvSeries', title: 'Breaking Bad', year: 2008, genres: 'Crime,Drama' }
+            ],
+            ratings: [
+                { tconst: 'tt0068646', average: 9.2, votes: 2_000_000 },
+                { tconst: 'tt0903747', average: 9.5, votes: 2_200_000 }
+            ],
+            episodes: []
+        });
+        return db;
+    };
+
+    const query = { detail: 'standard' as const, limit: 10 };
+
+    it('answers from the dataset when Seerr is not configured', async () => {
+        const result = await buildDiscoverMedia(undefined, { ...query, mediaType: 'movie', genre: 'Crime' }, dataset());
+
+        // Fenced, like every external string that reaches model context — a
+        // dataset row is no more trusted than an indexer's release name.
+        expect(result.items[0]?.title).toContain('untrusted:imdb.title');
+        expect(result.items.map(i => unfenced(i.title))).toEqual(['The Godfather']);
+        expect(result.items[0]?.ratings?.imdb).toBe(9.2);
+    });
+
+    it('maps the tv media type onto series', async () => {
+        const result = await buildDiscoverMedia(undefined, { ...query, mediaType: 'tv' }, dataset());
+        expect(result.items.map(i => unfenced(i.title))).toEqual(['Breaking Bad']);
+    });
+
+    it('filters by minimum rating', async () => {
+        const result = await buildDiscoverMedia(undefined, { ...query, mediaType: 'movie', minRating: 9.4 }, dataset());
+        expect(result.items).toHaveLength(0);
+    });
+
+    /**
+     * `genre` is a TMDB id for Seerr and a name for the dataset, because that
+     * is what each source holds. A numeric id matches no IMDb genre, so it is
+     * refused rather than returning an empty list that reads as "you have
+     * nothing like that".
+     */
+    it('refuses a TMDB genre id it cannot possibly match', async () => {
+        await expect(
+            buildDiscoverMedia(undefined, { ...query, mediaType: 'movie', genre: '28' }, dataset())
+        ).rejects.toThrow(/TMDB id/);
+    });
+
+    it('returns the same empty result as before when neither is available', async () => {
+        const result = await buildDiscoverMedia(undefined, { ...query, mediaType: 'movie' }, undefined);
+        expect(result).toMatchObject({ items: [], total: 0 });
     });
 });


### PR DESCRIPTION
Phase 0.8. Spec and plan in `docs/superpowers/` (untracked, as always here).

## The problem

Ratings in this stack are inconsistent, and for series they are **absent**.

Radarr returns a per-source map, so a film can carry IMDb, TMDB, Rotten Tomatoes and Metacritic at once. Sonarr returns a single unlabelled `{ votes, value }`, which `flattenSeriesRating` can only honestly record as `tvdb` — it does not say what the number is.

| | Film | Series |
| --- | --- | --- |
| `MergedRatings.imdb` | populated when Radarr supplies it | **never populated, by any path** |

`MergedRatings.imdb` existed in the merged shape and was unreachable for half the library. `get_library` did not merely return nothing for `rating_source: 'imdb'` on a series — `rejectImpossibleFilters` **threw**, and the tool description told the model series carry one flat TVDB rating.

## What this adds

IMDb's daily non-commercial datasets — `title.basics`, `title.ratings`, `title.episode` — in a local SQLite database beside `audit.db` and `logs.db`. Off by default; `metadata.imdb.enabled: true` switches it on. No account, no API key, nothing sent anywhere.

**Why a dataset and not TMDB.** No key to sign up for, no per-item fan-out across a 900-item library, and filtering happens in SQL before anything is serialised. `better-sqlite3` was already a dependency, so this is a third database beside two rather than a new storage strategy. TMDB publishes only ID exports, Rotten Tomatoes has neither dump nor public API, and Trakt needs OAuth — an auth model nothing else here uses.

**Ratings reach things you don't own.** `lookup_media` is the path that matters most — a rating is usually wanted *before* deciding to add something, and the *arr lookup endpoints carry none.

**`sort` on `get_library`** — the one new parameter, argued rather than assumed. A superlative cannot be answered by a filter: with 120 unwatched series and `limit: 50`, "which is best rated" is answered from fifty in no defined order, and the model reports it confidently, wrong in a way that looks exactly like being right.

```
get_library({ kind: "series", watched: false, rating_source: "imdb",
              sort: "rating", limit: 10 })
```

That query is the acceptance test for the phase. It was refused outright before.

## Decisions worth reviewing

- **`tvdb` stays the series default.** Changing it would silently re-scale every saved prompt's `min_rating` against a different source — the quiet break `CONTRIBUTING.md` warns about. `imdb` is one explicit `rating_source` away.
- **A rating sort now reports `ratingCoverage`**, which `min_rating` alone used to gate. Sorting by rating drops unrated items; without the count, "the ten best rated" would omit them silently. Unrated items are excluded rather than ranked zero — a title nobody rated is not a bad title.
- **The guard narrowed and gained its mirror image.** `tvdb` on a *film* is now refused too: Radarr never reports one, so that filter always matched nothing, silently.
- **Enrichment lives in `LibraryLoader`**, not in each tool, because duplicating the join is how joins drift apart. `get_library`, `get_media_details` and `diagnose` read one cached snapshot and cannot disagree about a rating.
- **Never overwrites a service's own value.** Tested where they conflict: Radarr says 8.8, the dataset says 9.3, Radarr wins.
- **A miss is never a zero.** An absent key, so an unknown title never ranks below one genuinely rated 1.0.
- **Startup never awaits the ingest.** A first run of minutes is minutes of normal service, not a container that looks broken. The dashboard says the ingest has not finished, because silence there is indistinguishable from a failed download.

## Known limits, stated rather than discovered later

- **The join has a hole.** The dataset keys on IMDb ids; Radarr leads with TMDB ids and there is no tmdb→imdb map in the dumps. Unmatched titles come back unrated **and counted** — `ratingCoverage` is what makes that visible rather than silent.
- **`discover_media`'s `genre` means different things per source** — a TMDB id for Seerr, a name for the dataset. A numeric id on the dataset path is refused rather than matching nothing; the tool description says so.
- **Licence.** The datasets are for personal, non-commercial use. No prebuilt database ships in the image; the user's own container downloads them. Attribution added in IMDb's own required wording.

## Verification

- `npm test` — **1139 passing**, 55 files; `npm run typecheck` and `npm run lint` clean at every one of the eleven commits
- Two README statements that had become false are corrected, not left to rot

**Not tagged `Release-As: 0.8.0`.** The gate is a real ingest against a real library, measuring download size, duration, and — the number that decides whether this phase was worth shipping — what proportion of the library actually joins on an IMDb id. No fixture can produce it. If it comes back low, the deferred id-authority work becomes the next question rather than a 0.9 nicety.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
