### PR TITLE
feat: prompts and resources — the questions worth asking

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,18 @@ Tool count is a hard constraint, not a preference: model accuracy degrades
 measurably past roughly 40 tools. New capability should extend an existing tool
 before it adds one.
 
+**Prompt names are public surface too.** A client that has surfaced
+`whats_wrong` as a slash command breaks when it is renamed, exactly as a saved
+prompt breaks when a tool is. They are frozen at 1.0 on the same terms, and
+`test/mcpPrompts.test.ts` asserts that no prompt names a tool that does not
+exist — so a rename fails there rather than silently in someone's client.
+
+**A resource must mirror a tool, never originate.** Client support for
+resources is uneven and arr-mcp has to work on all of them, so anything only a
+resource could answer would be unreachable wherever they are not surfaced. When
+a resource needs a fact no tool reports, the fix is to extend the tool — that is
+why `stack_health` reports per-instance permissions.
+
 ## Adding a service adapter
 
 The highest-value contribution, and deliberately self-contained. Six steps,

--- a/README.md
+++ b/README.md
@@ -20,16 +20,16 @@ Jellyfin. arr-mcp correlates them and gives you the causal chain.
   broken and what to do about it, and read the logs and the write audit — no
   hand-edited YAML, no restart.
 
-> ### Status: 0.8 — ratings that work for series too
+> ### Status: 0.9 — questions, not just tools
 >
-> No service in this stack can tell you a series' IMDb rating: Radarr returns a
-> per-source map, Sonarr returns one unlabelled number. Switch on IMDb's daily
-> dataset and every film and series gets one — including things you do not own
-> yet, so you can check a rating before deciding to add it. `get_library` gains
-> `sort`, because *"which unwatched series is best rated"* is a superlative and
-> a filter alone cannot answer one. Everything from 0.7 and earlier — many
-> instances read as one library, the writes, the correlation — is unchanged
-> underneath.
+> Nineteen tools and no hint which to reach for is a menu nobody can read. This
+> adds five prompts for the questions this stack actually gets asked — why isn't
+> this playable, what needs my attention, what should I watch, what's the best
+> thing I own, what happened this week — plus three resources, chiefly the list
+> of instance ids every tool wants. Both degrade cleanly: client support for
+> them is uneven, and **nothing is reachable only through them**. `get_library`
+> also gains `has_file`, so "what am I still waiting for" is finally a question
+> you can ask.
 > See [the roadmap](#roadmap).
 
 ## Services
@@ -69,6 +69,11 @@ could not reach, and how many results each contributed, so a long answer from
 one service can never silently hide another. `diagnose` takes a title, or an
 exact `service` plus `id`, and returns a verdict rather than a list — see
 below.
+
+`get_library` also answers **"what am I still waiting for"** — `has_file: false`
+with `monitored: true`. Media no *arr manages is excluded from that answer
+rather than counted as missing: nothing is going to fetch it, so it does not
+belong on a list of things to chase.
 
 `get_library`'s `quality` filter is films only — a series has no series-level
 quality. Its rating filters are mostly films only too, because Sonarr carries
@@ -403,6 +408,41 @@ where it previously returned nothing. Seerr still answers whenever it is
 present — it knows what is trending and requestable, which a static catalogue
 does not.
 
+## Prompts and resources
+
+Nineteen tools cover what arr-mcp can do. They do not tell you which one to
+reach for, and the questions people actually ask are rarely one call.
+
+**Five prompts**, which most clients surface as slash commands:
+
+| Prompt | Asks |
+| --- | --- |
+| `why_not_playable` | Why isn't this playable? |
+| `whats_wrong` | What needs my attention right now? |
+| `what_to_watch` | What should I watch tonight? |
+| `best_in_library` | What's the best thing I own? |
+| `whats_new` | What happened this week? |
+
+**Three resources**, which a client can attach once rather than re-fetch:
+
+| Resource | Holds |
+| --- | --- |
+| `arr://instances` | Every instance id and what it may do — the values other tools accept as `instance` |
+| `arr://health` | A stack verdict, stamped with when it was taken |
+| `arr://library/summary` | Total, on disk, still wanted |
+
+**Client support for both is uneven, so nothing is reachable only through
+them.** A prompt is a sequence of tool calls the model could have made anyway,
+and every resource mirrors something a tool already returns. On a client that
+surfaces neither, arr-mcp is exactly as capable as it was — you just have to
+know what to ask.
+
+`arr://health` is never cached (`ttlMs: 0`) and says so. A pinned "sonarr:
+reachable" five hours after Sonarr fell over is worse than the tool call it
+replaced — confidently wrong rather than merely absent. Every resource also
+carries its own `as_of`, because a cache hint is advice a client may ignore
+while a timestamp inside the content cannot be dropped.
+
 ## Config UI
 
 `http://<host>:6060`
@@ -504,7 +544,7 @@ Put it behind a reverse proxy with TLS if it needs to leave the LAN, and pin
 | 0.6 | Web config page: dashboard, diagnosing connection tests, log streams, config editing with hot reload |
 | 0.7 | Multiple Radarr, Sonarr and Bazarr instances — an HD and a 4K stack read as one library |
 | 0.8 | A local IMDb dataset: ratings that are consistent across films and series, and orderable |
-| 0.9 | MCP resources and prompts |
+| 0.9 | Prompts and resources: the questions worth asking, and the ids every tool wants |
 | 1.0 | The tool surface settles: security, consistency and dead-code audit |
 
 Each version is a self-contained, shippable slice — the goal is that 0.4 already

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,6 +6,8 @@ import type { WriteAudit } from './core/audit.ts';
 import { logger } from './core/logger.ts';
 import type { LogStore } from './core/logs.ts';
 import type { Runtime } from './core/runtime.ts';
+import { registerAllPrompts } from './mcp/prompts.ts';
+import { registerAllResources } from './mcp/resources.ts';
 import { registerAllTools } from './tools/register.ts';
 import { registerWebRoutes } from './web/routes.ts';
 
@@ -40,6 +42,12 @@ export function buildApp(opts: { runtime: Runtime; audit: WriteAudit; logs: LogS
         const snapshot = runtime.current;
         const server = new McpServer({ name: NAME, version: VERSION });
         registerAllTools(server, snapshot.tools);
+        // Registered beside the tools, never instead of them. Client support
+        // for prompts and resources is uneven and arr-mcp has to work on all of
+        // them, so a client that surfaces neither is exactly as capable as
+        // before — `test/mcp.test.ts` asserts that rather than trusting it.
+        registerAllPrompts(server);
+        registerAllResources(server, snapshot.tools);
         return server;
     });
 

--- a/src/core/resolver.ts
+++ b/src/core/resolver.ts
@@ -30,7 +30,27 @@ export type MergedItem = {
      */
     genres?: string[];
     ids: ExternalIds;
-    acquisition?: { service: string; monitored: boolean; hasFile: boolean; quality?: string; sizeBytes?: number };
+    acquisition?: {
+        service: string;
+        monitored: boolean;
+        hasFile: boolean;
+        quality?: string;
+        sizeBytes?: number;
+        /**
+         * When the managing service added it, ISO 8601, exactly as that service
+         * reported it.
+         *
+         * On `acquisition` rather than on the item, and that placement is the
+         * decision. "When Radarr added this" is one unambiguous fact; Jellyfin's
+         * `DateCreated` — when a file appeared in *its* library — is a different
+         * one, and a single field holding both answers would repeat the mistake
+         * Sonarr's unlabelled rating already taught this codebase. Media
+         * Jellyfin alone knows about has no acquisition half and therefore no
+         * added date, which `sort: 'added'` reports by omission rather than by
+         * guessing.
+         */
+        addedAt?: string;
+    };
     playback?: { user: string; watched: boolean; playCount?: number; lastPlayed?: string };
     ratings?: MergedRatings;
     /**

--- a/src/mcp/prompts.ts
+++ b/src/mcp/prompts.ts
@@ -1,0 +1,138 @@
+import type { McpServer } from '@modelcontextprotocol/server';
+import * as z from 'zod/v4';
+
+/**
+ * The five questions this stack actually gets asked (0.9 spec §1).
+ *
+ * **A prompt orchestrates tools and adds no capability.** That is what makes
+ * this phase safe on a client that does not surface prompts: every sequence
+ * below is one the model could have assembled itself, so what is lost is
+ * discoverability, never reach. Nineteen tool names and no indication of which
+ * question to ask is the problem this solves.
+ *
+ * **No prompt may instruct a write.** It may *offer* one. Write tools preview
+ * first and hand back a single-use token precisely so a model cannot act
+ * without the user seeing what it would do, and a prompt that walked straight
+ * into a write would route around that while looking like a convenience.
+ *
+ * **These names are public surface.** A client that has surfaced `whats_wrong`
+ * as a slash command breaks if it is renamed, exactly as a saved prompt breaks
+ * when a tool is renamed — so they are `snake_case` like the tools, and the
+ * 1.0 audit freezes them on the same terms.
+ */
+
+const user = (text: string) => ({
+    messages: [{ role: 'user' as const, content: { type: 'text' as const, text } }]
+});
+
+export function registerAllPrompts(server: McpServer): void {
+    server.registerPrompt(
+        'why_not_playable',
+        {
+            title: 'Why is this not playable?',
+            description:
+                'Walk the whole chain for one title — requested, managed, monitored, downloaded, indexed, imported, scanned — and name the first thing that explains it.',
+            argsSchema: z.object({ title: z.string().min(1).describe('The film or series to explain.') })
+        },
+        ({ title }) =>
+            user(
+                `Work out why "${title}" is not playable.
+
+1. Call \`diagnose\` with \`query: "${title}"\`. It walks the whole chain and names the first step that explains the absence, rather than listing everything it checked.
+2. If the verdict has \`certain: false\`, say plainly which step could not be checked and why — a confident answer across a hole is worse than an uncertain one.
+3. If the verdict points at nothing having been searched for, **offer** \`trigger_search\` and say what it would do. Do not call it. It previews first and returns a token for a reason: the user decides whether to act.
+4. If \`diagnose\` reports the item is missing entirely, use \`lookup_media\` to check it exists at all before suggesting anything be added.
+
+Answer with the cause and the next action, not a transcript of the checks.`
+            )
+    );
+
+    server.registerPrompt(
+        'whats_wrong',
+        {
+            title: 'What needs my attention?',
+            description:
+                'The periodic sweep: what is broken, stuck, out of disk, not scanning, or missing subtitles — reconciled into a short list of things that actually need you.',
+            argsSchema: z.object({})
+        },
+        () =>
+            user(
+                `Sweep the stack and tell me what needs me. In order:
+
+1. \`stack_health\` — unreachable services, failing health checks, disks running out, libraries that have not been scanned recently.
+2. \`get_queue\` — anything stalled, failed, or sitting at 0% across all four download paths.
+3. \`get_indexers\` — indexers that are unhealthy or recently rejecting.
+4. \`get_subtitles\` — what is missing subtitles, and which providers are throttled.
+
+Then reconcile: a stalled download and an unhealthy indexer are usually one problem, not two. Say so rather than listing both.
+
+Report only what needs action, most urgent first, with what to do about each. If nothing does, say that in one line — do not pad it with everything that is fine.
+
+Two things you cannot see, so do not claim to: the write audit is not exposed as a tool and lives in the config UI at /ui/audit, and there is no tool that triggers a library scan. If a stale scan is the problem, say it has to be started in Jellyfin.`
+            )
+    );
+
+    server.registerPrompt(
+        'what_to_watch',
+        {
+            title: 'What should I watch?',
+            description:
+                'Unwatched, well rated, and actually on disk — plus anything half-finished worth continuing.',
+            argsSchema: z.object({
+                kind: z.enum(['movie', 'series']).optional().describe('Films or series. Omit for both.')
+            })
+        },
+        ({ kind }) =>
+            user(
+                `Recommend something to watch tonight.
+
+1. \`get_library\` with \`watched: false\`, \`has_file: true\`${kind === undefined ? '' : `, \`kind: "${kind}"\``}, \`rating_source: "imdb"\`, \`sort: "rating"\` and a small \`limit\`. \`has_file: true\` matters — recommending something not downloaded wastes the answer.
+2. \`get_playback\` — anything part-watched is usually a better suggestion than something new.
+3. If \`ratingCoverage\` reports many unrated items, say so. It means the ranking saw less of the library than it looks like, and it usually means the IMDb dataset is off or still ingesting.
+
+Give a handful of suggestions with one line each on why. Rank them; do not just list what came back.`
+            )
+    );
+
+    server.registerPrompt(
+        'best_in_library',
+        {
+            title: 'What is the best thing I own?',
+            description: 'Rank everything in the library by rating, watched or not.',
+            argsSchema: z.object({
+                kind: z.enum(['movie', 'series']).optional().describe('Films or series. Omit for both.')
+            })
+        },
+        ({ kind }) =>
+            user(
+                `Rank my library by rating.
+
+Call \`get_library\` with \`rating_source: "imdb"\`, \`sort: "rating"\`${kind === undefined ? '' : `, \`kind: "${kind}"\``} and a small \`limit\`. Unlike a recommendation this includes what I have already watched — it is an inventory question, not a suggestion.
+
+Report \`ratingCoverage\`: how many carry no IMDb rating and so could not be ranked at all. An unrated title is not a bad title, and a top ten drawn from half the library should say so.
+
+For a series, \`rating_source: "imdb"\` is worth naming explicitly — the default for series is \`tvdb\`, which is a different number on a different scale.`
+            )
+    );
+
+    server.registerPrompt(
+        'whats_new',
+        {
+            title: 'What happened this week?',
+            description: 'A digest: what arrived, what aired, what finished downloading and what failed.',
+            argsSchema: z.object({
+                days: z.string().optional().describe('How many days back. Defaults to 7.')
+            })
+        },
+        ({ days }) =>
+            user(
+                `Summarise the last ${days ?? 7} days.
+
+1. \`get_library\` with \`sort: "added"\` and a small \`limit\` — what arrived, newest first. Items no *arr manages carry no added date and are left out; that is expected, not an error.
+2. \`get_calendar\` — what aired or is due.
+3. \`get_queue\` — what finished, and what failed.
+
+Write it as a digest a person would read: counts first, then anything that went wrong. Do not list every episode.`
+            )
+    );
+}

--- a/src/mcp/resources.ts
+++ b/src/mcp/resources.ts
@@ -1,0 +1,138 @@
+import type { McpServer } from '@modelcontextprotocol/server';
+import { logger } from '../core/logger.ts';
+import type { ToolContext } from '../tools/register.ts';
+import { buildGetLibrary } from '../tools/getLibrary.ts';
+import { buildStackHealth } from '../tools/stackHealth.ts';
+
+/**
+ * The three resources (0.9 spec §2).
+ *
+ * **Every one mirrors a tool.** That is the rule the whole phase rests on:
+ * client support for resources is uneven, and arr-mcp has to work on all of
+ * them, so a resource exposing something no tool returns would be unreachable
+ * wherever they are not surfaced. Nothing here originates — `arr://instances`
+ * is `stack_health`'s services and permissions, `arr://health` is
+ * `stack_health`, and the summary is `get_library` aggregates.
+ *
+ * Not in `src/tools/`, because these are not tools and putting them there
+ * would invite the assumption that adding one costs against
+ * `CONTRIBUTING.md`'s roughly-40 ceiling. They also change for different
+ * reasons: a resource changes when a client needs different context, a tool
+ * when a capability does.
+ */
+
+/** An hour. Only a config edit can invalidate the instance list. */
+const INSTANCES_TTL_MS = 60 * 60 * 1000;
+
+/**
+ * Zero, meaning never cache.
+ *
+ * A pinned health resource saying "sonarr: reachable" five hours after Sonarr
+ * fell over is worse than the tool call it replaced — it is confidently wrong
+ * rather than merely absent. The dashboard refuses to cache health for exactly
+ * this reason, and this is the same decision in the protocol's own vocabulary.
+ */
+const HEALTH_TTL_MS = 0;
+
+/** Five minutes. Counts drift, but a five-minute-old count misleads nobody. */
+const SUMMARY_TTL_MS = 5 * 60 * 1000;
+
+/**
+ * Every resource says when it was true.
+ *
+ * A `cacheHint` is advice a client is free to ignore; a timestamp inside the
+ * content cannot be dropped without dropping the content with it. A reader must
+ * never have to guess how old a number is, and for `arr://health` that is the
+ * difference between a snapshot and a lie.
+ */
+const stamped = (body: Record<string, unknown>): string =>
+    JSON.stringify({ as_of: new Date().toISOString(), ...body }, null, 2);
+
+const json = (uri: URL, body: Record<string, unknown>) => ({
+    contents: [{ uri: uri.href, mimeType: 'application/json', text: stamped(body) }]
+});
+
+export function registerAllResources(server: McpServer, context: ToolContext): void {
+    const { adapters, instances, library } = context;
+
+    server.registerResource(
+        'instances',
+        'arr://instances',
+        {
+            title: 'Configured instances',
+            description:
+                'Every configured service instance: its id, its type, and what it is permitted to do. The ids here are exactly the values other tools accept as `instance`. Mirrors stack_health, which answers the same thing for a client that does not surface resources.',
+            mimeType: 'application/json',
+            cacheHint: { ttlMs: INSTANCES_TTL_MS, cacheScope: 'private' }
+        },
+        uri =>
+            json(uri, {
+                instances: instances.map(i => ({
+                    id: i.id,
+                    type: i.type,
+                    safe_write: i.config.permissions.safe_write,
+                    destructive: i.config.permissions.destructive
+                }))
+            })
+    );
+
+    server.registerResource(
+        'health',
+        'arr://health',
+        {
+            title: 'Stack health (snapshot)',
+            description:
+                'A point-in-time verdict per service. **`stack_health` is the live answer** — this is a snapshot and says in `as_of` when it was taken. Read it again rather than trusting a pinned copy: a service that was reachable an hour ago may not be now.',
+            mimeType: 'application/json',
+            cacheHint: { ttlMs: HEALTH_TTL_MS, cacheScope: 'private' }
+        },
+        async uri => {
+            const health = await buildStackHealth(adapters, { detail: 'standard', limit: 50 }, instances);
+            return json(uri, {
+                services: health.services,
+                failures: health.failures.items,
+                degraded: health.degraded
+            });
+        }
+    );
+
+    server.registerResource(
+        'library-summary',
+        'arr://library/summary',
+        {
+            title: 'Library summary',
+            description:
+                'Counts across the joined library — total, on disk, and still wanted. Mirrors what get_library reports; call that for anything beyond the totals.',
+            mimeType: 'application/json',
+            cacheHint: { ttlMs: SUMMARY_TTL_MS, cacheScope: 'private' }
+        },
+        async uri => {
+            try {
+                const all = await buildGetLibrary(library, { detail: 'minimal', limit: 1 });
+                const onDisk = await buildGetLibrary(library, { detail: 'minimal', limit: 1, has_file: true });
+                const wanted = await buildGetLibrary(library, {
+                    detail: 'minimal',
+                    limit: 1,
+                    has_file: false,
+                    monitored: true
+                });
+
+                // `limit: 1` throughout: only the totals are wanted, and this
+                // reads from the same cached snapshot get_library does, so the
+                // three calls cost one library read rather than three.
+                return json(uri, {
+                    total: all.total,
+                    on_disk: onDisk.total,
+                    wanted: wanted.total,
+                    degraded: all.degraded
+                });
+            } catch (err) {
+                // A resource read that throws is a client-visible error for
+                // something nobody explicitly asked for. Degrading matches how
+                // every list tool here behaves when a service is down.
+                logger.warn({ err }, 'library summary resource degraded');
+                return json(uri, { total: 0, on_disk: 0, wanted: 0, degraded: ['library'] });
+            }
+        }
+    );
+}

--- a/src/services/radarr.ts
+++ b/src/services/radarr.ts
@@ -53,6 +53,7 @@ type RawMovie = {
     imdbId?: string;
     genres?: string[];
     ratings?: Record<string, RawRating>;
+    added?: string | null;
     movieFile?: { size?: number; quality?: { quality?: { name?: string } } };
 };
 
@@ -315,6 +316,7 @@ export class RadarrAdapter
                 service: this.id,
                 monitored: m.monitored ?? false,
                 hasFile: m.hasFile ?? false,
+                ...(m.added === undefined || m.added === null ? {} : { addedAt: m.added }),
                 ...(m.movieFile?.quality?.quality?.name === undefined
                     ? {}
                     : { quality: m.movieFile.quality.quality.name }),

--- a/src/services/sonarr.ts
+++ b/src/services/sonarr.ts
@@ -55,6 +55,7 @@ type RawSeries = {
     genres?: string[];
     /** Flat, unlike Radarr's per-source map — see `flattenSeriesRating`. */
     ratings?: RawRating;
+    added?: string | null;
     statistics?: { sizeOnDisk?: number; episodeFileCount?: number };
 };
 
@@ -326,6 +327,7 @@ export class SonarrAdapter
                 // episode on disk". No quality either: it is per-episode, which
                 // is why §5.2 makes the quality filter films-only.
                 hasFile: (s.statistics?.episodeFileCount ?? 0) > 0,
+                ...(s.added === undefined || s.added === null ? {} : { addedAt: s.added }),
                 ...(s.statistics?.sizeOnDisk === undefined ? {} : { sizeBytes: s.statistics.sizeOnDisk })
             },
             // Flat, and labelled tvdb. Treating it as a per-source map is the

--- a/src/tools/getLibrary.ts
+++ b/src/tools/getLibrary.ts
@@ -80,6 +80,7 @@ export type LibraryQuery = {
     year?: number;
     genre?: string;
     monitored?: boolean;
+    has_file?: boolean;
     watched?: boolean;
     watched_by?: string;
     quality?: string;
@@ -225,6 +226,21 @@ export async function buildGetLibrary(loader: LibraryLoader, opts: LibraryQuery)
         if (opts.year !== undefined && item.year !== opts.year) return false;
         if (genre !== undefined && !(item.genres ?? []).some(g => unfenced(g).toLowerCase() === genre)) return false;
         if (opts.monitored !== undefined && (item.acquisition?.monitored ?? false) !== opts.monitored) return false;
+        /**
+         * Strict, and deliberately **unlike** `monitored` directly above.
+         *
+         * `monitored ?? false` is right for monitoring: media no *arr manages
+         * genuinely is not monitored, because nothing is monitoring it. The
+         * same coalesce would be wrong here — Jellyfin-only media plainly does
+         * have a file, Jellyfin found it, and reporting `hasFile: false` for
+         * something demonstrably on disk would put it on a list of things to
+         * chase a download for.
+         *
+         * So an item with no acquisition half matches neither `true` nor
+         * `false`. It is the `presence: unknown` distinction again: absent
+         * evidence is not evidence of absence.
+         */
+        if (opts.has_file !== undefined && item.acquisition?.hasFile !== opts.has_file) return false;
         // Absent playback is "not watched", never "excluded": an item Jellyfin
         // has never seen is exactly what `watched: false` should surface.
         if (opts.watched !== undefined && (item.playback?.watched ?? false) !== opts.watched) return false;
@@ -287,12 +303,18 @@ export function registerGetLibrary(server: McpServer, loader: LibraryLoader): vo
         'get_library',
         {
             description:
-                'Your library, joined across Radarr, Sonarr and Jellyfin on shared external ids. `presence` is what no single service can tell you — but only when the absent half’s service actually answered: `arr_only` with a file means Jellyfin *was reachable and* cannot see a file the *arr believes is on disk (a likely broken import); `jellyfin_only` means nothing here is managing it, read the same way — it assumes Radarr/Sonarr answered too, and (unlike `arr_only`) is not yet hedged against their own outage. If Jellyfin is degraded, an item Radarr/Sonarr manages reports `unknown` instead of `arr_only`, and the top-level `degraded` list names it. If Jellyfin is not configured at all, `unknown` fires the same way but `degraded` stays empty — there is nothing to name as degraded — so check whether `jellyfin` even appears in your config instead. Two limits: `quality` applies to films only (a series’ quality is per-episode), and a series carries Sonarr’s one flat TVDB rating plus an IMDb rating when the IMDb dataset is enabled — `rating_source` still defaults to `tvdb` for a series, so ask for `imdb` explicitly. A rating filter also reports how much of the library that source actually covers.',
+                'Your library, joined across Radarr, Sonarr and Jellyfin on shared external ids. `presence` is what no single service can tell you — but only when the absent half’s service actually answered: `arr_only` with a file means Jellyfin *was reachable and* cannot see a file the *arr believes is on disk (a likely broken import); `jellyfin_only` means nothing here is managing it, read the same way — it assumes Radarr/Sonarr answered too, and (unlike `arr_only`) is not yet hedged against their own outage. If Jellyfin is degraded, an item Radarr/Sonarr manages reports `unknown` instead of `arr_only`, and the top-level `degraded` list names it. If Jellyfin is not configured at all, `unknown` fires the same way but `degraded` stays empty — there is nothing to name as degraded — so check whether `jellyfin` even appears in your config instead. `has_file: false` with `monitored: true` is "what am I still waiting for". Two limits: `quality` applies to films only (a series’ quality is per-episode), and a series carries Sonarr’s one flat TVDB rating plus an IMDb rating when the IMDb dataset is enabled — `rating_source` still defaults to `tvdb` for a series, so ask for `imdb` explicitly. A rating filter also reports how much of the library that source actually covers.',
             inputSchema: z.object({
                 kind: z.enum(['movie', 'series']).optional().describe('Films or series. Omit for both.'),
                 year: z.number().int().optional(),
                 genre: z.string().min(1).optional().describe('Matched case-insensitively against the *arr genres.'),
                 monitored: z.boolean().optional(),
+                has_file: z
+                    .boolean()
+                    .optional()
+                    .describe(
+                        'Whether a file is actually on disk. `false` with `monitored: true` is "what am I still waiting for"; `true` is "what can I watch now". Media no *arr manages is excluded from both answers rather than counted as missing — nothing is going to fetch it.'
+                    ),
                 watched: z.boolean().optional().describe('Jellyfin watch state. Items Jellyfin has never seen count as unwatched.'),
                 watched_by: UserSchema,
                 quality: z.string().min(1).optional().describe('Films only.'),

--- a/src/tools/getLibrary.ts
+++ b/src/tools/getLibrary.ts
@@ -65,11 +65,11 @@ const toTenPointScale = (source: RatingSource, value: number): number => (value 
  * `limit`, the best-rated may simply not be in the window, and the model then
  * answers confidently from whatever fifty it was handed.
  *
- * `added` is deliberately absent. `MergedItem` carries no added date, and a
- * sort option that silently does nothing is worse than one that was never
- * offered — it can be added later as a minor without breaking anything.
+ * `added` was absent through 0.8 because nothing carried an added date. 0.9
+ * put one on `acquisition`, which is what makes "what arrived this week"
+ * answerable rather than approximated.
  */
-export const SORT_FIELDS = ['rating', 'year', 'title'] as const;
+export const SORT_FIELDS = ['rating', 'year', 'title', 'added'] as const;
 export type SortField = (typeof SORT_FIELDS)[number];
 
 export type LibraryQuery = {
@@ -176,6 +176,20 @@ function applySort(items: readonly MergedItem[], sort: SortField, source: Rating
     const sorted = [...items];
 
     if (sort === 'title') return sorted.sort((a, b) => unfenced(a.title).localeCompare(unfenced(b.title)));
+
+    if (sort === 'added') {
+        // Excluded, not defaulted. An item nobody can date is not an item from
+        // 1970, and answering "we do not know" with the epoch is the same
+        // failure as ranking an unrated title zero.
+        //
+        // Compared as strings: ISO 8601 sorts lexicographically in the order it
+        // sorts chronologically, so no parsing is needed — and `new Date()` on
+        // a malformed value yields NaN, which compares false against everything
+        // and would scramble the order silently.
+        return sorted
+            .filter(i => i.acquisition?.addedAt !== undefined)
+            .sort((a, b) => (b.acquisition?.addedAt ?? '').localeCompare(a.acquisition?.addedAt ?? ''));
+    }
     // Descending: the newest and the best rated are what a superlative asks
     // for, and nobody asks for their worst film first.
     if (sort === 'year') return sorted.sort((a, b) => (b.year ?? 0) - (a.year ?? 0));
@@ -304,7 +318,7 @@ export function registerGetLibrary(server: McpServer, loader: LibraryLoader): vo
                     .enum(SORT_FIELDS)
                     .optional()
                     .describe(
-                        'Order the results *before* `limit` is applied — which is what makes "the best rated" answerable at all, since a filter alone would leave the top item outside the returned window. `rating` is descending and uses `rating_source`, excluding items that source has no rating for and reporting them in `ratingCoverage`; `year` is descending; `title` ascending. Omit to keep the library\'s own order.'
+                        'Order the results *before* `limit` is applied — which is what makes "the best rated" or "most recently added" answerable at all, since a filter alone would leave the top item outside the returned window. `rating` is descending and uses `rating_source`, excluding items that source has no rating for and reporting them in `ratingCoverage`; `added` is newest first and excludes media no *arr manages, which has no added date; `year` is descending; `title` ascending. Omit to keep the library\'s own order.'
                     ),
                 detail: DetailSchema,
                 limit: LimitSchema

--- a/src/tools/register.ts
+++ b/src/tools/register.ts
@@ -5,6 +5,7 @@ import type { WriteAudit } from '../core/audit.ts';
 import type { ImdbDataset } from '../metadata/imdbDataset.ts';
 import type { ConfirmTokens } from '../core/confirm.ts';
 import { IdentityResolver } from '../core/identity.ts';
+import type { ServiceInstance } from '../config/instances.ts';
 import { permissionSourceFrom } from '../core/permissions.ts';
 import { JellyfinAdapter } from '../services/jellyfin.ts';
 import { SeerrAdapter } from '../services/seerr.ts';
@@ -50,6 +51,9 @@ export type ToolContext = {
      * rating is usually wanted before deciding to add something.
      */
     dataset: ImdbDataset | undefined;
+    /** Every configured instance, as the config declares it — the source the
+     *  write gate reads, so `stack_health` cannot report a different answer. */
+    instances: readonly ServiceInstance[];
     /**
      * The write half (§10). Built once alongside the resolvers rather than per
      * request: `ConfirmTokens` holds the signing key and the spent-token set,
@@ -86,6 +90,7 @@ export function buildToolContext(
     return {
         adapters,
         dataset,
+        instances: listInstances(config),
         jellyfinIdentity,
         seerrIdentity:
             seerr !== undefined && config.services.seerr !== undefined
@@ -114,12 +119,12 @@ export function buildToolContext(
  * not find it missing after a config edit.
  */
 export function registerAllTools(server: McpServer, context: ToolContext): void {
-    const { adapters, dataset, jellyfinIdentity, seerrIdentity, library, write } = context;
+    const { adapters, dataset, instances, jellyfinIdentity, seerrIdentity, library, write } = context;
     const jellyfin = adapters.find((a): a is JellyfinAdapter => a instanceof JellyfinAdapter);
     const seerr = adapters.find((a): a is SeerrAdapter => a instanceof SeerrAdapter);
 
     registerDiagnose(server, { adapters, library });
-    registerStackHealth(server, adapters);
+    registerStackHealth(server, adapters, instances);
     registerGetIndexers(server, adapters.find(hasIndexers));
     registerGetSubtitles(server, adapters.filter(hasSubtitles));
     registerGetQueue(server, adapters);

--- a/src/tools/stackHealth.ts
+++ b/src/tools/stackHealth.ts
@@ -1,4 +1,5 @@
 import type { McpServer } from '@modelcontextprotocol/server';
+import type { ServiceInstance } from '../config/instances.ts';
 import * as z from 'zod/v4';
 import { ServiceError } from '../core/errors.ts';
 import { logger } from '../core/logger.ts';
@@ -26,8 +27,23 @@ export type StackHealthResult = {
      * in a truncation contract is noise in every response.
      */
     scans: ScanState[];
+    /**
+     * What each instance is allowed to do — absent unless the caller supplied
+     * the instances, and absent at `minimal`, which answers "is anything
+     * broken" and a permission is not a fault.
+     *
+     * Reported here because `arr://instances` needs it and a resource must
+     * mirror a tool rather than originate one: a client that ignores resources
+     * must not be the only one unable to answer "what may I do here". The
+     * permission *source* is untouched — `permissionSourceFrom` still reads
+     * config so an adapter cannot widen its own grants. This reports the gate's
+     * answer; it is not a second one.
+     */
+    permissions?: InstancePermissions[];
     degraded: string[];
 };
+
+export type InstancePermissions = { instance: string; safe_write: boolean; destructive: boolean };
 
 /**
  * minimal  — is anything broken? A verdict per service, and counts only.
@@ -63,6 +79,8 @@ function project(result: StackHealthResult, detail: DetailLevel): StackHealthRes
             service: s.service,
             ...(s.lastCompleted === undefined ? {} : { lastCompleted: s.lastCompleted })
         })),
+        // No permissions: minimal answers "is anything broken", and being
+        // allowed to write is not a fault.
         degraded: result.degraded
     };
 }
@@ -75,7 +93,9 @@ function project(result: StackHealthResult, detail: DetailLevel): StackHealthRes
  */
 export async function buildStackHealth(
     adapters: readonly ServiceAdapter[],
-    opts: { detail: DetailLevel; limit: number }
+    opts: { detail: DetailLevel; limit: number },
+    /** Optional and last, so every existing call site keeps compiling. */
+    instances?: readonly ServiceInstance[]
 ): Promise<StackHealthResult> {
     const services: ConnectionDiagnosis[] = [];
     const degraded: string[] = [];
@@ -168,22 +188,47 @@ export async function buildStackHealth(
 
     // Counts stay honest at every detail level: a model must never see
     // returned: 0 and conclude there are no disks.
+    // Sorted by id like the lists above, and read from each instance's own
+    // config rather than from its adapter — the same source the write gate
+    // uses, so the two can never disagree about what is permitted.
+    const permissions =
+        instances === undefined
+            ? undefined
+            : [...instances]
+                  .map(i => ({
+                      instance: i.id,
+                      safe_write: i.config.permissions.safe_write,
+                      destructive: i.config.permissions.destructive
+                  }))
+                  .sort((a, b) => a.instance.localeCompare(b.instance));
+
     return project(
-        { services, disks: shapedDisks, failures: shapedFailures, scans, degraded },
+        {
+            services,
+            disks: shapedDisks,
+            failures: shapedFailures,
+            scans,
+            ...(permissions === undefined ? {} : { permissions }),
+            degraded
+        },
         opts.detail
     );
 }
 
-export function registerStackHealth(server: McpServer, adapters: readonly ServiceAdapter[]): void {
+export function registerStackHealth(
+    server: McpServer,
+    adapters: readonly ServiceAdapter[],
+    instances?: readonly ServiceInstance[]
+): void {
     server.registerTool(
         'stack_health',
         {
             description:
-                'Health of every configured service: version, disk space, failing health checks, and when each library was last scanned. Returns partial results with a `degraded` list rather than failing when a service is down.',
+                'Health of every configured service: version, disk space, failing health checks, when each library was last scanned, and what each instance is permitted to do. Returns partial results with a `degraded` list rather than failing when a service is down. The `permissions` list is also the set of ids you may pass as `instance` to other tools.',
             inputSchema: z.object({ detail: DetailSchema, limit: LimitSchema })
         },
         async ({ detail, limit }) => {
-            const result = await buildStackHealth(adapters, { detail, limit });
+            const result = await buildStackHealth(adapters, { detail, limit }, instances);
             const neverScanned = result.scans.filter(s => s.lastCompleted === undefined).length;
             const summary =
                 result.degraded.length === 0

--- a/test/adapters.test.ts
+++ b/test/adapters.test.ts
@@ -378,3 +378,30 @@ describe('version floors', () => {
         expect(d.version).toBe('6.3.0.10514');
     });
 });
+
+/**
+ * `added` is the only source of an added date in this stack. Driven off the
+ * recorded fixture rather than a hand-written shape, so the day Radarr renames
+ * the field this fails here instead of silently emptying `sort: 'added'`.
+ */
+describe('when a service added something', () => {
+    it('carries the date Radarr reported, verbatim', async () => {
+        const radarr = new RadarrAdapter(
+            keyed(7878),
+            serving({ '/api/v3/movie': fixture('radarr/movie.json') })
+        );
+
+        const items = await radarr.listLibrary();
+        expect(items[0]?.acquisition?.addedAt).toBe('2021-09-24T16:04:10Z');
+    });
+
+    it('omits it rather than inventing one when the service did not say', async () => {
+        const radarr = new RadarrAdapter(
+            keyed(7878),
+            serving({ '/api/v3/movie': [{ id: 1, title: 'No Date', tmdbId: 1, monitored: true, hasFile: true }] })
+        );
+
+        const items = await radarr.listLibrary();
+        expect(items[0]?.acquisition?.addedAt).toBeUndefined();
+    });
+});

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -282,3 +282,54 @@ describe('a thrown ServiceError reaches the client with its remedy', () => {
         expect(text).toMatch(/id/i);
     });
 });
+
+/**
+ * The bet this whole phase rests on: client support for prompts and resources
+ * is uneven, and arr-mcp has to work on all of them. So a client that surfaces
+ * neither must be exactly as capable as before. Too central to leave resting on
+ * it being obvious.
+ */
+describe('prompts and resources, beside the tools rather than instead of them', () => {
+    const list = async (method: string): Promise<Record<string, unknown>> => {
+        const res = await app().request(
+            'http://localhost:6060/mcp',
+            rpc({ jsonrpc: '2.0', id: 1, method }, { Authorization: `Bearer ${TOKEN}` })
+        );
+        return (await rpcPayload(res)).result ?? {};
+    };
+
+    it('advertises the five prompts', async () => {
+        const { prompts } = (await list('prompts/list')) as { prompts: { name: string }[] };
+        expect(prompts.map(p => p.name).sort()).toEqual([
+            'best_in_library',
+            'what_to_watch',
+            'whats_new',
+            'whats_wrong',
+            'why_not_playable'
+        ]);
+    });
+
+    it('advertises the three resources', async () => {
+        const { resources } = (await list('resources/list')) as { resources: { uri: string }[] };
+        expect(resources.map(r => r.uri).sort()).toEqual([
+            'arr://health',
+            'arr://instances',
+            'arr://library/summary'
+        ]);
+    });
+
+    /**
+     * Nineteen, unchanged. 0.9 extended three existing tools and added none —
+     * `CONTRIBUTING.md` calls the count a hard constraint because accuracy
+     * degrades past roughly forty, and a phase that quietly spent four of that
+     * budget on convenience would be the wrong trade.
+     */
+    it('still advertises exactly nineteen tools', async () => {
+        const res = await app().request(
+            'http://localhost:6060/mcp',
+            rpc(toolsList, { Authorization: `Bearer ${TOKEN}` })
+        );
+        const { result } = (await rpcPayload(res)) as { result: { tools: unknown[] } };
+        expect(result.tools).toHaveLength(19);
+    });
+});

--- a/test/getLibrary.test.ts
+++ b/test/getLibrary.test.ts
@@ -500,3 +500,41 @@ describe('ordering', () => {
         expect(result.items.map(i => i.title)).toEqual(['Unseen']);
     });
 });
+
+/**
+ * "What arrived this week" was unanswerable before 0.9: nothing in the merged
+ * shape carried an added date, which is also why 0.8 shipped `sort` without
+ * `added` in it.
+ */
+describe('sorting by when things arrived', () => {
+    const arrived = (title: string, at: string, tmdb: number): IndexInput =>
+        film({
+            title,
+            ids: { tmdb },
+            acquisition: { service: 'radarr', monitored: true, hasFile: true, addedAt: at }
+        });
+
+    it('puts the most recently added first', async () => {
+        const items = [
+            arrived('Old', '2020-01-01T00:00:00Z', 1),
+            arrived('New', '2026-08-01T00:00:00Z', 2),
+            arrived('Middle', '2023-05-05T00:00:00Z', 3)
+        ];
+        const result = await buildGetLibrary(loaderOf(items), { ...base, sort: 'added' });
+        expect(result.items.map(i => i.title)).toEqual(['New', 'Middle', 'Old']);
+    });
+
+    /**
+     * Media Jellyfin alone knows about has no acquisition half and so no added
+     * date. Sorting it as the epoch would answer "we do not know" with "1970" —
+     * the same failure as ranking an unrated title zero.
+     */
+    it('excludes items with no added date rather than dating them to the epoch', async () => {
+        const items = [
+            arrived('Known', '2026-08-01T00:00:00Z', 1),
+            film({ title: 'Unknown', ids: { tmdb: 2 } })
+        ];
+        const result = await buildGetLibrary(loaderOf(items), { ...base, sort: 'added' });
+        expect(result.items.map(i => i.title)).toEqual(['Known']);
+    });
+});

--- a/test/getLibrary.test.ts
+++ b/test/getLibrary.test.ts
@@ -538,3 +538,55 @@ describe('sorting by when things arrived', () => {
         expect(result.items.map(i => i.title)).toEqual(['Known']);
     });
 });
+
+/**
+ * "What am I still waiting for" is one of the most commonly asked questions of
+ * an *arr stack, and every comparable MCP server has a wanted/missing tool for
+ * it. arr-mcp could not express it at all: `monitored` existed, nothing about
+ * whether a file was on disk, and `presence` answers a different question —
+ * which services know about an item, not whether one exists.
+ */
+describe('filtering by whether a file exists', () => {
+    const onDisk = film({ title: 'Have it', ids: { tmdb: 1 } });
+    const waiting = film({
+        title: 'Waiting',
+        ids: { tmdb: 2 },
+        acquisition: { service: 'radarr', monitored: true, hasFile: false }
+    });
+    const { acquisition: _drop, ...unmanaged } = film({ title: 'Unmanaged', ids: { tmdb: 3 } });
+
+    it('answers "what am I still waiting for"', async () => {
+        const result = await buildGetLibrary(loaderOf([onDisk, waiting]), {
+            ...base,
+            has_file: false,
+            monitored: true
+        });
+        expect(result.items.map(i => i.title)).toEqual(['Waiting']);
+    });
+
+    it('answers "what can I actually watch"', async () => {
+        const result = await buildGetLibrary(loaderOf([onDisk, waiting]), { ...base, has_file: true });
+        expect(result.items.map(i => i.title)).toEqual(['Have it']);
+    });
+
+    /**
+     * Absent is not false. Media no *arr manages is not "waiting for a
+     * download" — nothing is going to fetch it — so sweeping it into
+     * `has_file: false` would put it on a list of things to chase. The same
+     * distinction `presence: unknown` exists to protect.
+     */
+    it('excludes unmanaged media from both answers', async () => {
+        const items = [onDisk, waiting, unmanaged as IndexInput];
+
+        expect(
+            (await buildGetLibrary(loaderOf(items), { ...base, has_file: false })).items.map(i => i.title)
+        ).toEqual(['Waiting']);
+        expect((await buildGetLibrary(loaderOf(items), { ...base, has_file: true })).items.map(i => i.title)).toEqual([
+            'Have it'
+        ]);
+    });
+
+    it('leaves the library alone when not asked for', async () => {
+        expect((await buildGetLibrary(loaderOf([onDisk, waiting]), base)).total).toBe(2);
+    });
+});

--- a/test/mcpPrompts.test.ts
+++ b/test/mcpPrompts.test.ts
@@ -1,0 +1,144 @@
+import { McpServer } from '@modelcontextprotocol/server';
+import { describe, expect, it } from 'vitest';
+import { registerAllPrompts } from '../src/mcp/prompts.ts';
+
+/**
+ * Prompts, read out of a real registration. What matters is not that the text
+ * is any particular wording, but that it stays honest about the tools it
+ * orchestrates and never crosses into instructing a write.
+ */
+
+// The SDK stores the callback as `handler` and calls it with (args, extra) —
+// both confirmed by inspecting a real registration rather than assumed. The
+// second argument is the request context, which these prompts never read.
+type Registered = {
+    argsSchema?: { shape?: Record<string, unknown> };
+    handler: (
+        args: Record<string, unknown>,
+        extra: Record<string, unknown>
+    ) => Promise<{ messages: { content: { text: string } }[] }>;
+};
+
+const registered = (): Record<string, Registered> => {
+    const server = new McpServer({ name: 'test', version: '0' });
+    registerAllPrompts(server);
+    return (server as unknown as { _registeredPrompts: Record<string, Registered> })._registeredPrompts;
+};
+
+const textOf = async (name: string, args: Record<string, unknown> = {}): Promise<string> =>
+    (await registered()[name]!.handler(args, {})).messages[0]!.content.text;
+
+const ALL = ['best_in_library', 'what_to_watch', 'whats_new', 'whats_wrong', 'why_not_playable'];
+/** The SDK validates arguments before calling the handler, so a prompt with a
+ *  required one has to be given it here. */
+const MINIMUM_ARGS: Record<string, Record<string, unknown>> = { why_not_playable: { title: 'Alien' } };
+
+const allTexts = (): Promise<string[]> => Promise.all(ALL.map(name => textOf(name, MINIMUM_ARGS[name] ?? {})));
+
+/** Everything registerAllTools registers, as of 0.9. */
+const TOOLS = new Set([
+    'diagnose',
+    'stack_health',
+    'search_media',
+    'get_media_details',
+    'get_library',
+    'get_queue',
+    'get_calendar',
+    'get_subtitles',
+    'get_playback',
+    'get_indexers',
+    'get_requests',
+    'lookup_media',
+    'discover_media',
+    'trigger_search',
+    'remove_queue_item',
+    'delete_media',
+    'respond_to_request',
+    'delete_request',
+    'add_media'
+]);
+
+/** Backticked identifiers in prompt text that are parameters, not tools. */
+const NOT_TOOLS = new Set([
+    'certain',
+    'has_file',
+    'rating_source',
+    'ratingCoverage',
+    'watched',
+    'limit',
+    'kind',
+    'query'
+]);
+
+describe('the prompts a client sees', () => {
+    it('offers the five questions this stack gets asked', async () => {
+        expect(Object.keys(registered()).sort()).toEqual(ALL);
+    });
+
+    it('takes the arguments each question needs', async () => {
+        expect(Object.keys(registered().why_not_playable?.argsSchema?.shape ?? {})).toEqual(['title']);
+        expect(Object.keys(registered().whats_wrong?.argsSchema?.shape ?? {})).toEqual([]);
+        expect(Object.keys(registered().what_to_watch?.argsSchema?.shape ?? {})).toEqual(['kind']);
+    });
+
+    it('puts the argument it was given into the text', async () => {
+        expect(await textOf('why_not_playable', { title: 'Alien' })).toContain('Alien');
+        expect(await textOf('what_to_watch', { kind: 'series' })).toContain('"series"');
+    });
+
+    it('omits an optional argument rather than writing undefined into the text', async () => {
+        expect(await textOf('what_to_watch')).not.toContain('undefined');
+        expect(await textOf('whats_new')).toContain('7');
+    });
+});
+
+/**
+ * A prompt naming a tool that does not exist tells the model to call nothing,
+ * and fails silently in the user's client. This is a live risk at 1.0, when the
+ * audit renames things — the point of this test is that such a rename breaks
+ * here, loudly, instead of there.
+ */
+describe('naming only tools that exist', () => {
+    it('references no tool the server does not register', async () => {
+        for (const text of await allTexts()) {
+            for (const match of text.match(/`([a-z_]+)`/g) ?? []) {
+                const name = match.replaceAll('`', '');
+                if (!name.includes('_') || NOT_TOOLS.has(name)) continue;
+                expect(TOOLS.has(name), `prompt names unknown tool \`${name}\``).toBe(true);
+            }
+        }
+    });
+});
+
+/**
+ * Write tools preview first and return a single-use token so a model cannot act
+ * without the user seeing what it would do. A prompt that instructed a write
+ * would route around that while looking like a convenience.
+ */
+describe('never instructing a write', () => {
+    it('does not tell the model to call a write tool', async () => {
+        for (const text of await allTexts()) {
+            expect(text).not.toMatch(/\bcall `?(trigger_search|delete_media|add_media|remove_queue_item)`?/i);
+        }
+    });
+
+    it('offers the one write it mentions, and says why it is not calling it', async () => {
+        const text = await textOf('why_not_playable', { title: 'Alien' });
+        expect(text).toMatch(/\*\*offer\*\*|offer/i);
+        expect(text).toContain('Do not call it');
+    });
+});
+
+/**
+ * The two things this server genuinely cannot do. A prompt that stayed silent
+ * about them invites the model to hallucinate a tool for each.
+ */
+describe('being honest about what it cannot reach', () => {
+    it('says the write audit is not a tool', async () => {
+        expect(await textOf('whats_wrong')).toContain('/ui/audit');
+    });
+
+    it('says nothing can trigger a library scan', async () => {
+        expect(await textOf('whats_wrong')).toMatch(/no tool that triggers a library scan/i);
+    });
+});

--- a/test/mcpResources.test.ts
+++ b/test/mcpResources.test.ts
@@ -1,0 +1,145 @@
+import { McpServer } from '@modelcontextprotocol/server';
+import { describe, expect, it } from 'vitest';
+import type { ServiceInstance } from '../src/config/instances.ts';
+import type { IndexInput } from '../src/core/resolver.ts';
+import { registerAllResources } from '../src/mcp/resources.ts';
+import type { ServiceAdapter } from '../src/services/types.ts';
+import { buildStackHealth } from '../src/tools/stackHealth.ts';
+import { LibraryLoader } from '../src/tools/library.ts';
+import type { ToolContext } from '../src/tools/register.ts';
+
+/**
+ * The resources, read through a real `McpServer` registration rather than by
+ * calling the callbacks directly — the registration itself (uri, mimeType,
+ * cacheHint) is half of what is being asserted.
+ */
+
+const film = (title: string, tmdb: number, hasFile: boolean): IndexInput => ({
+    kind: 'movie',
+    title,
+    ids: { tmdb },
+    acquisition: { service: 'radarr', monitored: true, hasFile }
+});
+
+const LIBRARY: IndexInput[] = [film('Have it', 1, true), film('Waiting', 2, false)];
+
+const radarr = (): ServiceAdapter =>
+    ({
+        id: 'radarr/4k',
+        type: 'radarr',
+        testConnection: async () => ({ ok: true, service: 'radarr/4k', latency_ms: 1, version: '5.0.0' }),
+        getVersion: async () => '5.0.0',
+        listLibrary: async () => LIBRARY
+    }) as unknown as ServiceAdapter;
+
+const instance = (id: string, safe_write: boolean, destructive: boolean): ServiceInstance =>
+    ({
+        id,
+        type: id.split('/')[0],
+        config: { permissions: { safe_write, destructive } }
+    }) as unknown as ServiceInstance;
+
+const INSTANCES = [instance('radarr/4k', true, false), instance('sonarr', false, false)];
+
+const context = (): ToolContext =>
+    ({
+        adapters: [radarr()],
+        instances: INSTANCES,
+        library: new LibraryLoader([radarr()], undefined)
+    }) as unknown as ToolContext;
+
+/** The registry the SDK builds, which is what a client actually sees. */
+const registered = () => {
+    const server = new McpServer({ name: 'test', version: '0' });
+    registerAllResources(server, context());
+    return (server as unknown as { _registeredResources: Record<string, Record<string, unknown>> })
+        ._registeredResources;
+};
+
+const read = async (uri: string): Promise<Record<string, unknown>> => {
+    const entry = registered()[uri] as { readCallback: (u: URL) => unknown } | undefined;
+    if (entry === undefined) throw new Error(`${uri} is not registered`);
+    const result = (await entry.readCallback(new URL(uri))) as { contents: { text: string }[] };
+    return JSON.parse(result.contents[0]!.text) as Record<string, unknown>;
+};
+
+const ALL = ['arr://instances', 'arr://health', 'arr://library/summary'];
+
+describe('the resources a client sees', () => {
+    it('registers all three', () => {
+        expect(Object.keys(registered()).sort()).toEqual([...ALL].sort());
+    });
+
+    it('names every instance a tool would accept as `instance`', async () => {
+        const body = (await read('arr://instances')) as { instances: { id: string; safe_write: boolean }[] };
+        expect(body.instances.map(i => i.id)).toEqual(['radarr/4k', 'sonarr']);
+        expect(body.instances[0]?.safe_write).toBe(true);
+    });
+
+    it('summarises the library as total, on disk and still wanted', async () => {
+        expect(await read('arr://library/summary')).toMatchObject({ total: 2, on_disk: 1, wanted: 1 });
+    });
+});
+
+/**
+ * A cache hint is advice a client may ignore; a timestamp inside the content
+ * cannot be dropped without dropping the content. A reader must never have to
+ * guess when a number was true.
+ */
+describe('saying when it was true', () => {
+    it('stamps every resource with an as_of', async () => {
+        for (const uri of ALL) {
+            expect(await read(uri)).toMatchObject({ as_of: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/) });
+        }
+    });
+});
+
+describe('cache hints', () => {
+    // The SDK hangs cacheHint off the registration itself, beside `metadata`
+    // rather than inside it — confirmed by inspecting a real registration
+    // rather than inferred from the config object's shape.
+    const hintFor = (uri: string) => (registered()[uri] as { cacheHint?: { ttlMs?: number } }).cacheHint;
+
+    /**
+     * A pinned "sonarr: reachable" five hours after Sonarr fell over is worse
+     * than the tool call it replaced — confidently wrong rather than absent.
+     */
+    it('forbids caching live health', () => {
+        expect(hintFor('arr://health')?.ttlMs).toBe(0);
+    });
+
+    it('permits caching the config-shaped one, which only an edit invalidates', () => {
+        expect(hintFor('arr://instances')?.ttlMs).toBeGreaterThan(0);
+    });
+
+    it('caches the summary for less time than the instance list', () => {
+        expect(hintFor('arr://library/summary')?.ttlMs).toBeLessThan(hintFor('arr://instances')?.ttlMs ?? 0);
+    });
+});
+
+/**
+ * The rule the whole phase rests on, asserted rather than assumed: client
+ * support for resources is uneven, so anything only a resource could answer
+ * would be unreachable wherever they are not surfaced.
+ */
+describe('mirroring, never originating', () => {
+    it('exposes no instance stack_health cannot also report', async () => {
+        const body = (await read('arr://instances')) as {
+            instances: { id: string; safe_write: boolean; destructive: boolean }[];
+        };
+        const health = await buildStackHealth([radarr()], { detail: 'standard', limit: 50 }, INSTANCES);
+
+        for (const i of body.instances) {
+            expect(health.permissions).toContainEqual({
+                instance: i.id,
+                safe_write: i.safe_write,
+                destructive: i.destructive
+            });
+        }
+    });
+
+    it('says outright that stack_health is the live answer', () => {
+        const health = registered()['arr://health'] as { metadata?: { description?: string } };
+        expect(health.metadata?.description).toContain('stack_health');
+    });
+});

--- a/test/stackHealth.test.ts
+++ b/test/stackHealth.test.ts
@@ -9,6 +9,7 @@ import type {
     ScanState,
     ServiceAdapter
 } from '../src/services/types.ts';
+import type { ServiceInstance } from '../src/config/instances.ts';
 import { buildStackHealth, registerStackHealth } from '../src/tools/stackHealth.ts';
 
 /** What `ArrAdapter` used to name, now spelled as the capabilities it is. */
@@ -314,5 +315,50 @@ describe('stack_health', () => {
     it('registers without throwing', () => {
         const server = new McpServer({ name: 'test', version: '0.0.0' });
         expect(() => registerStackHealth(server, [])).not.toThrow();
+    });
+});
+
+/**
+ * `arr://instances` needs to say what each instance is allowed to do, and a
+ * resource must mirror a tool rather than originate — a client that ignores
+ * resources must not be the only one unable to answer "what may I do here".
+ * So stack_health reports it.
+ *
+ * The permission *source* is untouched: `permissionSourceFrom` still reads
+ * config, deliberately, so an adapter cannot widen its own grants. This
+ * reports the gate's answer; it does not become a second one.
+ */
+describe('stack_health permissions', () => {
+    const instance = (id: string, safe_write: boolean, destructive: boolean) =>
+        ({
+            id,
+            type: id.split('/')[0],
+            config: { permissions: { safe_write, destructive } }
+        }) as unknown as ServiceInstance;
+
+    it('reports what each instance is allowed to do', async () => {
+        const result = await buildStackHealth([fakeArr({ diagnosis: healthy })], std, [
+            instance('radarr/4k', true, false),
+            instance('sonarr', false, false)
+        ]);
+
+        expect(result.permissions).toEqual([
+            { instance: 'radarr/4k', safe_write: true, destructive: false },
+            { instance: 'sonarr', safe_write: false, destructive: false }
+        ]);
+    });
+
+    /** Minimal answers "is anything broken", and a permission is not a fault. */
+    it('leaves permissions out of a minimal answer', async () => {
+        const result = await buildStackHealth([fakeArr({ diagnosis: healthy })], { detail: 'minimal', limit: 50 }, [
+            instance('radarr', true, true)
+        ]);
+        expect(result.permissions).toBeUndefined();
+    });
+
+    /** Every existing call site passes no instances and must keep working. */
+    it('omits the field entirely when nobody supplied instances', async () => {
+        const result = await buildStackHealth([fakeArr({ diagnosis: healthy })], std);
+        expect(result.permissions).toBeUndefined();
     });
 });


### PR DESCRIPTION
Phase 0.9. Spec and plan in `docs/superpowers/`.

## The problem

Nineteen tools cover the capability surface and **none of them is discoverable**. Connect arr-mcp for the first time and you get nineteen names with no indication which question to ask. The flagship one — *why isn't this playable* — is invisible unless you already knew `diagnose` existed.

The recurring questions are worse, because they aren't one call. *"What needs my attention?"* is `stack_health`, `get_queue`, `get_indexers` and `get_subtitles`, reconciled. Every user re-derives that sequence, and a model that gets it slightly wrong reports a healthy stack with a full disk.

## The constraint that shaped everything

Prompts and resources have the most uneven client support in MCP. arr-mcp is driven from Claude Code, Hermes Agent, Open Claw and others. **So neither may ever be the only path to something:**

- **Prompts are safe by construction** — a prompt is a sequence the model could have assembled anyway. A client ignoring them loses discoverability, never capability.
- **Resources are not** — one exposing data no tool returns would be unreachable. So **every resource mirrors a tool**.

`test/app.test.ts` asserts the property rather than trusting it, and the tool count is still **19** against CONTRIBUTING's ~40 ceiling. Three existing tools were extended; none was added.

## What's new

**Five prompts:** `why_not_playable`, `whats_wrong`, `what_to_watch`, `best_in_library`, `whats_new`.

**Three resources:** `arr://instances` (the ids every tool's `instance` wants), `arr://health`, `arr://library/summary`.

**Three tool extensions,** each forced by the above:

| Extension | Why |
| --- | --- |
| `get_library.has_file` | Every comparable MCP server has a wanted/missing tool. arr-mcp couldn't express the question — not for want of a tool, for want of a filter. |
| `get_library.sort: 'added'` + `acquisition.addedAt` | `whats_new` needed a date nothing carried. Closes the gap 0.8 documented, before 1.0 freezes the surface. |
| `stack_health.permissions` | `arr://instances` needed it and no tool reported it. The resource would have *originated* data — breaking the rule two sections after stating it. |

## Decisions worth reviewing

- **`addedAt` lives on `acquisition`, not on the item.** "When Radarr added this" is one fact; Jellyfin's `DateCreated` — when a file appeared in *its* library — is another. One field holding both would repeat the mistake Sonarr's unlabelled rating already taught this codebase. Jellyfin-only media has no acquisition half, so no added date.
- **`has_file` is strict where `monitored` coalesces.** `monitored ?? false` is right — unmanaged media genuinely isn't monitored. The same coalesce would be wrong here: Jellyfin-only media plainly *has* a file, and calling it missing would put something already on disk on a list of downloads to chase.
- **Both sorts exclude rather than default.** An undated item isn't from 1970; an unrated one isn't rated zero.
- **`arr://health` is `ttlMs: 0`.** A pinned "sonarr: reachable" five hours after it fell over is worse than the tool call it replaced. Every resource also carries `as_of`, because a cache hint is advice a client may ignore while a timestamp in the content can't be dropped.
- **No prompt instructs a write.** `why_not_playable` offers `trigger_search` and says not to call it. Tested.
- **Two prompts say what the server can't reach** — the write audit isn't a tool (it's at `/ui/audit`), and nothing can trigger a library scan. Silence there invites the model to invent a tool for each.

## The test that will matter most

**Prompts may only name tools that exist.** A prompt naming a renamed tool tells the model to call nothing and fails silently in the user's client. At 1.0, when the audit renames things, this breaks loudly here instead.

## Verification

- `npm test` — **1171 passing**, 58 files; typecheck and lint clean at all seven commits
- Three SDK details confirmed by inspecting a real registration rather than assumed: `cacheHint` sits beside `metadata` not inside it, the prompt callback is stored as `handler`, and it takes `(args, extra)` and returns a promise

## Not tagged `Release-As: 0.9.0`

Two things fixtures can't answer: **do the prompts actually appear in your clients** (they differ, and a client surfacing none of it is worth knowing before the README implies otherwise), and **does `has_file: false, monitored: true` match Radarr's own wanted list** — if those disagree, the filter is wrong in a way no fixture would show.

## Deferred to the 1.0 audit

An ecosystem comparison found one real gap this phase deliberately doesn't close: **nothing can trigger a library scan.** `diagnose` names a stale scan as the usual cause and `jellyfin.ts:48` already holds the `RefreshLibrary` key — to read it. The tool that identifies the problem can't fix it. That's a *write*, needing a permission tier and preview wording, so it belongs in the audit rather than appended here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
