### PR TITLE
chore: cut 0.9 as a phase, and write down why this keeps happening

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,6 +18,34 @@ bleeding edge. Nothing else. The release workflow fails the job when a release
 computes no version tag — a release that publishes only `latest` is a silent
 policy violation, and it has happened once.
 
+## Cutting a phase whose verification runs after the merge
+
+`CONTRIBUTING.md` says the minor is cut with a `Release-As: X.Y.0` footer on the
+last commit of the phase. That assumes the phase is fully verified before it
+merges. Twice now it has not been — 0.8 and 0.9 both ended with a manual gate
+that needs a live stack, and neither could be run before the PR went in.
+
+Leaving the footer off is the right call there: it is honest about what was
+verified. But `bump-patch-for-minor-pre-major` then does exactly its job and
+proposes a **patch**, so the phase would ship as `0.8.4` under a number the
+README roadmap has already promised to something else.
+
+So the second step is deliberate, not a mistake to avoid:
+
+```
+merge the phase PR        →  release-please proposes X.Y.(Z+1)
+merge a follow-up commit  →  Release-As: X.(Y+1).0
+                          →  the same release PR re-cuts itself
+```
+
+The follow-up may be empty (`git commit --allow-empty`) when its only job is the
+footer, though a small docs change is better — an empty commit in the log gives
+a future reader nothing to work with.
+
+**Check the version on the release PR before merging it**, every time. The title
+says which it is, and it is far cheaper to notice there than after the tag
+exists.
+
 ## If the release PR is BLOCKED with nothing failing
 
 `main` requires the `check` and `docker` status checks, with `enforce_admins:


### PR DESCRIPTION
Release-please proposed **0.8.1** for the prompts-and-resources phase (#77). This carries `Release-As: 0.9.0` so it is cut as the phase the roadmap says it is — and documents the pattern, because this is the second time.

## Why it recurs

`CONTRIBUTING.md` says the minor is cut with a `Release-As:` footer on the last commit of the phase. That assumes the phase is fully verified before it merges. **0.8 and 0.9 both ended with a manual gate needing a live stack**, and neither could run before the PR went in — 0.8 needed a real IMDb ingest, 0.9 needs the prompts checked against your actual clients.

Leaving the footer off is the honest call there. But `bump-patch-for-minor-pre-major` then does exactly its job and proposes a patch, so the phase ships under a number the README roadmap has already promised to something else. 0.8 nearly went out as `0.7.4`; 0.9 as `0.8.1`.

So `RELEASING.md` now records it as a **deliberate two-step** rather than a trap to remember:

```
merge the phase PR        →  release-please proposes X.Y.(Z+1)
merge a follow-up commit  →  Release-As: X.(Y+1).0
                          →  the same release PR re-cuts itself
```

Plus the check that actually catches it: **read the version on the release PR title before merging**. Far cheaper to notice there than after the tag exists.

After merging this, PR #78 re-cuts itself as `chore(main): release 0.9.0`.

## Still worth doing, not blocking

The 0.9 gate: do the five prompts actually appear in Claude Code, Hermes Agent and Open Claw? They differ, and a client surfacing none of it is worth knowing before the README implies otherwise — it would not be a failure of the phase, which is exactly what the degradation test in `app.test.ts` exists to prove. Also worth checking `has_file: false, monitored: true` against Radarr's own wanted list; if those disagree the filter is wrong in a way no fixture would show.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
