### PR TITLE
feat: 1.0 — the tool surface is stable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,27 +49,32 @@ reads them to decide the next version and to write `CHANGELOG.md`.
 | Prefix | Effect on version |
 | --- | --- |
 | `fix:` | patch |
-| `feat:` | patch while on 0.x, minor after 1.0 |
-| `feat!:` or a `BREAKING CHANGE:` footer | minor while on 0.x, major after 1.0 |
+| `feat:` | minor |
+| `feat!:` or a `BREAKING CHANGE:` footer | **major** |
 | `chore:`, `docs:`, `ci:`, `test:`, `refactor:` | none |
 
-**Minor versions are reserved for phases while we are pre-1.0.** `0.6`, `0.7`
-and so on each mark a phase from the roadmap, not an individual feature — that
-is what the roadmap table in the README is numbering. A feature therefore lands
-as a patch (`0.6.3`, `0.6.4`), and the minor is cut deliberately when the phase
-is complete, with a `Release-As: 0.7.0` footer on the last commit of the phase.
+**What counts as breaking**, which is the part worth writing down:
 
-This is what `bump-patch-for-minor-pre-major` in `release-please-config.json`
-does, and it is the reason it is on. Without it a single `feat:` consumes the
-next phase number: a one-panel dashboard change proposed `0.7.0` and would have
-taken the number Phase 7 is meant to carry.
+- A tool renamed or removed
+- A parameter renamed or removed
+- A field removed from a response
+
+Adding a tool, an optional parameter or a response field is a **minor** — those
+are additive and nothing that reads the old shape stops working.
+
+The pre-1.0 scheme is gone. Minors used to be reserved for roadmap phases, so a
+`feat:` landed as a patch and the minor was cut deliberately with a
+`Release-As:` footer; `bump-patch-for-minor-pre-major` in
+`release-please-config.json` is what enforced it and is now inert. `RELEASING.md`
+records how that worked, because two releases were nearly cut under the wrong
+number by forgetting it.
 
 ## The tool surface is the public API
 
 Renaming a tool or removing a parameter breaks every user's saved prompts and
 agent configuration, and it breaks **silently** — the model stops finding the
 tool rather than raising an error. Changes to tool names or parameters therefore
-get stricter review than ordinary refactors. After 1.0, a renamed tool keeps its
+get stricter review than ordinary refactors. Since 1.0, a renamed tool keeps its
 old name as an alias for one full minor, with the deprecation stated in the
 tool's own description text.
 
@@ -93,6 +98,22 @@ why `stack_health` reports per-instance permissions.
 
 The highest-value contribution, and deliberately self-contained. Six steps,
 each with a worked example already in the tree.
+
+**You will have to test it yourself, properly.** The maintainer does not run
+every service this could support — there is no Lidarr, no Plex, no qBittorrent
+here — so an adapter for one cannot be exercised in review, only read. That
+makes your testing the only testing it gets before it ships.
+
+Concretely: run it against your own live instance, say in the pull request what
+you tested and against which version, and capture fixtures from the real service
+rather than writing them by hand. A test that passes against an invented shape
+proves nothing about the service it claims to support.
+
+And write down whatever surprised you. Every adapter here carries a note about
+something its API does that the documentation does not mention — SABnzbd
+reporting gigabytes as a string, Sonarr's rating arriving unlabelled, Jellyfin
+localising its task names. Those notes have prevented more bugs than the code
+around them.
 
 1. **Add the service id** to `ServiceIdSchema` in `src/config/schema.ts`, and a
    schema for it in `ServicesSchema`. Reuse `KeyedServiceSchema` unless the

--- a/README.md
+++ b/README.md
@@ -20,17 +20,6 @@ Jellyfin. arr-mcp correlates them and gives you the causal chain.
   broken and what to do about it, and read the logs and the write audit — no
   hand-edited YAML, no restart.
 
-> ### Status: 0.9 — questions, not just tools
->
-> Nineteen tools and no hint which to reach for is a menu nobody can read. This
-> adds five prompts for the questions this stack actually gets asked — why isn't
-> this playable, what needs my attention, what should I watch, what's the best
-> thing I own, what happened this week — plus three resources, chiefly the list
-> of instance ids every tool wants. Both degrade cleanly: client support for
-> them is uneven, and **nothing is reachable only through them**. `get_library`
-> also gains `has_file`, so "what am I still waiting for" is finally a question
-> you can ask.
-> See [the roadmap](#roadmap).
 
 ## Services
 
@@ -533,27 +522,43 @@ The UI is served over plain http on your LAN, like the services it manages.
 Put it behind a reverse proxy with TLS if it needs to leave the LAN, and pin
 `allowed_hosts` if you do.
 
-## Roadmap
+## What 1.0 promises
 
-| Version | Delivers |
+**The tool surface is stable.** Tool names, their parameters and the fields they
+return are the public API — and they break *silently*, because a model stops
+finding a renamed tool rather than raising an error. So from 1.0:
+
+| Change | Version |
 | --- | --- |
-| 0.1 / 0.2 | Walking skeleton: stateless MCP transport, bearer auth, Radarr, `stack_health` |
-| 0.3 | The remaining seven service adapters and ten read tools |
-| 0.4 | Cross-service correlation: identity resolver, three-way library join, `diagnose` |
-| 0.5 | Writes: permission tiers, `dry_run`, write audit, per-call confirmation |
-| 0.6 | Web config page: dashboard, diagnosing connection tests, log streams, config editing with hot reload |
-| 0.7 | Multiple Radarr, Sonarr and Bazarr instances — an HD and a 4K stack read as one library |
-| 0.8 | A local IMDb dataset: ratings that are consistent across films and series, and orderable |
-| 0.9 | Prompts and resources: the questions worth asking, and the ids every tool wants |
-| 1.0 | The tool surface settles: security, consistency and dead-code audit |
+| A tool renamed or removed, a parameter renamed or removed, a response field removed | **major** |
+| A tool added, an optional parameter added, a response field added | minor |
+| Everything else | patch |
 
-Each version is a self-contained, shippable slice — the goal is that 0.4 already
-answers questions no individual service can, with 0.5–0.7 making it complete.
+Two parameters were inconsistent when the surface froze, and both old spellings
+keep working forever: `discover_media` takes `kind` but still accepts
+`media_type`, and `get_library` takes `user` but still accepts `watched_by`.
+They are no longer documented, and nothing else will be quietly retired that
+way.
 
-0.1 and 0.2 are the same code under two tags. Dropping the component prefix
-from the release configuration made the release tooling treat the package as
-new and re-cut it; the changelog shows the same features twice. Not two
-releases.
+## Contributing
+
+**Contributions are welcome, and new service adapters most of all.** If you run
+something this does not speak to — Lidarr, Readarr, qBittorrent, Tautulli — an
+adapter is deliberately the most self-contained thing in the codebase, and
+[CONTRIBUTING.md](CONTRIBUTING.md) walks through it.
+
+One thing to know before you start: **I cannot test a service I do not run.** I
+have no Lidarr, no Plex, no qBittorrent, and reviewing an adapter for a service
+I cannot exercise means reading it and trusting you. So the bar for a new
+adapter is that *you* have tested it hard against your own live instance, and
+that the pull request says what you tested and against which version. Record
+what surprised you in a comment — every adapter here has a note about something
+its API does that the docs do not mention, and those notes are worth more than
+the code around them.
+
+Fixtures are captured from real services rather than hand-written for the same
+reason. A test that passes against an invented shape proves nothing about the
+service it claims to support.
 
 ## Requirements
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -31,7 +31,7 @@ export function buildApp(opts: { runtime: Runtime; audit: WriteAudit; logs: LogS
     const { runtime, audit, logs } = opts;
 
     // The factory runs once per request, so every call gets a fresh McpServer.
-    // This is what keeps the transport stateless (design spec §5) — do not
+    // This is what keeps the transport stateless — do not
     // hoist the server out of the closure.
     //
     // `runtime.current` is read here, per request, rather than captured when

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -38,7 +38,7 @@ const seedConfig = () => ({
 /**
  * Reads <configDir>/config.yaml, creating it with a generated bearer token on
  * first run. The file is the source of truth; environment variables seed
- * first-run defaults only (design spec §13).
+ * first-run defaults only.
  */
 /**
  * `persist: false` reads without ever writing.

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -46,17 +46,13 @@ const KeyedServiceSchema = z.strictObject({ ...BaseServiceShape, ...ApiKeyShape 
 export type KeyedServiceConfig = z.infer<typeof KeyedServiceSchema>;
 
 /**
- * Which services may appear more than once.
+ * Which services may appear more than once. Quality tiers are the reason anyone
+ * runs two — an HD and a 4K Radarr, their Sonarrs, and a Bazarr per stack
+ * because Bazarr connects to exactly one of each.
  *
- * Quality tiers are the reason anyone runs two of something: an HD and a 4K
- * Radarr, the matching Sonarrs, and a Bazarr per stack because Bazarr connects
- * to exactly one Radarr and one Sonarr.
- *
- * The other five are deliberately single. Prowlarr feeds every *arr from one
- * place and Seerr connects to your instances itself, so a second one is not a
- * tier — and more to the point, `register.ts` selects those with a `.find`.
- * Admitting a shape the code then degrades on is worse than refusing it, so the
- * schema refuses it.
+ * The other five are deliberately single: a second Prowlarr or Seerr is not a
+ * tier, and `register.ts` selects those with a `.find`. Admitting a shape the
+ * code then degrades on is worse than refusing it.
  */
 export const MULTI_INSTANCE: readonly ServiceId[] = ['bazarr', 'radarr', 'sonarr'];
 
@@ -195,19 +191,13 @@ const ServicesSchema = z
     .default({});
 
 /**
- * Metadata sources that are not services (0.8 spec ).
+ * Metadata sources that are not services: nothing here is reachable, has a URL
+ * or can be tested, and none of it is a credential.
  *
- * Separate from `services` because nothing here is reachable, has a URL, or
- * can be tested — an instance card would have nothing to put on it. It also
- * holds no credential, so the no-echo rule that shapes the rest of the config
- * page does not reach it.
- *
- * `.strict()` on both levels, and the reason is the same in each. The setting
- * a user is most likely to invent is a refresh interval, and IMDb publishes
- * daily — there is no second answer to choose between. A knob whose only
- * sensible value is the default exists to be got wrong, and quietly ignoring
- * one that was set is worse than refusing it: the user believes it took
- * effect.
+ * `.strict()` at both levels because the setting a user is most likely to
+ * invent is a refresh interval, and IMDb publishes daily — there is no second
+ * answer. Quietly ignoring one that was set is worse than refusing it, since
+ * the user believes it took effect.
  */
 export const MetadataSchema = z
     .object({
@@ -230,14 +220,13 @@ export const ConfigSchema = z.object({
         /**
          * scrypt hash of the UI password, `scrypt$salt$hash`.
          *
-         * Optional, unlike `bearer_token`, and the difference is the whole
-         * design: absent means **unclaimed**, and the config UI serves its
-         * setup page instead of a login form until someone chooses a password
-         * in the browser. A bearer token has no interactive path, so a missing
-         * one must be generated; a password does, so one is never invented.
+         * Optional, unlike `bearer_token`, and that difference is the design:
+         * absent means **unclaimed**, so the config UI serves its setup page
+         * until someone chooses a password in the browser. A bearer token has
+         * no interactive path and must be generated; a password does, so one is
+         * never invented.
          *
-         * Deleting this line is how you ask for a new password, and it puts
-         * the instance on exactly the path a fresh install takes. The password
+         * Deleting this line is how you ask for a new password. The password
          * itself is never stored and never logged.
          */
         password_hash: z.string().min(1).optional(),

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -13,7 +13,7 @@ export const ServiceIdSchema = z.enum([
 export type ServiceId = z.infer<typeof ServiceIdSchema>;
 
 /**
- * Permission tiers per the design spec §10. Both default to off: a service
+ * Permission tiers per the Both default to off: a service
  * added by hand-editing YAML must not silently acquire write access.
  */
 const PermissionsSchema = z
@@ -127,12 +127,12 @@ export type Instanced<T> = T & { readonly name?: string | undefined };
 export type BaseServiceConfig = Pick<KeyedServiceConfig, 'url' | 'timeout_ms' | 'permissions'>;
 
 /**
- * Jellyfin and Seerr only (design spec §9) — the two services with their own
+ * Jellyfin and Seerr only — the two services with their own
  * user concepts.
  *
  * `default_user` is optional on purpose: configuring a service purely so it
  * appears in stack_health is legitimate, and guessing an identity is the silent
- * mismatch §14 warns about. A per-user tool called with nothing configured
+ * mismatch warns about. A per-user tool called with nothing configured
  * fails naming this key.
  */
 const MultiUserServiceSchema = z.strictObject({
@@ -195,7 +195,7 @@ const ServicesSchema = z
     .default({});
 
 /**
- * Metadata sources that are not services (0.8 spec §3).
+ * Metadata sources that are not services (0.8 spec ).
  *
  * Separate from `services` because nothing here is reachable, has a URL, or
  * can be tested — an instance card would have nothing to put on it. It also

--- a/src/core/audit.ts
+++ b/src/core/audit.ts
@@ -5,7 +5,7 @@ import type { WriteTier } from './permissions.ts';
 import { logger } from './logger.ts';
 
 /**
- * Design spec §10's write audit: a durable answer to "what did this thing do
+ * The write audit: a durable answer to "what did this thing do
  * to my library, and who asked it to".
  *
  * SQLite rather than a JSONL file because 0.6's config page has to *read* this

--- a/src/core/auth.ts
+++ b/src/core/auth.ts
@@ -1,7 +1,7 @@
 /**
  * Per-service request shaping, and nothing else. Resilience policy lives in
  * ServiceHttp; keeping the two apart is what stops Transmission's session
- * handshake leaking into the adapter contract (design spec §6).
+ * handshake leaking into the adapter contract.
  */
 export interface AuthContext {
     url: URL;

--- a/src/core/cache.ts
+++ b/src/core/cache.ts
@@ -1,5 +1,5 @@
 /**
- * Design spec §16, with one deviation recorded in the Phase 3 design §3: this
+ * This cache is
  * is a TTL map, **not an LRU**.
  *
  * Eviction solves unbounded key growth, and the key space here is about a dozen
@@ -9,7 +9,7 @@
  */
 export type Clock = () => number;
 
-/** §16: library reads ~5 min, health ~30 s. */
+/** library reads ~5 min, health ~30 s. */
 export const LIBRARY_TTL_MS = 300_000;
 export const HEALTH_TTL_MS = 30_000;
 
@@ -59,7 +59,7 @@ export class TtlCache {
         } catch (err) {
             // Never cache a failure. A service restarting during the first call
             // would otherwise poison every later call until arr-mcp restarts —
-            // the same lesson the identity directory taught in Phase 2.
+            // the same lesson the identity directory taught earlier.
             //
             // Guarded on identity: a later successful load may already have
             // replaced this entry, and dropping that would be a second bug.
@@ -69,8 +69,8 @@ export class TtlCache {
     }
 
     /**
-     * The seam for write-invalidation (§16). Still nothing in production code
-     * calls it as of Phase 3b (only `test/cache.test.ts` exercises it
+     * The seam for write-invalidation. Still nothing in production code
+     * calls it (only `test/cache.test.ts` exercises it
      * directly): `LibraryLoader` needed "do not cache a degraded load," but
      * implemented it via `get`'s `shouldCache` predicate instead of a
      * follow-up call here, specifically to reuse the identity check that

--- a/src/core/confirm.ts
+++ b/src/core/confirm.ts
@@ -3,8 +3,8 @@ import type { Clock } from './cache.ts';
 import type { WriteTier } from './permissions.ts';
 
 /**
- * Design spec §10's per-call confirmation, built to survive the stateless
- * transport of §5.
+ * The per-call confirmation, built to survive the stateless
+ * transport
  *
  * A write tool called without `confirm` performs nothing and hands back a
  * preview plus a token. Calling again with that token performs the write. The

--- a/src/core/confirm.ts
+++ b/src/core/confirm.ts
@@ -3,32 +3,25 @@ import type { Clock } from './cache.ts';
 import type { WriteTier } from './permissions.ts';
 
 /**
- * The per-call confirmation, built to survive the stateless
- * transport
+ * The per-call confirmation, built to survive a stateless transport.
  *
  * A write tool called without `confirm` performs nothing and hands back a
- * preview plus a token. Calling again with that token performs the write. The
- * point is not to stop a determined model — it holds the token and can always
- * call twice — it is that the *first* call is the one that cannot mutate
- * anything, so a mis-parsed instruction ("delete the Alien films") surfaces as
- * a preview a human sees before it becomes a deletion.
+ * preview plus a token; calling again with that token performs the write. The
+ * point is not to stop a determined model — it holds the token and can call
+ * twice — it is that the *first* call cannot mutate anything, so a mis-parsed
+ * instruction ("delete the Alien films") surfaces as a preview a human sees.
  *
- * Two properties do the work:
+ * Two properties do the work. The token is an **HMAC over the exact
+ * operation**, so one issued for "delete movie 5" cannot be replayed as
+ * "delete movie 9" — without that binding a model could preview something
+ * harmless and confirm something else, which is worse than no confirmation
+ * because it looks like protection. And it is **single-use**, so "add movie"
+ * cannot be confirmed twice into a duplicate.
  *
- *   1. The token is an HMAC over the exact operation, so a token issued for
- *      "delete movie 5" cannot be replayed as "delete movie 9". Without this
- *      binding a model could preview something harmless and then confirm
- *      something else, which is strictly worse than no confirmation because it
- *      looks like protection.
- *   2. It is single-use, so "add movie" cannot be confirmed twice into a
- *      duplicate.
- *
- * The signing key is fresh per process and never written down: a restart
- * invalidating outstanding tokens is correct, not a limitation. The alternative
- * — deriving it from the bearer token — would tie confirmation lifetime to
- * credential rotation, which are unrelated concerns.
+ * The signing key is fresh per process and never written down. A restart
+ * invalidating outstanding tokens is correct: deriving it from the bearer
+ * token would tie confirmation lifetime to credential rotation.
  */
-
 /** Long enough for a model to read a preview and decide; short enough that a
  *  token found in an old transcript is dead. */
 export const CONFIRM_TTL_MS = 300_000;

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -31,7 +31,7 @@ function formatServiceError(kind: ServiceErrorKind, service: string, detail: str
 
 /**
  * A model told *why* something failed reports it; a model handed an opaque
- * error invents an explanation (design spec §15). The remedy therefore lives
+ * error invents an explanation. The remedy therefore lives
  * in `.message` itself, not only in `toModelText()`: every path that throws
  * this error is caught somewhere as a plain `Error`, and the only field a
  * generic catcher reads is `.message` — including the MCP SDK's own tool

--- a/src/core/fence.ts
+++ b/src/core/fence.ts
@@ -1,10 +1,10 @@
 
 /**
- * Design spec §11: everything a service returns is untrusted data, never
+ * everything a service returns is untrusted data, never
  * instruction. Prowlarr returns release names from public indexers — those
  * strings are attacker-controllable and flow straight into model context.
  *
- * This is mitigations 2 and 3 of the five in §11. It does not make injection
+ * This is two of the five mitigations It does not make injection
  * impossible; it makes injected text visibly *data*, and removes the
  * characters that let a string render as something other than what it is.
  */

--- a/src/core/gather.ts
+++ b/src/core/gather.ts
@@ -10,12 +10,12 @@ export type Gathered<T> = {
 };
 
 /**
- * Design spec §15: cross-service tools degrade, they do not fail. A tool
+ * cross-service tools degrade, they do not fail. A tool
  * spanning four services with one down returns three services' results plus
  * the name of the fourth — never an exception, and never a silently short list
  * that reads as "there is nothing in your queue".
  *
- * `counts` is measured before the caller truncates. §12's truncation contract
+ * `counts` is measured before the caller truncates. The truncation contract
  * says how many items were dropped but not which service lost them, and merged
  * lists are limited after concatenation — so without this, a long list from one
  * service can push another out of the response entirely and the model has no

--- a/src/core/http.ts
+++ b/src/core/http.ts
@@ -7,7 +7,7 @@ export const CIRCUIT_THRESHOLD = 5;
 export const CIRCUIT_COOLDOWN_MS = 60_000;
 
 /**
- * The one implementation of design spec §15's resilience policy. Eight
+ * The one implementation of the resilience policy. Eight
  * adapters sharing this is what makes "the breaker opens after five failures"
  * a checkable property of the stack rather than a property of Radarr.
  */
@@ -29,7 +29,7 @@ export class ServiceHttp {
         this.#fetch = fetchImpl;
     }
 
-    /** Reads retry once on timeout (design spec §15). */
+    /** Reads retry once on timeout. */
     async get<T>(path: string): Promise<T> {
         return this.#request<T>('GET', path, undefined, true);
     }

--- a/src/core/identity.ts
+++ b/src/core/identity.ts
@@ -5,12 +5,12 @@ import { ServiceError } from './errors.ts';
 type IdentityConfig = Pick<MultiUserServiceConfig, 'default_user' | 'allow_other_users'>;
 
 /**
- * Design spec §9. Two of the eight services have their own user concepts, and
+ * Two of the eight services have their own user concepts, and
  * both issue admin-scoped keys — so one key plus a user parameter can query as
  * anybody. `allow_other_users` exists to make that deliberate rather than
  * incidental.
  *
- * The gate runs before any network call and reads configuration only: §11.4
+ * The gate runs before any network call and reads configuration only
  * requires that no value a service returns can widen what the model may do.
  */
 export class IdentityResolver {
@@ -70,7 +70,7 @@ export class IdentityResolver {
 
     /**
      * Users change rarely, so the directory is fetched once per process
-     * (design spec §16 makes the cache in-memory and restart-clearing). A
+     * ( makes the cache in-memory and restart-clearing). A
      * failed fetch is deliberately not cached: a service restarting during the
      * first call would otherwise poison every later one until arr-mcp itself
      * restarts.

--- a/src/core/logs.ts
+++ b/src/core/logs.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import type { ServiceId } from '../config/schema.ts';
 
 /**
- * The SQLite ring buffer `logger.ts` has been pointing at since Phase 1, and
+ * The SQLite ring buffer `logger.ts` has been pointing at, and
  * the store behind the config UI's log streams.
  *
  * A ring buffer, not an audit trail — the opposite of `audit.ts`, and kept in

--- a/src/core/permissions.ts
+++ b/src/core/permissions.ts
@@ -3,7 +3,7 @@ import type { AnyServiceConfig } from '../config/schema.ts';
 import { ServiceError } from './errors.ts';
 
 /**
- * Design spec §10's two tiers, as an **ordered** pair rather than two
+ * The two tiers, as an **ordered** pair rather than two
  * independent switches.
  *
  * `safe` is a mutation the service itself can undo: monitor a movie, trigger a
@@ -109,7 +109,7 @@ export function checkPermission(source: PermissionSource, service: string, tier:
 }
 
 /**
- * The live-write form of the same check. Throws the §15-shaped error, so a
+ * The live-write form of the same check. Throws the standard degraded-service error, so a
  * refusal reaches the model as a sentence naming the exact YAML key to change
  * rather than as a bare "forbidden" it would then have to guess about.
  */

--- a/src/core/resolver.ts
+++ b/src/core/resolver.ts
@@ -3,12 +3,12 @@ import { RANK_NONE, rankTitle, unfenced } from './titleMatch.ts';
 export type ExternalIds = { tmdb?: number; tvdb?: number; imdb?: string };
 
 /**
- * Named sources rather than a loose map: these are the only ones there are, and a
- * `Record<string, number>` accepts a source name that does not exist.
+ * Named sources rather than a loose map, which would accept a source name that
+ * does not exist.
  *
- * A film populates some subset of the first five. A series populates `tvdb`
- * and nothing else — Sonarr's rating is one flat value,
- * unrelated to Radarr's per-source map. The two never mix.
+ * A film populates some subset of the first five; a series populates `tvdb`,
+ * plus `imdb` from the IMDb dataset. Sonarr's own rating is one flat value,
+ * unrelated to Radarr's per-source map — the two never mix.
  */
 export type MergedRatings = {
     imdb?: number;
@@ -37,43 +37,31 @@ export type MergedItem = {
         quality?: string;
         sizeBytes?: number;
         /**
-         * When the managing service added it, ISO 8601, exactly as that service
-         * reported it.
+         * When the managing service added it, ISO 8601, as reported.
          *
-         * On `acquisition` rather than on the item, and that placement is the
-         * decision. "When Radarr added this" is one unambiguous fact; Jellyfin's
-         * `DateCreated` — when a file appeared in *its* library — is a different
-         * one, and a single field holding both answers would repeat the mistake
-         * Sonarr's unlabelled rating already taught this codebase. Media
-         * Jellyfin alone knows about has no acquisition half and therefore no
-         * added date, which `sort: 'added'` reports by omission rather than by
-         * guessing.
+         * On `acquisition` rather than on the item, deliberately: "when Radarr
+         * added this" and Jellyfin's `DateCreated` are different facts, and one
+         * field holding both repeats the mistake Sonarr's unlabelled rating
+         * taught. Jellyfin-only media has no acquisition half and so no added
+         * date, which `sort: 'added'` reports by omission rather than guessing.
          */
         addedAt?: string;
     };
     playback?: { user: string; watched: boolean; playCount?: number; lastPlayed?: string };
     ratings?: MergedRatings;
     /**
-     * the diagnostic payload. `arr_only` **with a file** means a broken
-     * Jellyfin import — but only when Jellyfin actually answered: `arr_only`
-     * is what an *arr-managed item looks like whether Jellyfin found nothing
-     * *or was never asked at all*, and asserting the former across the latter
-     * is exactly the collapse a review found (the central
-     * constraint: "empty is looked and found nothing; undefined is could not
-     * look" applied one layer too shallow). `jellyfin_only` means media
-     * nothing is managing. Neither is visible from any single service.
+     * What no single service can tell you.
      *
-     * `unknown` covers two distinct shortfalls, deliberately not split
-     * further (`build`'s `BuildOptions` documents why a caller cannot even
-     * tell them apart from the input alone): a record with **neither** half
-     * of evidence at all, and an *arr-only record whose Jellyfin half was
-     * never gathered for this build — degraded, or never configured. Real
-     * *arr adapter data always contributes `acquisition`, so the
-     * neither-half case never happens on its own; what does happen, and what
-     * this state exists to stop, is a degraded or unconfigured Jellyfin
-     * making `LibraryIndex.build` fabricate `arr_only` — and with it a false
-     * "Jellyfin cannot see this file" — for every item in the library.
-     * `unknown` is the only answer that does not fabricate a source.
+     * `arr_only` **with a file** means a broken Jellyfin import — but only
+     * when Jellyfin actually answered. An *arr-managed item looks identical
+     * whether Jellyfin found nothing or was never asked, and asserting the
+     * first across the second is the collapse this guards: empty is "looked
+     * and found nothing", undefined is "could not look". `jellyfin_only`
+     * means media nothing is managing.
+     *
+     * `unknown` is what a degraded or unconfigured Jellyfin gets, instead of
+     * `arr_only` and a false "Jellyfin cannot see this file" across the whole
+     * library — the only answer that does not fabricate a source.
      */
     presence: 'both' | 'arr_only' | 'jellyfin_only' | 'unknown';
 };

--- a/src/core/resolver.ts
+++ b/src/core/resolver.ts
@@ -3,11 +3,11 @@ import { RANK_NONE, rankTitle, unfenced } from './titleMatch.ts';
 export type ExternalIds = { tmdb?: number; tvdb?: number; imdb?: string };
 
 /**
- * Named sources rather than a loose map: §8 lists exactly these, and a
+ * Named sources rather than a loose map: these are the only ones there are, and a
  * `Record<string, number>` accepts a source name that does not exist.
  *
  * A film populates some subset of the first five. A series populates `tvdb`
- * and nothing else — §21.2 established that Sonarr's rating is one flat value,
+ * and nothing else — Sonarr's rating is one flat value,
  * unrelated to Radarr's per-source map. The two never mix.
  */
 export type MergedRatings = {
@@ -24,9 +24,9 @@ export type MergedItem = {
     title: string;
     year?: number;
     /**
-     * Absent from §4.1's record and required by §5: `genre` is a `get_library`
+     * Absent from the record and required because `genre` is a `get_library`
      * filter, and no other field in the merged shape could answer one.
-     * Recorded here as a correction to the design rather than bolted on in 3b.
+     * Recorded here as a correction to the design rather than bolted on later.
      */
     genres?: string[];
     ids: ExternalIds;
@@ -54,11 +54,11 @@ export type MergedItem = {
     playback?: { user: string; watched: boolean; playCount?: number; lastPlayed?: string };
     ratings?: MergedRatings;
     /**
-     * §8's diagnostic payload. `arr_only` **with a file** means a broken
+     * the diagnostic payload. `arr_only` **with a file** means a broken
      * Jellyfin import — but only when Jellyfin actually answered: `arr_only`
      * is what an *arr-managed item looks like whether Jellyfin found nothing
      * *or was never asked at all*, and asserting the former across the latter
-     * is exactly the collapse the whole-phase review found (§8's central
+     * is exactly the collapse a review found (the central
      * constraint: "empty is looked and found nothing; undefined is could not
      * look" applied one layer too shallow). `jellyfin_only` means media
      * nothing is managing. Neither is visible from any single service.
@@ -126,7 +126,7 @@ function mergeInto(target: MergedItem, input: IndexInput): void {
 }
 
 /**
- * §8's shared join. Records merge when **any** strong id matches, which is what
+ * the shared join. Records merge when **any** strong id matches, which is what
  * handles Radarr knowing only `tmdbId` while Jellyfin knows only `Imdb`.
  *
  * Records sharing no id stay separate. That is correct rather than lossy:

--- a/src/core/resolver.ts
+++ b/src/core/resolver.ts
@@ -70,18 +70,15 @@ export type IndexInput = Omit<MergedItem, 'presence'>;
 
 export type BuildOptions = {
     /**
-     * Whether Jellyfin's half of *this* build was actually gathered —
-     * configured *and* read without error. Defaults to `true`, so a caller
-     * that does not pass it keeps `build`'s original behaviour (every
-     * existing call site but one).
+     * Whether Jellyfin's half of *this* build was gathered — configured *and*
+     * read without error. Defaults to `true`, so existing call sites are
+     * unchanged.
      *
-     * `LibraryIndex` has no way to tell "Jellyfin looked and this item is
-     * genuinely absent" from "Jellyfin was never asked" on its own: both
-     * arrive here as an `IndexInput` with `acquisition` set and `playback`
-     * unset — the join is symmetric, and an unset field carries no reason.
-     * `LibraryLoader` is the one caller that knows which case it is (it owns
-     * the fetch that did or did not happen), and passes it in rather than
-     * `LibraryIndex` guessing.
+     * `LibraryIndex` cannot tell "Jellyfin looked and this is genuinely absent"
+     * from "Jellyfin was never asked": both arrive with `acquisition` set and
+     * `playback` unset, and an unset field carries no reason. `LibraryLoader`
+     * owns the fetch, so it knows which — and passes it in rather than letting
+     * the index guess.
      */
     jellyfinGathered?: boolean;
 };

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -10,19 +10,13 @@ import { logger } from './logger.ts';
 import { Sessions } from './session.ts';
 
 /**
- * Everything a request needs that a config change can invalidate, behind one
- * swap.
+ * Everything a config change can invalidate, behind one swap — so editing
+ * config from the web page takes effect without restarting the container.
  *
- * Before the config UI, `index.ts` read the config once, built the adapters
- * once, and handed both to `buildApp`, which closed over them — so changing a
- * service meant restarting the container. Editing config from a web page and
- * then telling the user to restart it would be a worse experience than the
- * hand-edited YAML it replaces.
- *
- * The swap is one assignment of an immutable snapshot, not a mutation of a
+ * The swap is one assignment of an immutable snapshot, never a mutation of a
  * live object. A request that started before a reload finishes against the
- * snapshot it began with, rather than seeing half of each — which is what
- * makes "reload while a tool call is in flight" safe without any locking.
+ * snapshot it began with rather than seeing half of each, which is what makes
+ * "reload mid-tool-call" safe without any locking.
  */
 
 export type RuntimeSnapshot = {

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -7,7 +7,7 @@ import { createHmac, randomBytes, scryptSync, timingSafeEqual } from 'node:crypt
  * key and can change them. So the password is never stored — only a scrypt
  * hash — and the session cookie is a signed, expiring token rather than an
  * identifier looked up in a table, which keeps the transport as stateless as
- * §5 asks while still expiring properly.
+ *  asks while still expiring properly.
  */
 
 /** scrypt parameters. N=16384 is the Node default and costs ~50ms here, which

--- a/src/core/shape.ts
+++ b/src/core/shape.ts
@@ -42,3 +42,41 @@ export function applyLimit<T>(
         truncated: sliced.length < items.length
     };
 }
+
+/**
+ * The documented name's value, honouring an older spelling that still works.
+ *
+ * 1.0 froze the tool surface, and two names were inconsistent when it was
+ * frozen: `discover_media` asked for `media_type` in a vocabulary it did not
+ * answer in, and `get_library` called a Jellyfin user `watched_by` where two
+ * other tools call it `user`. Both old spellings keep working forever and stop
+ * being documented — removing one would break a saved prompt silently, which is
+ * exactly the failure freezing the surface exists to prevent.
+ *
+ * Disagreeing values are refused rather than resolved. Preferring one silently
+ * would make the answer depend on a precedence rule nobody wrote down, and the
+ * caller would never learn which half of their request was dropped.
+ *
+ * Shared rather than written twice, because two hand-rolled copies is how the
+ * two ends up behaving differently before anyone notices.
+ */
+export function preferred<T>(opts: {
+    name: string;
+    value: T | undefined;
+    alias: string;
+    aliasValue: T | undefined;
+    /** Maps the alias's vocabulary onto the documented one, where they differ —
+     *  `media_type: 'tv'` means the same as `kind: 'series'`. */
+    translate?: (value: T) => T;
+}): T | undefined {
+    const translate = opts.translate ?? ((value: T) => value);
+    const fromAlias = opts.aliasValue === undefined ? undefined : translate(opts.aliasValue);
+
+    if (opts.value !== undefined && fromAlias !== undefined && opts.value !== fromAlias) {
+        throw new Error(
+            `\`${opts.name}\` and \`${opts.alias}\` were both given and contradict each other. They are the same setting — \`${opts.alias}\` is the older spelling, kept working but no longer documented. Send one.`
+        );
+    }
+
+    return opts.value ?? fromAlias;
+}

--- a/src/core/shape.ts
+++ b/src/core/shape.ts
@@ -20,7 +20,7 @@ export const LimitSchema = z
     .describe(`Maximum items to return. Defaults to ${DEFAULT_LIMIT}, hard maximum ${MAX_LIMIT}.`);
 
 /**
- * The truncation contract from design spec §12. Silent truncation is how a
+ * The truncation contract from Silent truncation is how a
  * model confidently reports that a 900-film library contains 50 films, so
  * every read tool routes its list through here and serialises all four fields.
  *

--- a/src/mcp/prompts.ts
+++ b/src/mcp/prompts.ts
@@ -2,7 +2,7 @@ import type { McpServer } from '@modelcontextprotocol/server';
 import * as z from 'zod/v4';
 
 /**
- * The five questions this stack actually gets asked (0.9 spec §1).
+ * The five questions this stack actually gets asked (0.9 spec ).
  *
  * **A prompt orchestrates tools and adds no capability.** That is what makes
  * this phase safe on a client that does not surface prompts: every sequence

--- a/src/mcp/resources.ts
+++ b/src/mcp/resources.ts
@@ -5,7 +5,7 @@ import { buildGetLibrary } from '../tools/getLibrary.ts';
 import { buildStackHealth } from '../tools/stackHealth.ts';
 
 /**
- * The three resources (0.9 spec §2).
+ * The three resources (0.9 spec ).
  *
  * **Every one mirrors a tool.** That is the rule the whole phase rests on:
  * client support for resources is uneven, and arr-mcp has to work on all of

--- a/src/metadata/enrich.ts
+++ b/src/metadata/enrich.ts
@@ -1,7 +1,7 @@
 import type { ImdbDataset } from './imdbDataset.ts';
 
 /**
- * Filling IMDb ratings from the dataset (0.8 spec §4.1).
+ * Filling IMDb ratings from the dataset (0.8 spec ).
  *
  * Here rather than in `src/tools/` so nothing in the tool layer imports the
  * store: `LibraryLoader` takes one function, not a database.

--- a/src/metadata/imdbDataset.ts
+++ b/src/metadata/imdbDataset.ts
@@ -3,7 +3,7 @@ import type { Database as Db } from 'better-sqlite3';
 import { join } from 'node:path';
 
 /**
- * The IMDb dataset (0.8 spec §2), as a third SQLite database beside
+ * The IMDb dataset (0.8 spec ), as a third SQLite database beside
  * `audit.db` and `logs.db`.
  *
  * Its own file, and its own module, for the reason those two are separate

--- a/src/metadata/ingest.ts
+++ b/src/metadata/ingest.ts
@@ -1,7 +1,7 @@
 import type { RawEpisode, RawRating, RawTitle } from './imdbDataset.ts';
 
 /**
- * IMDb's dumps into rows (0.8 spec §1).
+ * IMDb's dumps into rows (0.8 spec ).
  *
  * **Generators, not arrays.** `title.basics` is on the order of 10⁷ rows, and
  * materialising it costs a multiple of its own size in heap on a machine that

--- a/src/metadata/refresh.ts
+++ b/src/metadata/refresh.ts
@@ -6,7 +6,7 @@ import type { ImdbDataset } from './imdbDataset.ts';
 import { parseEpisodes, parseRatings, parseTitles } from './ingest.ts';
 
 /**
- * Fetching the dumps, and the daily schedule (0.8 spec §2).
+ * Fetching the dumps, and the daily schedule (0.8 spec ).
  *
  * The only file in `src/metadata/` that touches the network, which is what
  * lets the store and the parser be tested without one.
@@ -14,7 +14,7 @@ import { parseEpisodes, parseRatings, parseTitles } from './ingest.ts';
 
 export const IMDB_BASE_URL = 'https://datasets.imdbws.com';
 
-/** IMDb publishes daily. Spec §3 explains why this is not configurable: there
+/** IMDb publishes daily. Spec explains why this is not configurable: there
  *  is no second sensible value, and a knob with one answer invites a wrong one. */
 export const REFRESH_INTERVAL_MS = 24 * 60 * 60 * 1000;
 

--- a/src/services/arrAdd.ts
+++ b/src/services/arrAdd.ts
@@ -37,10 +37,10 @@ export type ArrAddShape = {
  *
  * Probed against a live Radarr 6.3.0:
  *
- *   /movie/lookup/tmdb?tmdbId=603        200, one MovieResource
- *   /movie/lookup/tmdb?tmdbId=999999999  500, MovieNotFoundException
- *   /movie/lookup?term=tmdb:603          200, a one-element array
- *   /movie/lookup?term=tmdb:999999999    200, []
+ *   /movie/lookup/tmdb?tmdbId=603 200, one MovieResource
+ *   /movie/lookup/tmdb?tmdbId=999999999 500, MovieNotFoundException
+ *   /movie/lookup?term=tmdb:603 200, a one-element array
+ *   /movie/lookup?term=tmdb:999999999 200, []
  *
  * An unknown id is a **500** on the dedicated endpoint, which `classifyHttpStatus`
  * turns into `UpstreamError` — telling the user Radarr is broken when in fact

--- a/src/services/arrQueue.ts
+++ b/src/services/arrQueue.ts
@@ -167,7 +167,7 @@ export const calendarPath = (range: { start: Date; end: Date }): string =>
  * Sonarr omits the series object from calendar rows unless asked, so
  * `seriesTitle` came back empty for every episode — an episode calendar that
  * cannot say which series an episode belongs to is close to useless. Confirmed
- * against a live Sonarr 4.0.19 during the Phase 2 capture run.
+ * against a live Sonarr 4.0.19 during a live capture.
  */
 export const sonarrCalendarPath = (range: { start: Date; end: Date }): string =>
     `${calendarPath(range)}&includeSeries=true`;

--- a/src/services/arrRatings.ts
+++ b/src/services/arrRatings.ts
@@ -3,7 +3,7 @@ import type { MergedRatings } from '../core/resolver.ts';
 export type RawRating = { value?: number; votes?: number };
 
 /**
- * Design spec §21.2 resolved this against a live Radarr: the shape is
+ * Design spec resolved this against a live Radarr: the shape is
  * `{ <source>: { votes, value, type } }` with five sources — tmdb, trakt,
  * imdb, metacritic, rottenTomatoes — and **partial coverage**. Only 73% of
  * films carry an IMDb rating.
@@ -24,15 +24,15 @@ export function flattenRatings(raw: Record<string, RawRating> | undefined): Reco
 
 /**
  * **Sonarr's shape is not Radarr's**, resolved against a live Sonarr 4.0.19
- * during the Phase 2 capture run — which is what §21.2 had been waiting for.
+ * during a live capture — which is what had been waiting for.
  *
- * Radarr:  `{ tmdb: { votes, value, type }, imdb: {...}, … }` — per source.
- * Sonarr:  `{ votes: 164018, value: 8.3 }` — one flat rating, no source key.
+ * Radarr: `{ tmdb: { votes, value, type }, imdb: {...}, … }` — per source.
+ * Sonarr: `{ votes: 164018, value: 8.3 }` — one flat rating, no source key.
  *
  * Passing Sonarr's through `flattenRatings` treats `votes` and `value` as
  * *source names*, reporting a rating source called "votes" worth 164018. The
  * single rating is labelled `tvdb` because that is where Sonarr sources series
- * metadata from — design spec §7 relies on the same fact when it excludes a
+ * metadata from relies on the same fact when it excludes a
  * direct TVDB client as duplicated effort.
  */
 export function flattenSeriesRating(raw: RawRating | undefined): Record<string, number> | undefined {
@@ -41,7 +41,7 @@ export function flattenSeriesRating(raw: RawRating | undefined): Record<string, 
 }
 
 /**
- * The sources §4.1 names. Anything else an *arr invents is dropped rather than
+ * The sources names. Anything else an *arr invents is dropped rather than
  * carried.
  *
  * `tvdb` is deliberately absent. Sonarr's rating is flat — `{ votes, value }`,
@@ -58,7 +58,7 @@ const KNOWN = ['imdb', 'tmdb', 'rottenTomatoes', 'trakt', 'metacritic'] as const
 
 /**
  * `flattenRatings` produces `Record<string, number>` because that is what
- * `MediaDetails` has carried since Phase 2. The merged record uses named
+ * `MediaDetails` has carried. The merged record uses named
  * sources instead, so an unknown source name cannot survive into a filter that
  * would then match nothing.
  */

--- a/src/services/bazarr.ts
+++ b/src/services/bazarr.ts
@@ -17,7 +17,7 @@ import {
 } from './types.ts';
 
 /**
- * Hand-written: Bazarr publishes no OpenAPI document (design spec §21.1), so
+ * Hand-written: Bazarr publishes no OpenAPI document, so
  * these shapes come from recorded fixtures and the contract test checks them
  * against those fixtures rather than against a spec.
  *
@@ -145,7 +145,7 @@ export class BazarrAdapter implements ServiceAdapter, HealthCheckCapable, Subtit
     }
 
     /**
-     * §12's "provider state". Bazarr reports a healthy provider as `status:
+     * the "provider state". Bazarr reports a healthy provider as `status:
      * "Good"` and an unhealthy one with the provider's own error text, so
      * `healthy` is derived here rather than making every caller know that
      * string. The status text is provider-supplied and therefore fenced.

--- a/src/services/jellyfin.ts
+++ b/src/services/jellyfin.ts
@@ -18,7 +18,8 @@ import {
     type ServiceAdapter,
     type ServiceUser,
     type UserDirectoryCapable,
-    type UserLibraryCapable
+    type UserLibraryCapable,
+    type CommandHandle
 } from './types.ts';
 
 /**
@@ -30,6 +31,9 @@ import {
 type RawSystemInfo = { Version?: string; ServerName?: string; Id?: string };
 type RawUser = { Id?: string; Name?: string };
 type RawTask = {
+    /** Per-install GUID. Only `startLibraryScan` needs it; `getScanState`
+     *  matches on `Key`, which is stable across installs. */
+    Id?: string;
     Key?: string;
     Name?: string;
     State?: string;
@@ -130,6 +134,36 @@ export class JellyfinAdapter
         return users
             .filter((u): u is { Id: string; Name: string } => typeof u.Id === 'string' && typeof u.Name === 'string')
             .map(u => ({ id: u.Id, name: u.Name }));
+    }
+
+    /**
+     * Start the library scan — this adapter's only write.
+     *
+     * The task id is looked up rather than hard-coded, by the same
+     * `Key === LIBRARY_SCAN_KEY` match `getScanState` uses: Jellyfin's ids are
+     * per-install GUIDs, and the localised task *name* is no good either (a
+     * Dutch install returns "Mediabibliotheek scannen"). Matching on the key
+     * once, in one place, is what stops the two disagreeing about which task
+     * this is.
+     *
+     * Jellyfin answers this with 204 and no body, so there is no command id to
+     * report back — unlike the *arrs, which return one. The handle says so
+     * rather than inventing a number that would look like something you could
+     * poll.
+     */
+    async startLibraryScan(): Promise<CommandHandle> {
+        const tasks = await this.#http.get<RawTask[]>('/ScheduledTasks');
+        const scan = tasks.find(t => t.Key === LIBRARY_SCAN_KEY);
+
+        if (scan?.Id === undefined) {
+            throw new ServiceError('NotFound', this.id, 'Jellyfin did not report a library scan task', {
+                remedy: 'The task is called RefreshLibrary. If this Jellyfin has it disabled, start the scan from its dashboard instead.'
+            });
+        }
+
+        await this.#http.post(`/ScheduledTasks/Running/${encodeURIComponent(scan.Id)}`, undefined);
+
+        return { service: this.id, commandId: 0, name: LIBRARY_SCAN_KEY, status: 'started' };
     }
 
     async getScanState(): Promise<ScanState> {

--- a/src/services/jellyfin.ts
+++ b/src/services/jellyfin.ts
@@ -41,13 +41,12 @@ type RawTask = {
 };
 
 /**
- * The task Jellyfin runs to scan libraries, confirmed against a live 10.11.11.
+ * The library-scan task, confirmed against a live 10.11.11.
  *
- * Keyed on `Key`, never on `Name`, for two independent reasons. A live server
- * exposes eight library-ish keys including `LanguageTagsSetsRefreshLibraryTask`
- * and `TraktSyncLibraryTask`, so a pattern would match the wrong one — and
- * `Name` is **localised to the server language**. The instance this was
- * captured from returns "Mediabibliotheek scannen".
+ * Keyed on `Key`, never `Name`, for two reasons: a server exposes eight
+ * library-ish keys including `TraktSyncLibraryTask`, so a pattern matches the
+ * wrong one — and `Name` is localised, returning "Mediabibliotheek scannen" on
+ * the instance this came from.
  */
 const LIBRARY_SCAN_KEY = 'RefreshLibrary';
 
@@ -125,9 +124,9 @@ export class JellyfinAdapter
 
     /**
      * Jellyfin identifies users by GUID while config names them by username, so
-     * every per-user call resolves through this list. Typing a username by hand
-     * is a guaranteed source of silent mismatches, which is
-     * why the resolver reports the available names on a miss.
+     * every per-user call resolves through this list — and the resolver reports
+     * the available names on a miss, because a hand-typed username is a
+     * guaranteed source of silent mismatches.
      */
     async listUsers(): Promise<ServiceUser[]> {
         const users = await this.#http.get<RawUser[]>('/Users');

--- a/src/services/jellyfin.ts
+++ b/src/services/jellyfin.ts
@@ -89,7 +89,7 @@ type RawItemDetail = {
 
 /**
  * Jellyfin stores external ids as **strings** while Radarr and Sonarr use
- * numbers. Phase 3's identity resolver joins on tmdbId and tvdbId, so a string
+ * numbers. The identity resolver joins on tmdbId and tvdbId, so a string
  * here would silently fail every join — convert at the boundary.
  */
 const numericId = (value: string | undefined): number | undefined => {
@@ -126,7 +126,7 @@ export class JellyfinAdapter
     /**
      * Jellyfin identifies users by GUID while config names them by username, so
      * every per-user call resolves through this list. Typing a username by hand
-     * is a guaranteed source of silent mismatches (design spec §14), which is
+     * is a guaranteed source of silent mismatches, which is
      * why the resolver reports the available names on a miss.
      */
     async listUsers(): Promise<ServiceUser[]> {
@@ -276,7 +276,7 @@ export class JellyfinAdapter
 
     /**
      * Jellyfin is the only service that knows what has actually been *watched*,
-     * which is the gap design spec §12 says upstream never closed.
+     * which is the gap says upstream never closed.
      */
     async search(query: string, source: SearchSource): Promise<SearchHit[]> {
         if (source !== 'library') return [];
@@ -284,7 +284,7 @@ export class JellyfinAdapter
         // `Fields=ProviderIds` is not optional decoration: Jellyfin omits
         // ProviderIds from search results entirely without it, confirmed
         // against a live 10.11.11. Every hit came back with no external ids at
-        // all — which is precisely what Phase 3's resolver joins on.
+        // all — which is precisely what the resolver joins on.
         const page = await this.#http.get<{ Items?: RawItemDetail[] }>(
             `/Items?searchTerm=${encodeURIComponent(query)}&Recursive=true&IncludeItemTypes=Movie,Series&Fields=ProviderIds`
         );
@@ -311,9 +311,9 @@ export class JellyfinAdapter
     }
 
     /**
-     * Per-user by construction (§4.3). `EnableUserData` is what makes `Played`
+     * Per-user by construction. `EnableUserData` is what makes `Played`
      * come back at all, and `Fields=ProviderIds` is what makes the join
-     * possible — the same parameter whose absence made every Phase 2 search hit
+     * possible — the same parameter whose absence once made every search hit
      * arrive with no external ids.
      */
     async listUserLibrary(user: ServiceUser): Promise<IndexInput[]> {

--- a/src/services/prowlarr.ts
+++ b/src/services/prowlarr.ts
@@ -57,7 +57,7 @@ type RawRelease = {
 /**
  * Prowlarr manages indexers, not files, and exposes no diskspace endpoint —
  * `/api/v1/diskspace` returns 404, confirmed against a live instance during the
- * Phase 2a capture run. It is therefore deliberately not `DiskSpaceCapable`:
+ * a live capture. It is therefore deliberately not `DiskSpaceCapable`:
  * a method with no fixture is a method stack_health would call and nothing
  * would have tested.
  *
@@ -144,7 +144,7 @@ export class ProwlarrAdapter implements ServiceAdapter, HealthCheckCapable, Inde
     }
 
     /**
-     * The failed half of Prowlarr's history — §12's "recent rejections", which
+     * The failed half of Prowlarr's history — the "recent rejections", which
      * is a different thing from the rejection *counts* above.
      *
      * **Prowlarr does not record why a query failed.** The history payload has

--- a/src/services/radarr.ts
+++ b/src/services/radarr.ts
@@ -71,7 +71,7 @@ type RawCommand = components['schemas']['CommandResource'];
 
 /**
  * The task that actually rescans the film library, confirmed against a live
- * Radarr 6.3.0 during the Phase 2a capture run.
+ * Radarr 6.3.0 during a live capture.
  *
  * Matched exactly, never by pattern. A live instance runs eleven scheduled
  * tasks, three of which contain "Refresh": `RefreshMovie` is the library scan,
@@ -239,7 +239,7 @@ export class RadarrAdapter
     }
 
     /**
-     * The first write in the codebase, and the only one Phase 4 ships at the
+     * The first write in the codebase, and the only one an earlier phase ships at the
      * `safe` tier: it asks Radarr to look for releases for a film it already
      * tracks. Nothing is deleted, nothing is added, and the worst outcome is a
      * grab the user did not want — which the queue tools can then undo.
@@ -276,7 +276,7 @@ export class RadarrAdapter
         if (source === 'library') {
             // Radarr has no library search endpoint, so this fetches the whole
             // list. Costly on a 900-film instance and correct today; design
-            // spec §16's cache is what makes it cheap, and lands in Phase 3.
+            // spec the cache is what makes it cheap, and lands earlier.
             const movies = await this.#http.get<RawMovie[]>('/api/v3/movie');
             return movies.filter(m => (m.title ?? '').toLowerCase().includes(term)).map(m => this.#toHit(m, 'library'));
         }
@@ -310,7 +310,7 @@ export class RadarrAdapter
 
     /**
      * The whole film library in one call — Radarr has no server-side filter, so
-     * this is the same `/api/v3/movie` read `search` already does. §16's cache
+     * this is the same `/api/v3/movie` read `search` already does. The cache
      * is what makes it affordable, and it lives in the tool layer.
      */
     async listLibrary(): Promise<IndexInput[]> {

--- a/src/services/radarr.ts
+++ b/src/services/radarr.ts
@@ -239,10 +239,9 @@ export class RadarrAdapter
     }
 
     /**
-     * The first write in the codebase, and the only one an earlier phase ships at the
-     * `safe` tier: it asks Radarr to look for releases for a film it already
-     * tracks. Nothing is deleted, nothing is added, and the worst outcome is a
-     * grab the user did not want — which the queue tools can then undo.
+     * Safe tier: it asks Radarr to look for releases for a film it already
+     * tracks. Nothing is deleted or added, and the worst outcome is an unwanted
+     * grab, which the queue tools can undo.
      *
      * The id is coerced to a number rather than interpolated: `movieIds` is a
      * JSON array of integers, and a string there is silently accepted by Radarr

--- a/src/services/radarr.ts
+++ b/src/services/radarr.ts
@@ -149,6 +149,21 @@ export class RadarrAdapter
             }));
     }
 
+    /**
+     * Queues the same command `getScanState` reads the last run of, so what
+     * this starts and what that reports can never drift apart.
+     */
+    async startLibraryScan(): Promise<CommandHandle> {
+        const command = await this.#http.post<RawCommand>('/api/v3/command', { name: 'RefreshMovie' });
+
+        return {
+            service: this.id,
+            commandId: command.id ?? 0,
+            name: command.name ?? 'RefreshMovie',
+            ...(typeof command.status === 'string' ? { status: command.status } : {})
+        };
+    }
+
     async getScanState(): Promise<ScanState> {
         const tasks = await this.#http.get<RawTask[]>('/api/v3/system/task');
         const scan = tasks.find(t => t.taskName === LIBRARY_SCAN_TASK);

--- a/src/services/seerr.ts
+++ b/src/services/seerr.ts
@@ -50,7 +50,7 @@ type RawRequestPage = { results?: RawRequest[] };
 const STATUS: Record<number, RequestStatus> = { 1: 'pending', 2: 'approved', 3: 'declined' };
 
 /**
- * Design spec §21.4, settled 2026-08-06 against Seerr 3.4.1: passing
+ * Design spec, settled 2026-08-06 against Seerr 3.4.1: passing
  * `requestedBy` does filter server-side. Verified against a live 2-user
  * stack where every recorded request happened to belong to one user, which
  * made a naive before/after count comparison uninformative (it would match
@@ -267,8 +267,8 @@ export class SeerrAdapter
 
     /**
      * Seerr's discover is TMDB-backed, so the rating floor is applied by TMDB
-     * rather than by us. Design spec §7 defers rating filters over your *own*
-     * library to the IMDb dataset — that is get_library in Phase 3, not this.
+     * rather than by us. Design spec defers rating filters over your *own*
+     * library to the IMDb dataset — that is get_library earlier, not this.
      */
     async discover(opts: {
         mediaType: 'movie' | 'tv';

--- a/src/services/seerr.ts
+++ b/src/services/seerr.ts
@@ -50,30 +50,24 @@ type RawRequestPage = { results?: RawRequest[] };
 const STATUS: Record<number, RequestStatus> = { 1: 'pending', 2: 'approved', 3: 'declined' };
 
 /**
- * Design spec, settled 2026-08-06 against Seerr 3.4.1: passing
- * `requestedBy` does filter server-side. Verified against a live 2-user
- * stack where every recorded request happened to belong to one user, which
- * made a naive before/after count comparison uninformative (it would match
- * whether or not the server filtered). The decisive probe instead filtered
- * by the *other* user — one with zero requests — and got back zero rows
- * rather than the full unfiltered set, which only happens if the server
- * parsed and applied `requestedBy`.
+ * `requestedBy` does filter server-side, settled against a live Seerr 3.4.1.
+ * The decisive probe filtered by a user with *zero* requests and got zero rows
+ * back rather than the full set — a before/after count would have matched
+ * either way on the stack it was tested against.
  *
- * The in-memory filter still runs unconditionally — it costs nothing at
- * household volumes, and it means this constant can never silently widen
- * what one user sees of another's requests.
+ * The in-memory filter still runs unconditionally: it costs nothing at
+ * household volumes, and it means this constant can never silently widen what
+ * one user sees of another's requests.
  */
 const SEERR_FILTERS_SERVER_SIDE = true;
 
 /**
  * A release year, or nothing.
  *
- * `Number(''.slice(0, 4))` is **0**, not NaN, so a `Number.isFinite` guard
- * happily lets it through — which is how a live preview came out reading
- * "The Origin of Hide and Seek (0)". Seerr returns an empty `releaseDate` for
- * anything TMDB has no date for, which on a real instance is common. Requiring
- * four leading digits and a plausible value is what makes the absent case
- * absent rather than zero.
+ * `Number(''.slice(0, 4))` is **0**, not NaN, so a `Number.isFinite` guard lets
+ * it through — which is how a live preview read "The Origin of Hide and Seek
+ * (0)". Seerr returns an empty `releaseDate` whenever TMDB has no date, which is
+ * common. Four leading digits and a plausible value keep absent absent.
  */
 const yearOf = (date: string | undefined): number | undefined => {
     if (date === undefined || !/^\d{4}/.test(date)) return undefined;

--- a/src/services/sonarr.ts
+++ b/src/services/sonarr.ts
@@ -77,7 +77,7 @@ type RawCommand = components['schemas']['CommandResource'];
 
 /**
  * The task that rescans the series library, confirmed against a live Sonarr
- * 4.0.19 during the Phase 2a capture run.
+ * 4.0.19 during a live capture.
  *
  * Matched exactly, never by pattern — for the same reason as Radarr's
  * `RefreshMovie`. A live instance runs eleven tasks, and
@@ -340,7 +340,7 @@ export class SonarrAdapter
                 monitored: s.monitored ?? false,
                 // A series has no single file, so "has a file" means "has any
                 // episode on disk". No quality either: it is per-episode, which
-                // is why §5.2 makes the quality filter films-only.
+                // is why this makes the quality filter films-only.
                 hasFile: (s.statistics?.episodeFileCount ?? 0) > 0,
                 ...(s.added === undefined || s.added === null ? {} : { addedAt: s.added }),
                 ...(s.statistics?.sizeOnDisk === undefined ? {} : { sizeBytes: s.statistics.sizeOnDisk })

--- a/src/services/sonarr.ts
+++ b/src/services/sonarr.ts
@@ -146,6 +146,21 @@ export class SonarrAdapter
             }));
     }
 
+    /**
+     * Queues the same command `getScanState` reads the last run of, so what
+     * this starts and what that reports can never drift apart.
+     */
+    async startLibraryScan(): Promise<CommandHandle> {
+        const command = await this.#http.post<RawCommand>('/api/v3/command', { name: 'RefreshSeries' });
+
+        return {
+            service: this.id,
+            commandId: command.id ?? 0,
+            name: command.name ?? 'RefreshSeries',
+            ...(typeof command.status === 'string' ? { status: command.status } : {})
+        };
+    }
+
     async getScanState(): Promise<ScanState> {
         const tasks = await this.#http.get<RawTask[]>('/api/v3/system/task');
         const scan = tasks.find(t => t.taskName === LIBRARY_SCAN_TASK);

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -3,10 +3,7 @@ import type { IndexInput } from '../core/resolver.ts';
 import { ServiceError, type ServiceErrorKind } from '../core/errors.ts';
 import { assertVersionSupported } from './versions.ts';
 
-/**
- * A diagnosis, not a boolean. A connection test that
- * returns true/false tells the user nothing about what to fix.
- */
+/** A diagnosis, not a boolean: true/false tells nobody what to fix. */
 export type ConnectionDiagnosis = {
     ok: boolean;
     service: string;
@@ -16,11 +13,8 @@ export type ConnectionDiagnosis = {
 };
 
 export interface ServiceAdapter {
-    /**
-     * `radarr` for a single instance, `radarr/4k` for a named one. This is the
-     * identity everything human-facing uses — audit rows, log filters, error
-     * messages, merged read output.
-     */
+    /** `radarr`, or `radarr/4k` when named. The identity everything
+     *  human-facing uses: audit rows, log filters, errors, merged output. */
     readonly id: string;
     /**
      * What kind of service this is. **Capability dispatch keys on this, never
@@ -34,11 +28,9 @@ export interface ServiceAdapter {
     getVersion(): Promise<string>;
 }
 
-/**
- * `service` is carried on every row because stack_health merges rows from up
- * to eight services into one list. A failing health check that does not say
- * who reported it is not actionable.
- */
+/** `service` is on every row because stack_health merges up to eight services
+ *  into one list, and a failure that does not say who reported it is not
+ *  actionable. */
 export type DiskSpace = {
     service: string;
     /** Optional: omitted below `detail: full`, where paths are the longest
@@ -84,7 +76,7 @@ export const hasHealthChecks = (a: ServiceAdapter): a is ServiceAdapter & Health
 export const hasScanState = (a: ServiceAdapter): a is ServiceAdapter & ScanStateCapable =>
     typeof (a as Partial<ScanStateCapable>).getScanState === 'function';
 
-// --- an earlier phase read-tool capabilities ---
+// --- read-tool capabilities ---
 
 export type IndexerSummary = {
     service: string;
@@ -273,9 +265,8 @@ export type SearchHit = {
     year?: number;
     ids: { tmdb?: number; tvdb?: number; imdb?: string };
     /**
-     * Ratings by source, on each source's native scale — the same shape and
-     * the same convention as `MediaDetails.ratings`, which this is the
-     * not-yet-owned counterpart to.
+     * Ratings by source, on each source's native scale — same shape as
+     * `MediaDetails.ratings`, which this is the not-yet-owned counterpart to.
      *
      * Nothing an *arr's lookup endpoint returns populates this: their search
      * payloads are shaped for *adding* a title, not describing one. It exists
@@ -299,7 +290,7 @@ export interface SearchCapable {
 export const hasSearch = (a: ServiceAdapter): a is ServiceAdapter & SearchCapable =>
     typeof (a as Partial<SearchCapable>).search === 'function';
 
-// --- an earlier phase write capabilities ---
+// --- write capabilities ---
 
 /**
  * What the *arrs hand back when told to do something: a queued command, not a

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -4,7 +4,7 @@ import { ServiceError, type ServiceErrorKind } from '../core/errors.ts';
 import { assertVersionSupported } from './versions.ts';
 
 /**
- * A diagnosis, not a boolean (design spec §6/§14). A connection test that
+ * A diagnosis, not a boolean. A connection test that
  * returns true/false tells the user nothing about what to fix.
  */
 export type ConnectionDiagnosis = {
@@ -52,7 +52,7 @@ export type DiskSpace = {
 
 export type HealthCheck = { service: string; source: string; type: string; message: string };
 
-/** Library scan staleness, the fourth thing design spec §12 asks stack_health for. */
+/** Library scan staleness, the fourth thing asks stack_health for. */
 export type ScanState = { service: string; lastCompleted?: string; running?: boolean };
 
 export interface DiskSpaceCapable {
@@ -65,7 +65,7 @@ export interface ScanStateCapable {
     getScanState(): Promise<ScanState>;
 }
 
-/** Jellyfin and Seerr only — the two multi-user services (design spec §9). */
+/** Jellyfin and Seerr only — the two multi-user services. */
 export type ServiceUser = { id: string; name: string };
 
 export interface UserDirectoryCapable {
@@ -84,7 +84,7 @@ export const hasHealthChecks = (a: ServiceAdapter): a is ServiceAdapter & Health
 export const hasScanState = (a: ServiceAdapter): a is ServiceAdapter & ScanStateCapable =>
     typeof (a as Partial<ScanStateCapable>).getScanState === 'function';
 
-// --- Phase 2b read-tool capabilities ---
+// --- an earlier phase read-tool capabilities ---
 
 export type IndexerSummary = {
     service: string;
@@ -101,7 +101,7 @@ export type IndexerSummary = {
     rejectedGrabs?: number;
 };
 
-/** A query an indexer refused, with the reason it gave. §12's "recent rejections". */
+/** A query an indexer refused, with the reason it gave. the "recent rejections". */
 export type IndexerRejection = { indexer: string; at: string; reason: string; query?: string };
 
 export interface IndexerCapable {
@@ -128,7 +128,7 @@ export type SubtitleGap = {
 };
 
 /**
- * §12's "provider state". A subtitle gap says what is missing; this says
+ * the "provider state". A subtitle gap says what is missing; this says
  * whether Bazarr is currently able to do anything about it.
  */
 export type SubtitleProvider = {
@@ -279,7 +279,7 @@ export type SearchHit = {
      *
      * Nothing an *arr's lookup endpoint returns populates this: their search
      * payloads are shaped for *adding* a title, not describing one. It exists
-     * for the IMDb dataset (0.8 §4.1), which fills it for a hit carrying an
+     * for the IMDb dataset (0.8 ), which fills it for a hit carrying an
      * imdb id.
      */
     ratings?: Record<string, number>;
@@ -299,7 +299,7 @@ export interface SearchCapable {
 export const hasSearch = (a: ServiceAdapter): a is ServiceAdapter & SearchCapable =>
     typeof (a as Partial<SearchCapable>).search === 'function';
 
-// --- Phase 4 write capabilities ---
+// --- an earlier phase write capabilities ---
 
 /**
  * What the *arrs hand back when told to do something: a queued command, not a
@@ -459,7 +459,7 @@ export const hasRequestManage = (a: ServiceAdapter): a is ServiceAdapter & Reque
 
 /**
  * A whole-library read, shaped for the identity resolver rather than for a
- * tool. Phase 3 joins three of these into one index; nothing else consumes it.
+ * tool. The resolver joins three of these into one index; nothing else consumes it.
  */
 export interface LibraryCapable {
     listLibrary(): Promise<IndexInput[]>;
@@ -469,7 +469,7 @@ export const hasLibrary = (a: ServiceAdapter): a is ServiceAdapter & LibraryCapa
     typeof (a as Partial<LibraryCapable>).listLibrary === 'function';
 
 /**
- * Separate from LibraryCapable because Jellyfin's half is per-user (§4.3):
+ * Separate from LibraryCapable because Jellyfin's half is per-user:
  * watch state does not exist without a user, and a shared signature would let
  * a caller forget to supply one.
  */
@@ -502,7 +502,7 @@ export async function diagnoseConnection(
     const started = performance.now();
     try {
         const version = await probe();
-        // §14: a connection test distinguishes version-too-old from every other
+        // a connection test distinguishes version-too-old from every other
         // failure. Checked here rather than in each adapter, so no adapter can
         // forget — and after the probe, so an unreachable service reports being
         // unreachable rather than being the wrong version.

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -439,17 +439,15 @@ export interface RequestManageCapable {
     respondToRequest(id: string, verdict: RequestVerdict): Promise<MediaRequest>;
     deleteRequest(id: string): Promise<void>;
     /**
-     * Resolves a human title for a request.
+     * A human title for a request.
      *
-     * Needed because Seerr's `/api/v1/request` payload carries **no title at
-     * all** — its `media` object is ids and service metadata only, confirmed
-     * against a live Seerr 3.4.1 and against the recorded fixture. So
-     * `MediaRequest.title` is undefined for every real request, and a write
-     * preview built from it alone says "request 19", which is not something
-     * anyone can meaningfully approve.
+     * Seerr's `/api/v1/request` payload carries **no title at all** — ids and
+     * service metadata only, confirmed against a live 3.4.1. So a preview built
+     * from the request alone says "request 19", which nobody can meaningfully
+     * approve.
      *
-     * Resolves undefined rather than throwing: a title lookup that fails must
-     * not block a user from deleting a request.
+     * Resolves undefined rather than throwing: a failed title lookup must not
+     * block someone deleting a request.
      */
     describeRequestMedia(request: MediaRequest): Promise<{ title: string; year?: number } | undefined>;
 }

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -318,6 +318,22 @@ export const hasSearchTrigger = (a: ServiceAdapter): a is ServiceAdapter & Searc
     typeof (a as Partial<SearchTriggerCapable>).triggerSearch === 'function';
 
 /**
+ * Starting the library scan whose staleness `getScanState` reports.
+ *
+ * The two go together deliberately: `diagnose` names a stale scan as the usual
+ * reason something downloaded is still not playable, and until 1.0 nothing
+ * could act on that — its best answer ended "now go and do it yourself". The
+ * services that can be asked are exactly the three that can be read.
+ */
+export interface LibraryScanCapable {
+    /** Queues a rescan and returns; it does not wait for the scan to finish. */
+    startLibraryScan(): Promise<CommandHandle>;
+}
+
+export const hasLibraryScan = (a: ServiceAdapter): a is ServiceAdapter & LibraryScanCapable =>
+    typeof (a as Partial<LibraryScanCapable>).startLibraryScan === 'function';
+
+/**
  * Both flags default to the *least* destructive reading at every layer — the
  * tool schema, the adapter signature and the service call — so a caller that
  * forgets one deletes less than they asked for rather than more.

--- a/src/services/versions.ts
+++ b/src/services/versions.ts
@@ -48,9 +48,9 @@ export function compareVersions(a: number[], b: number[]): number {
 }
 
 /**
- * Design spec §14 requires connection tests to distinguish version-too-old
+ * Design spec requires connection tests to distinguish version-too-old
  * alongside DNS failure, connection refused and a bad key. This is what finally
- * produces `VersionUnsupported`, which had been in the taxonomy since Phase 1
+ * produces `VersionUnsupported`, which had been in the taxonomy 
  * with nothing able to reach it.
  */
 export function assertVersionSupported(service: ServiceId, raw: string): void {

--- a/src/tools/addMedia.ts
+++ b/src/tools/addMedia.ts
@@ -13,7 +13,7 @@ import {
 import { registerWriteTool, type WriteContext, type WritePlan } from './write.ts';
 
 /**
- * The last of Phase 4's writes, and the only one that has to *choose*
+ * The last of the writes, and the only one that has to *choose*
  * something on the user's behalf.
  *
  * Adding needs a quality profile and a root folder, and neither has a

--- a/src/tools/diagnose/chain.ts
+++ b/src/tools/diagnose/chain.ts
@@ -18,12 +18,10 @@ export type Evidence = {
     item: MergedItem | undefined;
     request: { status: RequestStatus | 'unknown' } | null | undefined;
     /**
-     * A multi-service stage: `items` is whatever the collector actually read
-     * (from however many of Radarr/Sonarr/SABnzbd/Transmission answered),
-     * `partial` names the ones that didn't. A single unreachable client used
-     * to erase the whole stage to `undefined`, discarding rows another
-     * client *did* return — including the stalled row that was the actual
-     * cause. `undefined` still means every configured client failed.
+     * `items` is what the collector actually read, `partial` names the clients
+     * that did not answer. One unreachable client used to erase the whole stage,
+     * discarding rows another client did return — including the stalled row that
+     * was the cause. `undefined` still means every client failed.
      */
     queue: { items: QueueItem[]; partial: string[] } | undefined;
     /** Analogue of `jellyfinConfigured`, below: no download client at all, not merely unreachable. */
@@ -39,16 +37,11 @@ export type Evidence = {
      */
     jellyfinConfigured: boolean;
     /**
-     * Library-read reachability (the `LibraryLoader`/`LibraryIndex`
-     * build) — kept separate from `degraded`, below, which is *probe*
-     * reachability (this module's own scan/indexer/queue/seerr/explicit-id
-     * calls). A service can fail one without the other: Jellyfin's
-     * `getScanState` failing must not erase a library read that succeeded
-     * (`libraryStep` would otherwise discard the flagship `library` verdict
-     * over an unrelated endpoint), and a Radarr *library* read failing must
-     * not make `queueStep` believe every configured queue is unknown when
-     * they all answered in full. Only `libraryStep` reads this array; every
-     * other step reads `degraded`.
+     * Library-read reachability, separate from `degraded` below, which is
+     * *probe* reachability. A service can fail one without the other: a failing
+     * Jellyfin `getScanState` must not erase a library read that succeeded, and
+     * a failing Radarr library read must not make `queueStep` call every queue
+     * unknown. Only `libraryStep` reads this; every other step reads `degraded`.
      */
     libraryDegraded: readonly string[];
     degraded: readonly string[];

--- a/src/tools/diagnose/chain.ts
+++ b/src/tools/diagnose/chain.ts
@@ -10,7 +10,7 @@ export type Step = { stage: Stage; service?: string; status: StepStatus; detail:
 
 /**
  * `undefined` and `null` mean different things throughout, and the distinction
- * is the whole of §6.1: **undefined is "could not look", null is "looked and
+ * is the whole of **undefined is "could not look", null is "looked and
  * found nothing"**. Collapsing them is how a diagnosis becomes confidently
  * wrong about a service that was down.
  */
@@ -39,7 +39,7 @@ export type Evidence = {
      */
     jellyfinConfigured: boolean;
     /**
-     * Library-read reachability (item 8's `LibraryLoader`/`LibraryIndex`
+     * Library-read reachability (the `LibraryLoader`/`LibraryIndex`
      * build) — kept separate from `degraded`, below, which is *probe*
      * reachability (this module's own scan/indexer/queue/seerr/explicit-id
      * calls). A service can fail one without the other: Jellyfin's
@@ -261,7 +261,7 @@ function queueStep(ev: Evidence, item: MergedItem): QueueResult {
     // A service already named in `degraded` is unreachable even if the
     // collector's per-stage `partial` list did not separately say so (N8).
     // Deliberately `degraded` (probe reachability), not `libraryDegraded`
-    // (item 2 of the whole-phase review): Radarr/Sonarr's *library* read
+    // (a review finding): Radarr/Sonarr's *library* read
     // failing must not make this stage believe their *queue* probe failed
     // too — the two used to share one array, so a Radarr library-read
     // failure alone made this stage report unknown even when every
@@ -331,11 +331,11 @@ function queueStep(ev: Evidence, item: MergedItem): QueueResult {
 function indexerStep(ev: Evidence, item: MergedItem): Step {
     if (!ev.prowlarrConfigured) return SKIPPED('indexers', 'No indexer manager is configured.');
     if (ev.degraded.includes('prowlarr')) {
-        // `degraded` is probe reachability (item 2 of the whole-phase
-        // review) — the same array `scanStep`/`queueStep` read, and correctly
+        // `degraded` is probe reachability — the same array
+        // `scanStep`/`queueStep` read, and correctly
         // so here: Prowlarr contributes no library-read half, so there is no
-        // `libraryDegraded` signal for it to consult instead (N8's original
-        // point still holds — a service's own probe failing must count even
+        // `libraryDegraded` signal for it to consult instead — a service's
+        // own probe failing must count even
         // when `rejections` happens to be defined from a stale read).
         return { stage: 'indexers', service: 'prowlarr', status: 'unknown', detail: 'Prowlarr could not be reached.' };
     }
@@ -356,11 +356,11 @@ function indexerStep(ev: Evidence, item: MergedItem): Step {
 function libraryStep(ev: Evidence, item: MergedItem): Step {
     if (!ev.jellyfinConfigured) return SKIPPED('library', 'Jellyfin is not configured.');
     if (ev.libraryDegraded.includes('jellyfin')) {
-        // Never "it is not in Jellyfin" when Jellyfin was not asked (§6.1).
-        // Reads `libraryDegraded`, not `degraded` (item 2 of the whole-phase
-        // review): a failed scan probe belongs to `degraded` and must not
+        // Never "it is not in Jellyfin" when Jellyfin was not asked.
+        // Reads `libraryDegraded`, not `degraded`: a failed scan probe
+        // belongs to `degraded` and must not
         // land here — this stage is about the library *read*, and item.presence
-        // alone is not enough of a guard (item 1's `unknown` looks the same
+        // alone is not enough of a guard (`unknown` looks the same
         // as "no evidence at all" to the check below, but `hasFile` is still
         // real *arr data this module must not reinterpret as a Jellyfin gap).
         return { stage: 'library', service: 'jellyfin', status: 'unknown', detail: 'Jellyfin could not be reached, so its library was not checked.' };
@@ -382,8 +382,8 @@ function libraryStep(ev: Evidence, item: MergedItem): Step {
 function scanStep(ev: Evidence): Step {
     if (!ev.jellyfinConfigured) return SKIPPED('scan', 'Jellyfin is not configured.');
     if (ev.degraded.includes('jellyfin')) {
-        // `degraded` here is specifically the `getScanState` probe (item 2 of
-        // the whole-phase review) — deliberately *not* `libraryDegraded`,
+        // `degraded` here is specifically the `getScanState` probe —
+        // deliberately *not* `libraryDegraded`,
         // which `libraryStep` reads instead. The two used to share one array,
         // so a failed scan probe silently erased a library read that
         // succeeded; they are independent endpoints and are allowed to
@@ -444,7 +444,7 @@ function fileRemedy(ev: Evidence, queueStatus: StepStatus, indexerStatus: StepSt
  * is worth a mention, just not the verdict.
  *
  * The wording changes on `fileIsOk`, rather than being suppressed by it
- * (whole-phase review, item 3's second symptom). A `request`/`managed`
+ * (a review finding's second symptom). A `request`/`managed`
  * verdict with genuinely no file yet (`monitored: false` *and*
  * `hasFile: false`) and a faulted queue row used to go silent about that
  * fault entirely — "…is not monitored." with a "turn monitoring on" remedy
@@ -464,7 +464,7 @@ const queueAside = (queueResult: QueueResult, fileIsOk: boolean): string => {
 
 /**
  * The known one-line hedge (ledgered at Task 5, applied here at the
- * whole-phase review): evidence genuinely cannot distinguish "an ended
+ * a review finding: evidence genuinely cannot distinguish "an ended
  * series, deliberately left unmonitored" or "a stale declined request" from
  * "an ongoing series, accidentally unmonitored" — there is no correctness fix
  * for that, only this disclosure. It fires only for `request`/`managed`
@@ -481,7 +481,7 @@ const SERIES_FILE_VISIBLE_HEDGE =
  * The top-level `Diagnosis.degraded` a caller sees, and the input to the
  * `resolve` verdict's own certainty below, are both "everything this
  * diagnosis could not fully check" — the union of probe reachability and
- * library-read reachability (item 2 of the whole-phase review keeps those
+ * library-read reachability (a review finding keeps those
  * two arrays separate for the *per-stage* checks above, which each care
  * about only one; nothing downstream of this point needs that distinction).
  */

--- a/src/tools/diagnose/chain.ts
+++ b/src/tools/diagnose/chain.ts
@@ -69,7 +69,10 @@ const DISPLAY_ORDER: readonly Stage[] = [
 
 const SKIPPED = (stage: Stage, detail: string): Step => ({ stage, status: 'skipped', detail });
 
-/** Splits on runs of non-alphanumerics, exactly the way a release name's dots/dashes/spaces are treated — both sides of `mentions()` must tokenise identically, or a title survives round-tripping through `normaliseTitle`'s punctuation-*deletion* differently than a haystack split on the same punctuation (N3). */
+/** Splits on runs of non-alphanumerics, the way a release name's dots and
+ *  dashes are. Both sides of `mentions` must tokenise identically, or
+ *  `normaliseTitle` deleting punctuation and a haystack splitting on it never
+ *  produce the same tokens. */
 const tokenize = (value: string): string[] =>
     value
         .toLowerCase()
@@ -103,22 +106,20 @@ const mentions = (haystack: string, item: MergedItem): boolean => {
     const words = titleWords(item);
     if (words.length === 0) return false;
 
-    // Same asymmetry class as N3: the needle is unfenced before tokenising,
-    // so the haystack must be too — otherwise `<<untrusted:service.field>>`
-    // itself, the service id and the field name become haystack tokens.
+    // The needle is unfenced before tokenising, so the haystack must be too —
+    // otherwise the fence markers themselves become haystack tokens.
     const hayWords = tokenize(unfenced(haystack));
     const haySet = new Set(hayWords);
     if (!words.every(w => haySet.has(w))) return false;
 
-    // A series release's year is an episode's air year/date, not the series'
-    // start year — "The.Simpsons.S32E01.2020" is not a mismatch just because
-    // the show started in 1989 (N4). Skip the guard entirely for series.
+    // A series release's year is the episode's, not the show's start year:
+    // "The.Simpsons.S32E01.2020" is no mismatch for a show that began in 1989.
+    // Skip the guard entirely for series.
     if (item.kind !== 'series' && item.year !== undefined) {
-        // A token that is itself part of the title ("2049" in "Blade Runner
-        // 2049", "1917" as a whole title, "2001" in "2001: A Space Odyssey")
-        // must not be read as *the release's* year — it is already accounted
-        // for by the word match above. Only a year-shaped token that is not
-        // one of the title's own words is a candidate (N4).
+        // A year inside the title itself — "2049", "1917", "2001" — is not
+        // *the release's* year, and the word match above already accounted for
+        // it. Only a year-shaped token that is not one of the title's own
+        // words counts.
         const wordSet = new Set(words);
         const yearInHay = hayWords.find(w => /^(19|20)\d{2}$/.test(w) && !wordSet.has(w));
         if (yearInHay !== undefined && Number(yearInHay) !== item.year) return false;
@@ -225,7 +226,8 @@ const QUEUE_FAULT_REMEDY =
 const QUEUE_IMPORT_REMEDY =
     'The download finished but has not been imported yet — check Radarr/Sonarr’s activity/history for why, then trigger the import manually if it did not run on its own.';
 
-/** The download-client services `queue` evidence can come from — used to fold `degraded` into "could not fully look" the same way `scan`/`indexers` already do (N8). */
+/** The download clients `queue` evidence can come from, so `degraded` folds
+ *  into "could not fully look" the way `scan` and `indexers` already do. */
 const QUEUE_SERVICES: readonly ServiceId[] = ['radarr', 'sonarr', 'sabnzbd', 'transmission'];
 
 type QueueResult = { step: Step; remedy?: string };
@@ -235,14 +237,11 @@ function queueStep(ev: Evidence, item: MergedItem): QueueResult {
     if (ev.queue === undefined) return { step: { stage: 'queue', status: 'unknown', detail: 'No download client could be reached.' } };
 
     const { items, partial } = ev.queue;
-    // A service already named in `degraded` is unreachable even if the
-    // collector's per-stage `partial` list did not separately say so (N8).
-    // Deliberately `degraded` (probe reachability), not `libraryDegraded`
-    // (a review finding): Radarr/Sonarr's *library* read
-    // failing must not make this stage believe their *queue* probe failed
-    // too — the two used to share one array, so a Radarr library-read
-    // failure alone made this stage report unknown even when every
-    // configured download client had answered in full.
+    // A service in `degraded` is unreachable even if the per-stage `partial`
+    // list did not say so. Deliberately `degraded` (probe reachability), not
+    // `libraryDegraded`: the two once shared one array, so a Radarr
+    // library-read failure alone made this stage report unknown even when
+    // every download client had answered in full.
     const effectivePartial = [...new Set([...partial, ...ev.degraded.filter(s => QUEUE_SERVICES.some(t => s === t || s.startsWith(`${t}/`)))])];
     const mine = items.filter(q => mentions(q.title, item));
 
@@ -288,7 +287,7 @@ function queueStep(ev: Evidence, item: MergedItem): QueueResult {
         // the adapter that read it knows what its status means — reported
         // as could-not-fully-classify, not silently folded into "active"
         // (which would claim progress this module has no basis for) or
-        // "fault" (which would claim a problem it cannot name) (N6).
+        // "fault", which would claim a problem it cannot name.
         return {
             step: {
                 stage: 'queue',
@@ -485,7 +484,7 @@ export function buildChain(query: string, ev: Evidence): Diagnosis {
 
     // `file` is now computed whenever Radarr/Sonarr knows about the item at
     // all, regardless of `monitored` — a file can exist on disk even when
-    // monitoring is off, and residual-C1 needs that real signal (below) to
+    // monitoring is off, and the check below needs that real signal to
     // tell "not monitored, and also no file" apart from "not monitored, but
     // it is sitting right there".
     if (acquisition === undefined) {
@@ -519,7 +518,7 @@ export function buildChain(query: string, ev: Evidence): Diagnosis {
     const isBlocked = (s: Stage): boolean => byStage.get(s)?.status === 'blocked';
     // A file already confirmed on disk is proof that whatever request/managed
     // history led here already worked well enough to produce it — residual
-    // C1: an old declined/pending request, or `monitored: false`, cannot be
+    // An old declined/pending request, or `monitored: false`, cannot be
     // why playback fails when the file is sitting right there. From this
     // point on only Jellyfin's visibility of that file matters.
     const fileIsOk = byStage.get('file')?.status === 'ok';
@@ -552,7 +551,7 @@ export function buildChain(query: string, ev: Evidence): Diagnosis {
         certaintyPath = ['request', 'managed'];
     } else if (isBlocked('file')) {
         // A missing file is a symptom, not the cause: a stalled download or
-        // a dead indexer is (C1) — but only reached here because `file` is
+        // a dead indexer is — but only reached here because `file` is
         // genuinely `blocked`, not merely mentioned by an unrelated row.
         if (isBlocked('queue')) {
             // Checked first: a queue row is live, current evidence about an
@@ -573,8 +572,8 @@ export function buildChain(query: string, ev: Evidence): Diagnosis {
         // Only reachable with `fileIsOk` true — `libraryStep` can only
         // report `blocked` when `acquisition.hasFile === true`, which is
         // exactly `file`'s own `ok` condition. request/managed are excluded
-        // above, and correctly so: I6 (scan explains a blocked library) and
-        // N1 (an unknown scan costs certainty even when library alone would
+        // above, and correctly so: a scan explains a blocked library, and
+        // an unknown scan costs certainty even when library alone would
         // have been enough to verdict on) both apply here.
         verdictStage = isBlocked('scan') ? 'scan' : 'library';
         certaintyPath = ['file', 'library', 'scan'];
@@ -599,7 +598,7 @@ export function buildChain(query: string, ev: Evidence): Diagnosis {
     if (verdictStage === undefined) {
         // The positive claim "is available in Jellyfin and playable" is only
         // honest when `library` itself said `ok` — read the step, not just
-        // whether Jellyfin is configured (C2): `certain: false` alone does
+        // whether Jellyfin is configured: `certain: false` alone does
         // not retract an unqualified sentence sitting right next to it.
         const summary =
             libStep?.status === 'ok'

--- a/src/tools/diagnose/chain.ts
+++ b/src/tools/diagnose/chain.ts
@@ -92,25 +92,19 @@ const titleWords = (item: MergedItem): string[] => {
 };
 
 /**
- * Whether a release name (a queue row's title, a rejection's query) plausibly
- * refers to `item`.
+ * Whether a release name plausibly refers to `item`. Three failure modes it
+ * guards against, each of which has happened:
  *
- * Three failure modes this specifically guards against:
- * - **Substring matching.** "Alien" is a substring of "Aliens", and "Dune" of
- *   "Dune.Part.Two" — different films. Matching whole, tokenised words closes
- *   the first; a differing year in the haystack closes the second (title
- *   match without a contradicting year is still allowed — an ambiguous
- *   release name is more useful reported than silently dropped).
- * - **A length filter that starves short titles.** "Up", "Se7en" and "Top
- *   Gun" have no word over three characters; a filter that drops short words
- *   (the original approach) leaves nothing to match *anything*. All words
- *   count, however short.
- * - **Punctuation deletion vs. punctuation splitting (N3, a round-1
- *   regression).** `normaliseTitle` *deletes* intra-word punctuation
- *   ("Spider-Man" → "spiderman"), while a release name is naturally *split*
- *   on the same characters ("Spider.Man.2002" → "spider", "man", "2002").
- *   Deleting on one side and splitting on the other means neither ever
- *   produces the same tokens: `tokenize` splits both sides identically.
+ * - **Substring matching.** "Alien" is inside "Aliens", "Dune" inside
+ *   "Dune.Part.Two". Whole tokenised words close the first; a contradicting
+ *   year closes the second.
+ * - **A length filter starves short titles.** "Up", "Se7en" and "Top Gun" have
+ *   no word over three characters, so dropping short words left nothing to
+ *   match. Every word counts, however short.
+ * - **Deleting punctuation on one side, splitting on the other.**
+ *   `normaliseTitle` deletes it ("Spider-Man" → "spiderman") while a release
+ *   name splits on it ("Spider.Man.2002" → spider, man, 2002), so neither ever
+ *   produced the same tokens. `tokenize` splits both sides identically.
  */
 const mentions = (haystack: string, item: MergedItem): boolean => {
     const words = titleWords(item);
@@ -172,21 +166,16 @@ function requestStep(ev: Evidence): Step {
 }
 
 /**
- * Explicit, not a regex over free text: `/stall|fail|error|paused/i` reads
- * `completed` — a download waiting on Radarr/Sonarr to import it, which *is*
- * the broken import this phase exists to surface — as "still downloading",
- * because the word "complete" contains none of those substrings. It misreads
- * `downloadClientUnavailable`, and Radarr/Sonarr's own `warning`/`delay`, the
- * same way. Status vocabulary is collected from what the adapters actually
- * emit: Radarr/Sonarr's queue (`queued`, `paused`, `downloading`, `completed`,
- * `failed`, `warning`, `delay`, `downloadClientUnavailable`), Transmission's
- * RPC spec, and SABnzbd's slot status, all lowercased before matching here.
+ * An explicit set, not a regex over free text. `/stall|fail|error|paused/i`
+ * reads `completed` — a download waiting to be imported, which is exactly the
+ * broken import this tool exists to surface — as "still downloading", because
+ * "complete" contains none of those substrings. It misreads
+ * `downloadClientUnavailable` and `warning`/`delay` the same way.
  *
- * `seeding` / `queued to seed` (Transmission) mean the torrent itself
- * finished — the file is fully on disk, same as Radarr/Sonarr's `completed`
- * — so they classify as import-pending, not active (N5). `propagating`
- * (SABnzbd, the file is being finalised/verified post-download — healthy)
- * stays active (N6).
+ * The vocabulary is what the adapters actually emit, lowercased. `seeding` and
+ * `queued to seed` mean the file is fully on disk, so they are import-pending
+ * rather than active; `propagating` is SABnzbd finalising a healthy download,
+ * so it stays active.
  */
 const QUEUE_ACTIVE = new Set([
     'downloading',
@@ -207,18 +196,13 @@ const QUEUE_IMPORT_PENDING = new Set(['completed', 'seeding', 'queued to seed'])
 type QueueClass = 'active' | 'importPending' | 'fault' | 'indeterminate';
 
 /**
- * Anything not explicitly recognised as active or import-pending is a fault
- * — that includes real faults like `failed`/`paused`/`stalled`/`warning`,
- * and anything this module has never seen before — silence is not evidence
- * of health.
+ * Anything not recognised as active or import-pending is a fault, including
+ * statuses this module has never seen: silence is not evidence of health.
  *
- * One exception (N6, by I5's own reasoning): the literal string `"unknown"`
- * is not a status a download client actually reports — it is *this repo's
- * own adapters'* fallback (`SabnzbdAdapter`'s `s.status ?? 'unknown'`,
- * `TransmissionAdapter`'s `TORRENT_STATUS[...] ?? 'unknown'`) for a status
- * code they could not map. That is the service answering with something
- * this module cannot classify — `indeterminate`, not a fault, exactly as an
- * indeterminate Seerr request status is `unknown`, not silently `ok` (I5).
+ * One exception. The literal `"unknown"` is not something a download client
+ * reports — it is our own adapters' fallback for a status code they could not
+ * map. That is the service saying something unclassifiable, so it is
+ * `indeterminate` rather than a fault.
  */
 function classifyQueueStatus(item: QueueItem): QueueClass {
     if (item.errorMessage !== undefined) return 'fault';
@@ -409,19 +393,14 @@ const REMEDIES: Partial<Record<Stage, string>> = {
 };
 
 /**
- * `file`'s remedy used to assert "no indexer reported a failure" and "nothing
- * is downloading" unconditionally — a claim about Prowlarr or a download
- * client even when the stack runs neither, *or* when it runs both but
- * neither answered (N2: the summary's own caveat says "Could not check:
- * queue, prowlarr" right next to a remedy asserting they were checked).
+ * The remedy must not claim a service was checked when it was not. It once
+ * asserted "no indexer reported a failure" unconditionally — printed directly
+ * beneath the summary's own "Could not check: queue, prowlarr".
  *
- * `StepStatus: 'skipped'` alone cannot tell "not configured" apart from
- * "configured, reachable, and genuinely found nothing" — `queueStep`/
- * `indexerStep` return the same status for both, with only their `detail`
- * text differing. So the *configured* flags decide "not configured", and
- * `status === 'unknown'` (only reachable when configured) decides
- * "unreachable"; only when neither applies does a service get credit for
- * having actually been checked.
+ * `'skipped'` alone cannot tell "not configured" from "checked and found
+ * nothing", since both steps return it for either. So the *configured* flags
+ * decide "not configured" and `'unknown'` decides "unreachable"; a service
+ * gets credit for being checked only when neither applies.
  */
 function fileRemedy(ev: Evidence, queueStatus: StepStatus, indexerStatus: StepStatus): string {
     const uncheckable: string[] = [];
@@ -437,11 +416,9 @@ function fileRemedy(ev: Evidence, queueStatus: StepStatus, indexerStatus: StepSt
 }
 
 /**
- * A queue row can be genuinely blocked (a fault, or a completed-but-unimported
- * download) while `file` is still `ok` — an upgrade grab failing, say. C1
- * correctly stops that from outranking a green chain, but going silent about
- * a real, active failure is over-correction in the other direction (N7): it
- * is worth a mention, just not the verdict.
+ * A queue row can be genuinely blocked while `file` is still `ok` — a failing
+ * upgrade grab, say. That must not outrank a green chain, but going silent
+ * about a real failure over-corrects: it is worth a mention, not the verdict.
  *
  * The wording changes on `fileIsOk`, rather than being suppressed by it
  * (a review finding's second symptom). A `request`/`managed`
@@ -463,16 +440,13 @@ const queueAside = (queueResult: QueueResult, fileIsOk: boolean): string => {
 };
 
 /**
- * The known one-line hedge (ledgered at Task 5, applied here at the
- * a review finding: evidence genuinely cannot distinguish "an ended
- * series, deliberately left unmonitored" or "a stale declined request" from
- * "an ongoing series, accidentally unmonitored" — there is no correctness fix
- * for that, only this disclosure. It fires only for `request`/`managed`
- * verdicts on a series with a confirmed file already visible in Jellyfin:
- * `excludeRequestManaged` already keeps a movie in this situation out of
- * `request`/`managed` entirely (residual C1), so a movie can never reach this
- * sentence, and "episodes you do not have yet" is always literally accurate
- * here.
+ * A disclosure, not a fix. Evidence genuinely cannot tell "an ended series
+ * deliberately left unmonitored" from "an ongoing one accidentally
+ * unmonitored", so this says so rather than guessing.
+ *
+ * Only for `request`/`managed` verdicts on a series with a file already
+ * visible in Jellyfin — a movie in that position is excluded upstream, so
+ * "episodes you do not have yet" is always literally true here.
  */
 const SERIES_FILE_VISIBLE_HEDGE =
     ' (A file is already on disk and visible in Jellyfin — this may only affect episodes you do not have yet.)';

--- a/src/tools/diagnose/evidence.ts
+++ b/src/tools/diagnose/evidence.ts
@@ -30,7 +30,7 @@ const RECENT_REJECTION_LIMIT = 50;
 /**
  * Every probe returns `undefined` on failure and records the service in
  * `degraded`. That is the shape the chain reads: undefined is "could not
- * look", and it is what stops a verdict being confident across a hole (§6.1).
+ * look", and it is what stops a verdict being confident across a hole.
  */
 async function probe<T>(id: string, degraded: string[], fn: () => Promise<T>): Promise<T | undefined> {
     try {
@@ -48,13 +48,13 @@ async function resolveItem(
     degraded: string[],
     libraryDegraded: string[]
 ): Promise<MergedItem | undefined> {
-    // §9's gate lives in the loader's identity resolver, and a refusal
+    // the gate lives in the loader's identity resolver, and a refusal
     // propagates out of diagnose rather than becoming a degraded stage — this
     // call is deliberately not wrapped in `probe`.
     const snapshot = await deps.library.load(target.user);
     // Library-read reachability, not probe reachability — kept in its own
-    // array rather than folded into `degraded` (item 2 of the whole-phase
-    // review). A Jellyfin `getScanState` probe failing below must not make
+    // array rather than folded into `degraded`. A Jellyfin `getScanState`
+    // probe failing below must not make
     // `libraryStep` believe the *library read* failed too, and a Radarr
     // *library* read failing here must not make `queueStep` believe Radarr's
     // *queue* probe failed — each stage now reads only the reachability
@@ -153,7 +153,7 @@ export async function collectEvidence(deps: DiagnoseDeps, target: DiagnoseTarget
         seerr === undefined ? Promise.resolve(null) : probe(seerr.id, degraded, () => seerr.getRequests({}));
 
     // Multi-service: `gather` already distinguishes "some clients answered,
-    // some didn't" from "all of them did" — exactly the queue shape §6.1 asks
+    // some didn't" from "all of them did" — exactly the queue shape asks
     // for, folded into `queue`/`queueConfigured` below rather than collapsed
     // to a single undefined the way one failing client used to erase the
     // whole stage.
@@ -188,7 +188,7 @@ export async function collectEvidence(deps: DiagnoseDeps, target: DiagnoseTarget
      * Matched on tmdbId, falling back to tvdbId, never on title. Title is
      * only optionally present on a Seerr request (`MediaRequest['title']` is
      * `?`), and even when it is, a fuzzy match is far more fragile than the
-     * strong, structured ids already used for §8's whole join.
+     * strong, structured ids already used for the whole join.
      *
      * tmdbId is tried first because it is the id both movies and series can
      * carry; tvdbId is the fallback that closes Task 7's Finding B —
@@ -198,7 +198,7 @@ export async function collectEvidence(deps: DiagnoseDeps, target: DiagnoseTarget
      *
      * The requester's name is deliberately not carried into the evidence. The
      * status answers the question, and naming who asked exposes another
-     * household member's activity to whoever ran the tool (§9).
+     * household member's activity to whoever ran the tool.
      */
     let request: Evidence['request'];
     if (requests === undefined) {

--- a/src/tools/diagnose/evidence.ts
+++ b/src/tools/diagnose/evidence.ts
@@ -52,25 +52,21 @@ async function resolveItem(
     // propagates out of diagnose rather than becoming a degraded stage — this
     // call is deliberately not wrapped in `probe`.
     const snapshot = await deps.library.load(target.user);
-    // Library-read reachability, not probe reachability — kept in its own
-    // array rather than folded into `degraded`. A Jellyfin `getScanState`
-    // probe failing below must not make
-    // `libraryStep` believe the *library read* failed too, and a Radarr
-    // *library* read failing here must not make `queueStep` believe Radarr's
-    // *queue* probe failed — each stage now reads only the reachability
-    // signal that actually applies to it.
+    // Library-read reachability, in its own array rather than folded into
+    // `degraded`. A Jellyfin scan probe failing must not make `libraryStep`
+    // believe the *library read* failed, nor a Radarr library read make
+    // `queueStep` believe Radarr's *queue* probe failed. Each stage reads only
+    // the signal that applies to it.
     for (const id of snapshot.degraded) if (!libraryDegraded.includes(id)) libraryDegraded.push(id);
 
     // The explicit id wins: it is unambiguous and a title is not.
     if (target.service !== undefined && target.id !== undefined) {
         const adapter = deps.adapters.find(a => a.id === target.service);
-        // A `ServiceId` the schema accepts but that does not implement
-        // getMediaDetails (e.g. sabnzbd) is a configuration mistake, not a
-        // hole to degrade across — silently returning `undefined` here would
-        // make the caller's own named service read as "the item does not
-        // exist" (`certain: true`), which is worse than either a stale
-        // download-client outage or a real absence. Same error, same remedy,
-        // as get_media_details.
+        // A service the schema accepts but that has no getMediaDetails
+        // (sabnzbd, say) is a configuration mistake, not a hole to degrade
+        // across. Returning `undefined` would make the caller's own named
+        // service read as "this does not exist" with `certain: true`. Same
+        // error and remedy as get_media_details.
         if (adapter === undefined || !hasMediaDetails(adapter)) {
             throw new ServiceError('NotFound', target.service, `${target.service} is not configured`, {
                 remedy: `Add services.${target.service} to config.yaml, or name a configured service.`

--- a/src/tools/discoverMedia.ts
+++ b/src/tools/discoverMedia.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/server';
 import * as z from 'zod/v4';
 import { logger } from '../core/logger.ts';
-import { DetailSchema, LimitSchema, applyLimit, type DetailLevel } from '../core/shape.ts';
+import { DetailSchema, LimitSchema, applyLimit, preferred, type DetailLevel } from '../core/shape.ts';
 import type { SeerrAdapter } from '../services/seerr.ts';
 import { fenceText } from '../core/fence.ts';
 import { enrichWithImdb } from '../metadata/enrich.ts';
@@ -19,7 +19,7 @@ const project = (h: SearchHit, detail: DetailLevel): SearchHit => {
 export async function buildDiscoverMedia(
     adapter: SeerrAdapter | undefined,
     opts: {
-        mediaType: 'movie' | 'tv';
+        kind: 'movie' | 'series';
         genre?: string;
         year?: number;
         minRating?: number;
@@ -39,7 +39,10 @@ export async function buildDiscoverMedia(
     let hits: SearchHit[];
     try {
         hits = await adapter.discover({
-            mediaType: opts.mediaType,
+            // Translated here, at the boundary that needs it: Seerr is
+            // TMDB-backed and TMDB says `tv`. Everything on our side of this
+            // call says `series`, including the items Seerr hands back.
+            mediaType: opts.kind === 'series' ? 'tv' : 'movie',
             ...(opts.genre === undefined ? {} : { genre: opts.genre }),
             ...(opts.year === undefined ? {} : { year: opts.year }),
             ...(opts.minRating === undefined ? {} : { minRating: opts.minRating })
@@ -78,7 +81,7 @@ export async function buildDiscoverMedia(
  * rejected rather than silently returning nothing.
  */
 function fromDataset(
-    opts: { mediaType: 'movie' | 'tv'; genre?: string; year?: number; minRating?: number; detail: DetailLevel; limit: number },
+    opts: { kind: 'movie' | 'series'; genre?: string; year?: number; minRating?: number; detail: DetailLevel; limit: number },
     dataset: ImdbDataset | undefined
 ): GetSearchResult {
     const empty = { items: [], total: 0, returned: 0, truncated: false, degraded: [], counts: {} };
@@ -92,7 +95,7 @@ function fromDataset(
 
     const hits = dataset
         .discover({
-            kind: opts.mediaType === 'movie' ? 'movie' : 'series',
+            kind: opts.kind,
             ...(opts.genre === undefined ? {} : { genre: opts.genre }),
             ...(opts.year === undefined ? {} : { year: opts.year }),
             ...(opts.minRating === undefined ? {} : { minRating: opts.minRating }),
@@ -102,7 +105,7 @@ function fromDataset(
             (t): SearchHit => ({
                 service: 'imdb',
                 source: 'discover',
-                kind: opts.mediaType === 'movie' ? 'movie' : 'series',
+                kind: opts.kind,
                 id: t.tconst,
                 // Fenced like every other external string. A dataset row is no
                 // more trusted than an indexer's release name.
@@ -132,7 +135,12 @@ export function registerDiscoverMedia(
             description:
                 'Browse what exists rather than what you have: films or series by genre, year and minimum rating. Nothing is requested or added. Answered by Seerr when it is configured — TMDB-backed, so `genre` is a TMDB genre id and the rating is TMDB’s. With no Seerr it is answered from the local IMDb dataset instead, where `genre` is a name such as `Crime` and the rating is IMDb’s; passing a numeric id there is refused rather than silently matching nothing.',
             inputSchema: z.object({
-                media_type: z.enum(['movie', 'tv']).default('movie').describe('Films or series.'),
+                kind: z.enum(['movie', 'series']).optional().describe('Films or series. Defaults to films.'),
+                // Undocumented on purpose: the spelling this tool had when the
+                // surface froze at 1.0. Kept working forever — removing it
+                // would break a saved prompt silently — but described nowhere,
+                // so nothing new is written against it.
+                media_type: z.enum(['movie', 'tv']).optional(),
                 genre: z.string().optional().describe('TMDB genre id, e.g. 28 for Action.'),
                 year: z.number().int().min(1900).max(2100).optional().describe('Restrict to one release year.'),
                 min_rating: z.number().min(0).max(10).optional().describe('Minimum TMDB rating out of 10.'),
@@ -140,9 +148,18 @@ export function registerDiscoverMedia(
                 limit: LimitSchema
             })
         },
-        async ({ media_type, genre, year, min_rating, detail, limit }) => {
+        async ({ kind, media_type, genre, year, min_rating, detail, limit }) => {
+            const resolved =
+                preferred({
+                    name: 'kind',
+                    value: kind,
+                    alias: 'media_type',
+                    aliasValue: media_type,
+                    translate: v => (v === 'tv' ? 'series' : v)
+                }) ?? 'movie';
+
             const result = await buildDiscoverMedia(adapter, {
-                mediaType: media_type,
+                kind: resolved as 'movie' | 'series',
                 ...(genre === undefined ? {} : { genre }),
                 ...(year === undefined ? {} : { year }),
                 ...(min_rating === undefined ? {} : { minRating: min_rating }),
@@ -152,7 +169,7 @@ export function registerDiscoverMedia(
             const summary =
                 result.degraded.length > 0
                     ? 'Seerr could not be reached; nothing to discover.'
-                    : `${result.returned} of ${result.total} ${media_type === 'tv' ? 'series' : 'film(s)'} found.`;
+                    : `${result.returned} of ${result.total} ${resolved === 'series' ? 'series' : 'film(s)'} found.`;
 
             return { content: [{ type: 'text', text: summary }], structuredContent: result };
         }

--- a/src/tools/discoverMedia.ts
+++ b/src/tools/discoverMedia.ts
@@ -52,7 +52,7 @@ export async function buildDiscoverMedia(
         return { items: [], total: 0, returned: 0, truncated: false, degraded: [adapter.id], counts: {} };
     }
 
-    // Enrichment applies whatever the source (§4.1). Seerr's discover is
+    // Enrichment applies whatever the source. Seerr's discover is
     // TMDB-backed, so a hit carrying an imdb id gains an IMDb rating beside
     // the TMDB one it already had — source selection and enrichment are
     // independent decisions.
@@ -70,7 +70,7 @@ export async function buildDiscoverMedia(
 /**
  * Discovery from the local dataset, for a stack with no Seerr.
  *
- * **Seerr wins whenever it is configured** (spec §4.2). It knows what is
+ * **Seerr wins whenever it is configured** (spec ). It knows what is
  * trending, what is requestable and what you have already asked for; the
  * dataset knows a year column. Merging two orderings that mean different
  * things would produce a ranking that means neither.

--- a/src/tools/getIndexers.ts
+++ b/src/tools/getIndexers.ts
@@ -10,7 +10,7 @@ export type GetIndexersResult = {
     returned: number;
     truncated: boolean;
     degraded: string[];
-    /** §12's "recent rejections". Present only at detail: full. */
+    /** the "recent rejections". Present only at detail: full. */
     recentRejections?: IndexerRejection[];
 };
 

--- a/src/tools/getLibrary.ts
+++ b/src/tools/getLibrary.ts
@@ -15,32 +15,24 @@ export type RatingSource = (typeof RATING_SOURCES)[number];
 const FILM_SOURCES: readonly RatingSource[] = ['imdb', 'tmdb', 'trakt', 'metacritic', 'rottenTomatoes'];
 
 /**
- * What a series can actually carry.
+ * What a series can carry. `tvdb` is Sonarr's own flat value; `imdb` comes
+ * only from the IMDb dataset, since Sonarr never reports one.
  *
- * `tvdb` is Sonarr's own flat value. `imdb` arrives from the IMDb dataset
- * (0.8 ) and is reachable *only* through it — Sonarr has never reported
- * one, and `flattenSeriesRating` can only honestly record its single unlabelled
- * number as `tvdb`. So with the dataset off, asking for `imdb` on a series is
- * accepted and simply finds nothing rated, which `ratingCoverage` then states.
- * That is the right shape: "your dataset has not been built yet" is a different
- * answer from "this filter is impossible", and only the second deserves a
- * refusal.
+ * With the dataset off, asking for `imdb` is accepted and finds nothing rated,
+ * which `ratingCoverage` states. "Not built yet" is a different answer from
+ * "impossible", and only the second deserves a refusal.
  */
 const SERIES_SOURCES: readonly RatingSource[] = ['tvdb', 'imdb'];
 
 /**
- * The scale each source's raw value arrives on. `min_rating` is documented as
- * 0–10 for every source, but Radarr/Sonarr pass Metacritic and Rotten Tomatoes
- * through on their own site's native 0–100 scale, and nothing upstream of
- * this filter rescales them — `flattenRatings`/`toMergedRatings`
- * (`src/services/arrRatings.ts`) store exactly what the *arr reported.
+ * The native scale each source arrives on. `min_rating` is documented as 0–10,
+ * but Metacritic and Rotten Tomatoes come through on 0–100 and nothing
+ * upstream rescales them.
  *
- * Comparing a raw 64 or 82 against an 0–10 `min_rating` threshold makes
- * "rated at all" read as "rated 8+" for those two sources: measured against a
- * real library, an 8+ filter matched 136 of 136 metacritic-rated films and
- * 121 of 121 rottenTomatoes-rated ones. The next source to add here needs to
- * see this decision, which is why it is a named table rather than a `/ 10` at
- * the comparison site below.
+ * Comparing a raw 64 against an 0–10 threshold makes "rated at all" read as
+ * "rated 8+": measured on a real library, an 8+ filter matched 136 of 136
+ * metacritic-rated films. A named table rather than a `/ 10` at the comparison
+ * site, so the next source added has to see this.
  */
 const RATING_SCALE_MAX: Record<RatingSource, number> = {
     imdb: 10,
@@ -160,18 +152,16 @@ function rejectImpossibleFilters(opts: LibraryQuery): void {
 }
 
 /**
- * Ordering, applied **before** `applyLimit` — ordering after truncation is the
- * same bug wearing a parameter.
+ * Applied **before** `applyLimit` — ordering after truncation is the same bug
+ * wearing a parameter.
  *
- * A rating sort assumes unrated items have already been removed by the caller,
- * which is what `needsRating` below guarantees. They are excluded rather than
- * ranked as zero: sorted to the bottom, an item nobody has rated is
- * indistinguishable from one rated 0.4, and `ratingCoverage.unrated` is what
- * states how many were set aside.
+ * A rating sort relies on `needsRating` below having already removed unrated
+ * items. Excluded rather than ranked zero: at the bottom of a list, an item
+ * nobody rated is indistinguishable from one rated 0.4, and
+ * `ratingCoverage.unrated` states how many were set aside.
  *
- * `localeCompare` rather than `<`, so "Ålesund" sorts where a reader expects
- * rather than after "Zulu", and `unfenced` because a title reaching here still
- * carries its untrusted-value fence.
+ * `localeCompare` so "Ålesund" sorts where a reader expects, and `unfenced`
+ * because a title here still carries its untrusted-value fence.
  */
 function applySort(items: readonly MergedItem[], sort: SortField, source: RatingSource): MergedItem[] {
     const sorted = [...items];

--- a/src/tools/getLibrary.ts
+++ b/src/tools/getLibrary.ts
@@ -7,18 +7,18 @@ import { unfenced } from '../core/titleMatch.ts';
 import { UserSchema } from './getPlayback.ts';
 import type { LibraryLoader } from './library.ts';
 
-/** The five §4.1 names a film can carry, plus the one a series can. */
+/** The five names a film can carry, plus the one a series can. */
 export const RATING_SOURCES = ['imdb', 'tmdb', 'trakt', 'metacritic', 'rottenTomatoes', 'tvdb'] as const;
 export type RatingSource = (typeof RATING_SOURCES)[number];
 
-/** Films only. `tvdb` is Sonarr's flat value and belongs to series alone (§21.2). */
+/** Films only. `tvdb` is Sonarr's flat value and belongs to series alone. */
 const FILM_SOURCES: readonly RatingSource[] = ['imdb', 'tmdb', 'trakt', 'metacritic', 'rottenTomatoes'];
 
 /**
  * What a series can actually carry.
  *
  * `tvdb` is Sonarr's own flat value. `imdb` arrives from the IMDb dataset
- * (0.8 §4.1) and is reachable *only* through it — Sonarr has never reported
+ * (0.8 ) and is reachable *only* through it — Sonarr has never reported
  * one, and `flattenSeriesRating` can only honestly record its single unlabelled
  * number as `tvdb`. So with the dataset off, asking for `imdb` on a series is
  * accepted and simply finds nothing rated, which `ratingCoverage` then states.
@@ -61,7 +61,7 @@ const RATING_SCALE_MAX: Record<RatingSource, number> = {
 const toTenPointScale = (source: RatingSource, value: number): number => (value / RATING_SCALE_MAX[source]) * 10;
 
 /**
- * §4.3. A superlative cannot be answered by a filter: with more items than
+ *  A superlative cannot be answered by a filter: with more items than
  * `limit`, the best-rated may simply not be in the window, and the model then
  * answers confidently from whatever fifty it was handed.
  *
@@ -102,7 +102,7 @@ export type GetLibraryResult = {
 const ratingOf = (item: MergedItem, source: RatingSource): number | undefined => item.ratings?.[source];
 
 /**
- * §5: "whichever source covers the most of the library". Ties break in the
+ * "whichever source covers the most of the library". Ties break in the
  * declared order, so the same library always answers the same way.
  *
  * A series query stays on `tvdb` by default even though the IMDb dataset can
@@ -128,7 +128,7 @@ function bestCoveredSource(items: readonly MergedItem[], kind: LibraryQuery['kin
 }
 
 /**
- * §5.2's two documented limits, enforced rather than left to produce an empty
+ * the two documented limits, enforced rather than left to produce an empty
  * list. A filter that quietly matches nothing is worse than a stated gap: the
  * model reports "you have no such series" and the user believes it.
  *
@@ -272,7 +272,7 @@ export async function buildGetLibrary(loader: LibraryLoader, opts: LibraryQuery)
         return { ...shaped, items: shaped.items.map(i => project(i, opts.detail)), degraded, counts };
     }
 
-    // §5.1: coverage is measured over everything the other filters kept, before
+    // coverage is measured over everything the other filters kept, before
     // the rating filter removes anything — that is what makes "184 rated, 66
     // unrated" answer the question the caller actually asked.
     const source = opts.rating_source ?? bestCoveredSource(filtered, opts.kind);

--- a/src/tools/getLibrary.ts
+++ b/src/tools/getLibrary.ts
@@ -2,7 +2,7 @@ import type { McpServer } from '@modelcontextprotocol/server';
 import * as z from 'zod/v4';
 import type { ServiceId } from '../config/schema.ts';
 import type { MergedItem } from '../core/resolver.ts';
-import { DetailSchema, LimitSchema, applyLimit, type DetailLevel } from '../core/shape.ts';
+import { DetailSchema, LimitSchema, applyLimit, preferred, type DetailLevel } from '../core/shape.ts';
 import { unfenced } from '../core/titleMatch.ts';
 import { UserSchema } from './getPlayback.ts';
 import type { LibraryLoader } from './library.ts';
@@ -315,7 +315,13 @@ export function registerGetLibrary(server: McpServer, loader: LibraryLoader): vo
                     .describe(
                         'Whether a file is actually on disk. `false` with `monitored: true` is "what am I still waiting for"; `true` is "what can I watch now". Media no *arr manages is excluded from both answers rather than counted as missing — nothing is going to fetch it.'
                     ),
-                watched: z.boolean().optional().describe('Jellyfin watch state. Items Jellyfin has never seen count as unwatched.'),
+                watched: z.boolean().optional().describe('Jellyfin watch state. Items Jellyfin has never seen count as unwatched. Pair with `user` to ask about someone else.'),
+                user: UserSchema,
+                // Undocumented on purpose: the spelling this tool had when the
+                // surface froze at 1.0, where `get_playback` and `get_requests`
+                // already called the same thing `user`. Kept working forever —
+                // removing it would break a saved prompt silently — but
+                // described nowhere.
                 watched_by: UserSchema,
                 quality: z.string().min(1).optional().describe('Films only.'),
                 min_rating: z
@@ -347,7 +353,13 @@ export function registerGetLibrary(server: McpServer, loader: LibraryLoader): vo
             })
         },
         async input => {
-            const result = await buildGetLibrary(loader, input as LibraryQuery);
+            const { user, watched_by, ...rest } = input as LibraryQuery & { user?: string };
+            const watchedBy = preferred({ name: 'user', value: user, alias: 'watched_by', aliasValue: watched_by });
+
+            const result = await buildGetLibrary(loader, {
+                ...rest,
+                ...(watchedBy === undefined ? {} : { watched_by: watchedBy })
+            } as LibraryQuery);
 
             const coverage =
                 result.ratingCoverage === undefined

--- a/src/tools/getMediaDetails.ts
+++ b/src/tools/getMediaDetails.ts
@@ -47,7 +47,7 @@ export type MediaDetailsQuery = {
 };
 
 /**
- * The resolved form (§5.3): the merged record the join §8 exists for.
+ * The resolved form: the merged record the join exists for.
  *
  * Like the explicit form, it **throws rather than degrading**. A request for
  * one specific item either produced that item or did not, and an empty success
@@ -76,7 +76,7 @@ export async function buildResolvedMediaDetails(loader: LibraryLoader, query: st
 }
 
 /**
- * Two forms, both deliberate (§5.3). `query` returns the merged record;
+ * Two forms, both deliberate. `query` returns the merged record;
  * `service` + `id` returns one service's raw view, which is how you inspect a
  * join that looks wrong and what `diagnose` needs when `presence` says the two
  * halves disagree.
@@ -141,8 +141,8 @@ export function registerGetMediaDetails(
             }, dataset);
 
             // `unknown` is not a place something is "present in" — it is the
-            // absence of a confident answer (item 1 of the whole-phase
-            // review), so it gets its own phrasing rather than reading as
+            // absence of a confident answer, so it gets its own phrasing
+            // rather than reading as
             // "present in: unknown."
             const summary =
                 'presence' in result

--- a/src/tools/library.ts
+++ b/src/tools/library.ts
@@ -17,7 +17,7 @@ export type LibrarySnapshot = {
 
 /**
  * One cached library index, shared by get_library, get_media_details and
- * diagnose (§8: duplicating the join is how joins drift apart).
+ * diagnose (duplicating the join is how joins drift apart).
  *
  * The cache lives here rather than in the adapters, so adapters stay directly
  * testable against fixtures and caching policy sits in one reviewable place.
@@ -36,7 +36,7 @@ export class LibraryLoader {
          * The IMDb dataset, when one is configured.
          *
          * Enrichment happens here rather than in each tool for the reason this
-         * class exists at all (§8: duplicating the join is how joins drift
+         * class exists at all (duplicating the join is how joins drift
          * apart). `get_library`, `get_media_details` and `diagnose` all read
          * this one cached snapshot, so they cannot disagree about a rating,
          * and the dataset is queried once per cache TTL rather than once per
@@ -55,7 +55,7 @@ export class LibraryLoader {
     async load(user?: string): Promise<LibrarySnapshot> {
         const resolved = await this.#resolveUser(user);
 
-        // §4.3: the key includes the user id, or one household member's watch
+        // the key includes the user id, or one household member's watch
         // history appears in another's answer — a correctness bug that reads as
         // a privacy one.
         const key = `library:${resolved?.id ?? 'none'}`;
@@ -72,7 +72,7 @@ export class LibraryLoader {
     }
 
     /**
-     * §16's write-invalidation seam, and the reason `TtlCache.invalidate`
+     * the write-invalidation seam, and the reason `TtlCache.invalidate`
      * existed unused until now. Called after a successful write, so the next
      * `get_library` reflects the change rather than up to five minutes of a
      * library that no longer exists.
@@ -94,7 +94,7 @@ export class LibraryLoader {
      * user was named — naming someone must not turn a plain Jellyfin outage
      * into a hard failure of the whole library read; the *arr half is still
      * worth returning. Three distinct meanings, three distinct outcomes
-     * (whole-phase review item 5 — this is the one place all three have to
+     * (a review finding — this is the one place all three have to
      * stay apart):
      *
      * - `AuthFailed` — the named user was refused (`allow_other_users` is
@@ -110,7 +110,7 @@ export class LibraryLoader {
      *   silently swallowed the remedy and reported "jellyfin could not be
      *   reached" forever, indistinguishable from a real, transient outage,
      *   while `stack_health` kept calling Jellyfin healthy. This is also what
-     *   used to make item 1's `unknown`-when-ungathered collapse permanent
+     *   used to make the `unknown`-when-ungathered collapse permanent
      *   rather than transient on such a stack: nothing about the failure ever
      *   changes, so it never stops being ungathered.
      *   Previously this propagated only when `requested !== undefined` (a

--- a/src/tools/library.ts
+++ b/src/tools/library.ts
@@ -33,16 +33,11 @@ export class LibraryLoader {
         jellyfinIdentity: IdentityResolver | undefined,
         cache: TtlCache = new TtlCache(),
         /**
-         * The IMDb dataset, when one is configured.
-         *
-         * Enrichment happens here rather than in each tool for the reason this
-         * class exists at all (duplicating the join is how joins drift
-         * apart). `get_library`, `get_media_details` and `diagnose` all read
-         * this one cached snapshot, so they cannot disagree about a rating,
-         * and the dataset is queried once per cache TTL rather than once per
-         * tool call.
-         *
-         * Last and optional, so every existing call site keeps compiling.
+         * Enrichment happens here, not per tool, for the reason this class
+         * exists: all three readers share one snapshot, so they cannot
+         * disagree about a rating, and the dataset is queried once per cache
+         * TTL rather than once per call. Last and optional, so existing call
+         * sites keep compiling.
          */
         dataset?: ImdbDataset | undefined
     ) {
@@ -55,32 +50,23 @@ export class LibraryLoader {
     async load(user?: string): Promise<LibrarySnapshot> {
         const resolved = await this.#resolveUser(user);
 
-        // the key includes the user id, or one household member's watch
-        // history appears in another's answer — a correctness bug that reads as
-        // a privacy one.
+        // Keyed by user, or one household member's watch history appears in
+        // another's answer — a correctness bug that reads as a privacy one.
         const key = `library:${resolved?.id ?? 'none'}`;
 
-        // A partial load is not worth five minutes of cache: the missing
-        // service is usually restarting, and the next call should find it.
-        // Declined via `shouldCache` rather than a follow-up `invalidate()`:
-        // invalidate has no way to tell "my degraded load lost a race to a
-        // fresher, complete one" from "nothing raced me" — it would delete
-        // the good entry in the first case. `shouldCache` runs on the same
-        // identity check the cache's own failure path uses, so only this
-        // exact load's entry is ever dropped.
+        // A partial load is not worth five minutes of cache. Declined via
+        // `shouldCache` rather than a later `invalidate()`, which cannot tell
+        // "my degraded load lost a race to a complete one" from "nothing raced
+        // me" and would delete the good entry.
         return this.#cache.get(key, LIBRARY_TTL_MS, () => this.#build(resolved), snapshot => snapshot.degraded.length === 0);
     }
 
     /**
-     * the write-invalidation seam, and the reason `TtlCache.invalidate`
-     * existed unused until now. Called after a successful write, so the next
-     * `get_library` reflects the change rather than up to five minutes of a
-     * library that no longer exists.
+     * Called after a successful write, so the next `get_library` reflects it
+     * rather than up to five minutes of a library that no longer exists.
      *
-     * Clears every entry rather than one key: this cache holds nothing but
-     * library snapshots, and a Radarr write invalidates *every* user's
-     * snapshot, not just the writer's — the keys are per Jellyfin user, and the
-     * film that was just deleted is gone from all of them. Recomputing a
+     * Clears every entry, not one key: keys are per Jellyfin user, and a film
+     * just deleted is gone from all of them. Recomputing a
      * household's worth of snapshots costs one library read each; serving a
      * stale one costs a wrong answer.
      */
@@ -89,41 +75,21 @@ export class LibraryLoader {
     }
 
     /**
-     * Returns undefined when there is no Jellyfin half to fetch. The decision
-     * to propagate or degrade turns on the error's *kind*, not on whether a
-     * user was named — naming someone must not turn a plain Jellyfin outage
-     * into a hard failure of the whole library read; the *arr half is still
-     * worth returning. Three distinct meanings, three distinct outcomes
-     * (a review finding — this is the one place all three have to
-     * stay apart):
+     * Undefined when there is no Jellyfin half to fetch.
      *
-     * - `AuthFailed` — the named user was refused (`allow_other_users` is
-     *   false and it wasn't the default). Always propagates: the model must
+     * Propagate or degrade turns on the error's **kind**, never on whether a
+     * user was named — naming someone must not turn a plain Jellyfin outage
+     * into a hard failure of the whole read, since the *arr half is still
+     * worth returning.
+     *
+     * - `AuthFailed` — the named user was refused. Propagates: a model must
      *   not retry a refusal.
-     * - `NotFound` — either nobody was named and no `default_user` is
-     *   configured, or the name in play (named or default) does not exist in
-     *   Jellyfin's own directory. Always propagates now, regardless of
-     *   `requested`: both are configuration errors with an actionable remedy
-     *   already attached (`IdentityResolver` names the exact config key), and
-     *   `src/config/schema.ts` documents that a per-user tool called with
-     *   nothing configured *fails naming that key* — degrading here instead
-     *   silently swallowed the remedy and reported "jellyfin could not be
-     *   reached" forever, indistinguishable from a real, transient outage,
-     *   while `stack_health` kept calling Jellyfin healthy. This is also what
-     *   used to make the `unknown`-when-ungathered collapse permanent
-     *   rather than transient on such a stack: nothing about the failure ever
-     *   changes, so it never stops being ungathered.
-     *   Previously this propagated only when `requested !== undefined` (a
-     *   user was explicitly named) — the no-`default_user`-configured case
-     *   degraded silently. That distinction is gone: both are the same kind
-     *   of error (a config key that needs setting), so both surface the same
-     *   way. This must not be confused with `AuthFailed` above, which is a
-     *   different, narrower thing — a *configured* default exists, someone
-     *   asked to be answered as somebody else, and it was refused. That is
-     *   never a configuration gap and must never degrade.
-     * - Everything else — `Unreachable`, `Timeout`, `UpstreamError`, and any
-     *   non-`ServiceError` — degrades regardless of whether a user was named:
-     *   a real reachability problem, not a configuration one.
+     * - `NotFound` — no `default_user` configured, or the name does not exist
+     *   in Jellyfin. Propagates, because it is a config error carrying a
+     *   remedy that names the exact key. Degrading here instead reported
+     *   "jellyfin could not be reached" forever — indistinguishable from a
+     *   transient outage, and while `stack_health` called Jellyfin healthy.
+     * - Everything else degrades: a reachability problem, not a config one.
      */
     async #resolveUser(requested: string | undefined): Promise<ServiceUser | undefined> {
         if (this.#identity === undefined) return undefined;

--- a/src/tools/lookupMedia.ts
+++ b/src/tools/lookupMedia.ts
@@ -9,7 +9,7 @@ import { buildSearchMedia, type GetSearchResult } from './searchMedia.ts';
  * `search_media` with `source` fixed to `discover`.
  *
  * A separate tool rather than a parameter because the two answer different
- * questions, and design spec §12 lists them separately. The tool surface is
+ * questions, and lists them separately. The tool surface is
  * the public API, and a model choosing between "search my library" and "tell
  * me about this" should not have to reason about an enum to do it.
  */

--- a/src/tools/register.ts
+++ b/src/tools/register.ts
@@ -48,7 +48,7 @@ export type ToolContext = {
      * `library` already closes over it — the owned-library join happens there
      * exactly once. This field is for the tools that answer about things you
      * may *not* own, which never touch the library index: search, lookup and
-     * details. Spec §4.1 calls that the path that matters most, because a
+     * details. Spec calls that the path that matters most, because a
      * rating is usually wanted before deciding to add something.
      */
     dataset: ImdbDataset | undefined;
@@ -56,7 +56,7 @@ export type ToolContext = {
      *  write gate reads, so `stack_health` cannot report a different answer. */
     instances: readonly ServiceInstance[];
     /**
-     * The write half (§10). Built once alongside the resolvers rather than per
+     * The write half. Built once alongside the resolvers rather than per
      * request: `ConfirmTokens` holds the signing key and the spent-token set,
      * and rebuilding it per request would make every confirmation token invalid
      * the moment it was issued — the handshake spans two calls by construction.
@@ -115,7 +115,7 @@ export function buildToolContext(
  *
  * Tools whose service is not configured are **still registered**: they return
  * an empty result explaining the service is absent. Hiding a tool would make
- * the surface depend on configuration, and design spec §18 treats the tool
+ * the surface depend on configuration, and treats the tool
  * surface as the public API — a model that learned `get_subtitles` exists must
  * not find it missing after a config edit.
  */
@@ -138,7 +138,7 @@ export function registerAllTools(server: McpServer, context: ToolContext): void 
     registerLookupMedia(server, adapters, dataset);
     registerDiscoverMedia(server, seerr, dataset);
 
-    // Registered unconditionally like every read tool, and for the same §18
+    // Registered unconditionally like every read tool, and for the same 
     // reason: the tool surface is the public API and must not depend on
     // configuration. A stack with no write permission still *has*
     // trigger_search — it refuses, naming the key to set, which is a far better

--- a/src/tools/register.ts
+++ b/src/tools/register.ts
@@ -28,6 +28,7 @@ import { registerDeleteRequest, registerRespondToRequest } from './manageRequest
 import { registerRemoveQueueItem } from './removeQueueItem.ts';
 import { registerSearchMedia } from './searchMedia.ts';
 import { registerStackHealth } from './stackHealth.ts';
+import { registerTriggerScan } from './triggerScan.ts';
 import { registerTriggerSearch } from './triggerSearch.ts';
 import type { WriteContext } from './write.ts';
 
@@ -143,6 +144,7 @@ export function registerAllTools(server: McpServer, context: ToolContext): void 
     // trigger_search — it refuses, naming the key to set, which is a far better
     // answer than a tool the model was told about and cannot find.
     registerTriggerSearch(server, write, adapters);
+    registerTriggerScan(server, write, adapters);
     registerRemoveQueueItem(server, write, adapters);
     registerDeleteMedia(server, write, adapters);
     registerRespondToRequest(server, write, adapters);
@@ -150,7 +152,13 @@ export function registerAllTools(server: McpServer, context: ToolContext): void 
     registerAddMedia(server, write, adapters);
 }
 
-/** The tool surface, frozen. §18: renaming one breaks users' saved prompts. */
+/**
+ * The tool surface, frozen at 1.0.
+ *
+ * Renaming or removing any of these breaks every user's saved prompts
+ * *silently* — the model stops finding the tool rather than raising an error —
+ * so from 1.0 onward it takes a major version. Adding one is a minor.
+ */
 export const TOOL_NAMES = [
     'diagnose',
     'stack_health',
@@ -166,6 +174,7 @@ export const TOOL_NAMES = [
     'lookup_media',
     'discover_media',
     'trigger_search',
+    'trigger_scan',
     'remove_queue_item',
     'delete_media',
     'respond_to_request',

--- a/src/tools/stackHealth.ts
+++ b/src/tools/stackHealth.ts
@@ -46,10 +46,10 @@ export type StackHealthResult = {
 export type InstancePermissions = { instance: string; safe_write: boolean; destructive: boolean };
 
 /**
- * minimal  — is anything broken? A verdict per service, and counts only.
+ * minimal — is anything broken? A verdict per service, and counts only.
  * standard — everything except disk paths, the longest strings in the response
  *            and rarely what the question was about.
- * full     — everything, paths included.
+ * full — everything, paths included.
  */
 function project(result: StackHealthResult, detail: DetailLevel): StackHealthResult {
     if (detail === 'full') return result;
@@ -87,7 +87,7 @@ function project(result: StackHealthResult, detail: DetailLevel): StackHealthRes
 
 /**
  * Composes per-service diagnoses into one answer. This tool must work
- * *especially* well when something is broken (design spec §15) — a service
+ * *especially* well when something is broken — a service
  * that is down contributes a diagnosis and a `degraded` entry, never an
  * exception.
  */

--- a/src/tools/triggerScan.ts
+++ b/src/tools/triggerScan.ts
@@ -1,0 +1,81 @@
+import type { McpServer } from '@modelcontextprotocol/server';
+import * as z from 'zod/v4';
+import { ServiceIdSchema, type ServiceId } from '../config/schema.ts';
+import { ServiceError } from '../core/errors.ts';
+import { hasLibraryScan, type ServiceAdapter } from '../services/types.ts';
+import { INSTANCE_PARAM_DESCRIPTION, resolveInstance } from './resolveInstance.ts';
+import { registerWriteTool, type WriteContext, type WritePlan } from './write.ts';
+
+/**
+ * The other half of the answer `diagnose` gives most often.
+ *
+ * `diagnose` names a stale library scan as the usual reason something that
+ * finished downloading is still not playable — and until 1.0 nothing here could
+ * act on it, so its best answer ended "now go and start one yourself". The tool
+ * that identifies a problem should be able to fix it.
+ *
+ * **Safe, not destructive.** A scan reads the filesystem and updates a
+ * database; nothing is deleted, nothing is grabbed, and running one you did not
+ * need costs time and disk I/O rather than data. `destructive` is reserved for
+ * writes whose worst outcome is losing something.
+ */
+
+const findAdapter = (adapters: readonly ServiceAdapter[], service: ServiceId, instance?: string) => {
+    const adapter = resolveInstance(adapters, service, instance);
+
+    if (!hasLibraryScan(adapter)) {
+        // Refused rather than accepted as a no-op: a queue client or an indexer
+        // has no library to scan, and reporting success for an action that
+        // could never happen is how a model concludes the scan is done.
+        throw new ServiceError('NotFound', service, `${service} has no library to scan`, {
+            remedy: 'Only radarr, sonarr and jellyfin manage a library. For "it downloaded but will not play", jellyfin is almost always the one you want.'
+        });
+    }
+
+    return adapter;
+};
+
+export function registerTriggerScan(
+    server: McpServer,
+    context: WriteContext,
+    adapters: readonly ServiceAdapter[]
+): void {
+    registerWriteTool(server, context, {
+        name: 'trigger_scan',
+        description:
+            'Asks Radarr, Sonarr or Jellyfin to rescan its library — the "it downloaded but still will not play" action, and the usual fix for what `diagnose` reports as a stale scan. Jellyfin is the one that matters when something is missing from what you can actually watch. This queues the scan and returns immediately; a large library can take minutes, so check `stack_health` afterwards rather than expecting it to be done. Previews by default — call again with the returned `confirm` token to actually run it.',
+        inputSchema: z.object({
+            service: ServiceIdSchema.describe('radarr, sonarr or jellyfin.'),
+            instance: z.string().optional().describe(INSTANCE_PARAM_DESCRIPTION)
+        }),
+        // Resolved from the arguments, so the permission checked, the audit row
+        // written and the token issued all name the same instance.
+        service: ({ service, instance }) => findAdapter(adapters, service, instance).id,
+        operation: 'trigger_scan',
+        tier: 'safe',
+
+        async plan({ service, instance }): Promise<WritePlan> {
+            const adapter = findAdapter(adapters, service, instance);
+
+            return {
+                target: adapter.id,
+                summary: `Ask ${adapter.id} to rescan its library.`,
+                effects: [
+                    `Queues a library scan on ${adapter.id}.`,
+                    'Finds media added or moved on disk since the last scan.',
+                    'Can take minutes on a large library, and runs in the background.'
+                ],
+                args: { service, ...(instance === undefined ? {} : { instance }) }
+            };
+        },
+
+        async apply(_plan, { service, instance }) {
+            const adapter = findAdapter(adapters, service, instance);
+            const handle = await adapter.startLibraryScan();
+
+            return `${adapter.id} is rescanning its library. It runs in the background — check get_media_details or stack_health in a few minutes rather than expecting it to be finished now.${
+                handle.commandId === 0 ? '' : ` Command id ${handle.commandId}.`
+            }`;
+        }
+    });
+}

--- a/src/tools/triggerSearch.ts
+++ b/src/tools/triggerSearch.ts
@@ -7,7 +7,7 @@ import { hasMediaDetails, hasSearchTrigger, type ServiceAdapter } from '../servi
 import { registerWriteTool, type WriteContext, type WritePlan } from './write.ts';
 
 /**
- * Phase 4's first write, and the shape every later one follows.
+ * The first write, and the shape every later one follows.
  *
  * It takes `service` plus `id` and **not** a title. Every read tool accepts a
  * fuzzy title because the cost of resolving one wrongly is a wrong answer the

--- a/src/tools/write.ts
+++ b/src/tools/write.ts
@@ -7,20 +7,16 @@ import { checkPermission, type PermissionSource, type WriteTier } from '../core/
 import type { LibraryLoader } from './library.ts';
 
 /**
- * Design spec, assembled once.
+ * The four properties every write must have — permission tier, `dry_run`, an
+ * audit record, per-call confirmation — are this function, not four things each
+ * tool remembers. A tool supplies only what is specific to it: `plan`, which
+ * describes an effect without touching anything, and `apply`, reached only once
+ * all four gates pass.
  *
- * The four properties a write must have — permission tier, `dry_run`, an audit
- * record, per-call confirmation — are not four things each write tool
- * remembers to do. They are this function, and a write tool supplies only the
- * two halves that are actually specific to it: `plan`, which resolves
- * arguments into a concrete described effect without touching anything, and
- * `apply`, which is reached only once all four gates have passed.
- *
- * That split is the design. A tool physically cannot mutate during the preview
- * phase, because the preview phase only ever calls `plan` — the mutating code
- * is in a callback the harness declines to invoke. Reviewing a new write tool
- * therefore means reading its `plan`/`apply` pair, not auditing whether it
- * remembered to check permissions.
+ * That split is the design. A tool physically cannot mutate during preview,
+ * because preview only calls `plan` — the mutating code sits in a callback the
+ * harness declines to invoke. So reviewing a write tool means reading its
+ * `plan`/`apply` pair, not auditing whether it checked permissions.
  */
 
 /** What `plan` resolved the request into: a concrete target and a description

--- a/src/tools/write.ts
+++ b/src/tools/write.ts
@@ -7,7 +7,7 @@ import { checkPermission, type PermissionSource, type WriteTier } from '../core/
 import type { LibraryLoader } from './library.ts';
 
 /**
- * Design spec §10, assembled once.
+ * Design spec, assembled once.
  *
  * The four properties a write must have — permission tier, `dry_run`, an audit
  * record, per-call confirmation — are not four things each write tool
@@ -76,7 +76,7 @@ export type WriteContext = {
     permissions: PermissionSource;
     confirm: ConfirmTokens;
     audit: WriteAudit;
-    /** Invalidated after a successful write (§16). */
+    /** Invalidated after a successful write. */
     library: LibraryLoader;
 };
 

--- a/src/web/assets.ts
+++ b/src/web/assets.ts
@@ -295,7 +295,7 @@ if (addService) {
 // Every other part of this page is server-rendered through an escaping
 // template, and that is sound. This one is different in kind: log lines carry
 // release names straight from public indexers, which are the most
-// attacker-controllable strings in the whole system (design spec §11). Setting
+// attacker-controllable strings in the whole system. Setting
 // innerHTML here would make one escaping mistake, anywhere in the server-side
 // rendering path, an XSS. Building nodes and assigning textContent makes that
 // impossible rather than merely unlikely.

--- a/src/web/assets.ts
+++ b/src/web/assets.ts
@@ -122,9 +122,9 @@ dialog .panel { margin: 0; border: 0; border-radius: 10px; max-height: 82vh; ove
  * Everything else is a form post and a server render.
  */
 export const JS = `
-// Say what actually happened. The clipboard write below fails on every plain
-// http origin, and reporting "Copied" for a fallback that only selected the
-// text is how someone pastes the wrong thing and blames the field.
+// Say what actually happened. The clipboard write fails on every plain http
+// origin, and reporting "Copied" for a fallback that only selected the text is
+// how someone pastes the wrong thing and blames the field.
 const flash = (btn, text) => {
   if (btn.dataset.label === undefined) btn.dataset.label = btn.textContent.trim();
   btn.textContent = text;
@@ -154,10 +154,9 @@ document.addEventListener('click', async (e) => {
   }
 });
 
-// The client config is assembled here, in the browser, and never rendered by
-// the server. The token is masked three lines above it on the page; putting the
-// same value into the HTML as readable JSON would quietly undo that, and a
-// screenshot of the dashboard would carry a working credential.
+// Assembled in the browser, never rendered by the server. The token is masked
+// three lines above on the page, so putting it into the HTML as readable JSON
+// would undo that and make a screenshot carry a working credential.
 document.addEventListener('click', async (e) => {
   const btn = e.target.closest('[data-copy-config]');
   if (!btn) return;
@@ -180,10 +179,9 @@ document.addEventListener('click', async (e) => {
     await navigator.clipboard.writeText(config);
     flash(btn, 'Copied');
   } catch {
-    // No clipboard on http, and unlike the fields above there is nothing
-    // already on screen to select — so fill the textarea now and reveal it.
-    // That puts the token on screen, which is acceptable only because it takes
-    // an explicit click on a button that says it copies credentials.
+    // No clipboard on http, and nothing on screen to select — so fill the
+    // textarea and reveal it. That puts the token on screen, acceptable only
+    // because it took a click on a button that says it copies credentials.
     box.value = config;
     selectIn(box);
     flash(btn, 'Selected — copy it');
@@ -203,9 +201,8 @@ document.addEventListener('click', (e) => {
 });
 
 // The add form: a dialog opened by a button, with fields that follow the
-// service picker. Both are enhancements — with scripting off the <noscript>
-// rule in pages.ts styles the dialog back into the page and every field shows,
-// which is the form exactly as it was before either of these existed.
+// picker. Both are enhancements — with scripting off, a <noscript> rule styles
+// the dialog back into the page and every field shows.
 const addService = document.getElementById('add-service');
 if (addService) {
   document.addEventListener('click', (e) => {

--- a/src/web/configPage.ts
+++ b/src/web/configPage.ts
@@ -5,30 +5,20 @@ import { html, raw, type SafeHtml } from './html.ts';
 import { layout } from './pages.ts';
 
 /**
- * The configuration page: one card per configured instance, and nothing else.
+ * One card per configured instance, and nothing else. Three rules shape it.
  *
- * Three rules shape it.
+ * **A secret is never rendered back.** Credentials render as empty fields
+ * meaning "unchanged", so a saved page or a screenshot cannot carry them. Blank
+ * therefore never means "clear this" — removing the instance does.
  *
- * **A secret is never rendered back.** API keys, the Transmission password and
- * the UI password all render as empty fields meaning "unchanged", so a saved
- * page, a screenshot or a browser's autofill history cannot carry them. An empty
- * credential field therefore can never mean "clear this"; removing the instance
- * is how you clear it, which is unambiguous.
+ * **Each card is its own form**, so a save touches exactly the instance it came
+ * from rather than rewriting every other service on screen.
  *
- * **Each card is its own form.** The page used to render all eight services
- * inside one form and rebuild every service from `svc.<id>.<field>` prefixes on
- * every save. With instances that prefix would have to carry `radarr/4k`. A form
- * per card means bare field names, and a save that touches exactly the instance
- * it came from rather than rewriting seven others that happened to be on screen.
- *
- * **Nothing here is `type="password"`.** That one attribute is what makes a
- * browser, and every password-manager extension, read a card as a login form:
- * a text input for the username, a password input below it. They then filled
- * the URL with a saved username and the key with a saved password on every
- * single load, so editing a timeout meant re-pasting both. `autocomplete="off"`
- * does not stop it — it is ignored for exactly these fields, deliberately. So
- * the secrets are masked in CSS instead (`IGNORE`, and `.secret` in
- * `assets.ts`), which leaves nothing for the heuristics to find.
+ * **Nothing here is `type="password"`.** That attribute is what makes browsers
+ * and password managers read a card as a login form and fill the URL and key on
+ * every load, so editing a timeout meant re-pasting both. `autocomplete="off"`
+ * is ignored for those fields deliberately, so the secrets are masked in CSS
+ * instead, leaving nothing for the heuristics to find.
  */
 
 export const SERVICE_IDS = ServiceIdSchema.options;
@@ -57,11 +47,10 @@ type AnyService = {
 /**
  * Every way of saying "do not fill this in" that anything actually reads.
  *
- * `autocomplete="off"` is first because it is the standard one, and last
- * because on its own it does nothing here: Chrome and every major extension
- * ignore it for fields they have decided are credentials. The rest are each
- * vendor's own opt-out, which they do honour. Dashlane reads `data-form-type`
- * off the form rather than the input, so that one is on the `<form>` tags.
+ * `autocomplete="off"` is the standard one and does nothing on its own — Chrome
+ * and every major extension ignore it for fields they consider credentials. The
+ * rest are per-vendor opt-outs, which they do honour. Dashlane reads
+ * `data-form-type` off the form, so that one is on the `<form>` tags.
  */
 const IGNORE = raw(
     'autocomplete="off" data-1p-ignore data-lpignore="true" data-bwignore data-protonpass-ignore'

--- a/src/web/html.ts
+++ b/src/web/html.ts
@@ -1,7 +1,7 @@
 /**
  * The one place untrusted text becomes HTML.
  *
- * Design spec §11 treats everything a service returns as data, never
+ * Design spec treats everything a service returns as data, never
  * instruction — and the config UI is where that data stops being JSON in a
  * model's context and becomes markup in a browser. A release name from a
  * public indexer reaches the log stream; a film title reaches the audit view.

--- a/src/web/pages.ts
+++ b/src/web/pages.ts
@@ -270,7 +270,7 @@ const statusDot = (d: ConnectionDiagnosis): SafeHtml =>
 /**
  * A card per service, showing the *diagnosis* rather than a tick or a cross.
  *
- * §6/§14: a connection test that returns true/false tells you nothing about
+ * /a connection test that returns true/false tells you nothing about
  * what to fix. `testConnection` already returns kind, detail and remedy — this
  * is the first surface that shows all three to a human.
  */
@@ -455,7 +455,7 @@ export function dashboardPage(opts: {
 /**
  * The three streams.
  *
- * `logger.ts` has promised "the config UI's three log streams" since Phase 1,
+ * `logger.ts` has promised "the config UI's three log streams",
  * and the design spec that named them is not in this repository — so these are
  * the three the code can actually support, chosen from what the logger already
  * binds: everything, only what is wrong, and one service at a time. They are

--- a/src/web/pages.ts
+++ b/src/web/pages.ts
@@ -179,28 +179,22 @@ function sameSize(a: number, b: number): boolean {
  * Collapse the mounts every service reports down to the disks behind them.
  *
  * Services in a stack are containers over the same host filesystems, so the
- * array that arrives here is mostly the same two or three disks repeated: the
- * array volume once per *arr plus the download client, the container root once
- * per service, `/config` again for each. Ten rows to say "you have two disks",
- * which is a table nobody reads.
+ * same two or three disks arrive repeated — ten rows to say "you have two
+ * disks", which is a table nobody reads.
  *
- * Free bytes are the fingerprint, compared with a tolerance rather than for
- * equality — **not every service has byte precision to report**. SABnzbd
- * returns gigabytes as a string to two decimals (`gigabytesToBytes` in
- * `sabnzbd.ts` records a live 5.0.4 answering `"4711.95"`), a quantum of about
- * 10.7 MB, while the *arrs return exact byte counts. Measured, one 4.6 TB
- * filesystem arrives from the two of them 4.8 MB apart. Exact equality can
- * never match a source like that, and the symptom is the disk you were trying
- * to de-duplicate listed twice with identical rounded numbers.
+ * Free bytes are the fingerprint, compared with a **tolerance rather than for
+ * equality**: not every service reports byte precision. SABnzbd returns
+ * gigabytes to two decimals, so one 4.6 TB filesystem arrives 4.8 MB away from
+ * the exact count Radarr gives for it, and exact equality could never match
+ * them — the symptom being the disk listed twice with identical rounded
+ * numbers.
  *
- * Totals then guard against a false merge: a mount only joins a group whose
- * total it does not contradict, which also folds in Transmission — it reports
- * free space without a total, so it has nothing to contradict and lands on the
- * disk it shares.
+ * A mount only joins a group whose total it does not contradict, which guards
+ * against a false merge and folds in Transmission, which reports free space
+ * with no total to contradict.
  *
- * Paths are dropped rather than listed. Knowing that one disk is `/storage` to
- * Radarr and `/data` to SABnzbd is a container-mapping question; the question
- * this table answers is whether anything is about to run out of room.
+ * Paths are dropped: which mount is `/storage` is a container-mapping
+ * question, and this table answers whether anything is running out of room.
  */
 export function groupDisks(disks: readonly DiskSpace[]): DiskGroup[] {
     const groups: DiskGroup[] = [];

--- a/src/web/pages.ts
+++ b/src/web/pages.ts
@@ -69,13 +69,12 @@ dialog { display: block; position: static; max-width: none; width: auto; margin:
 }
 
 /**
- * Shown until someone claims the instance — a fresh install has no password at
- * all, so there is nothing a login form could accept.
+ * Shown until someone claims the instance: a fresh install has no password, so
+ * there is nothing a login form could accept. No `nav`, since there is nowhere
+ * to go and no session to sign out of.
  *
- * No `nav`: there is nowhere else to go yet, and a sign-out button on a page
- * with no session is nonsense. The warning is not decoration — between the
- * container starting and this form being submitted, the instance belongs to
- * whoever reaches it first.
+ * The warning is not decoration — until this form is submitted, the instance
+ * belongs to whoever reaches it first.
  */
 export function setupPage(opts: { version: string; error?: string | undefined }): string {
     const body = html`<div class="login">
@@ -150,11 +149,10 @@ export type DiskGroup = { freeSpace: number; totalSpace?: number | undefined; se
 /**
  * How far apart two reports of one filesystem may be and still be one disk.
  *
- * Measured, not guessed: SABnzbd's two-decimal gigabytes put the same 4.6 TB
- * filesystem 4.8 MB — 0.0001% — away from the byte count Radarr reports for it.
- * This is a thousand times that, and still three orders of magnitude below the
- * gap between any two disks a real stack holds (a 228 GB root against a 10.8 TB
- * array differ by 5000%).
+ * Measured: SABnzbd's two-decimal gigabytes put the same 4.6 TB filesystem
+ * 4.8 MB — 0.0001% — from the byte count Radarr gives. This is a thousand times
+ * that, and three orders of magnitude below the gap between any two real
+ * disks.
  *
  * Relative rather than absolute because the quantisation error scales with the
  * number being reported, and an absolute figure that suited a 10 TB array would

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -230,15 +230,14 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
     // --- configuration --------------------------------------------------
 
     /**
-     * Who each user-aware service says its users are, for the default-user
-     * field to suggest.
+     * Who each user-aware service says its users are, to suggest in the
+     * default-user field.
      *
-     * Capped well below any service's own timeout on purpose. This is the page
-     * you open *because* something is unreachable, and a Jellyfin that is down
-     * must cost a moment, not the ten seconds its own client would wait. A
-     * service that misses the cap is simply absent from the result, which the
-     * card renders as a plain text field saying so — never as an empty dropdown
-     * that reads like "this service has no users".
+     * Capped well below the services' own timeouts: this is the page you open
+     * *because* something is unreachable, so a dead Jellyfin must cost a
+     * moment, not ten seconds. A service that misses the cap is absent from the
+     * result and the card says so — never an empty dropdown, which reads as
+     * "this service has no users".
      */
     const USER_LOOKUP_MS = 2500;
 
@@ -381,25 +380,18 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
     );
 
     /**
-     * Test one instance — against the fields as they stand, not as they are
-     * saved.
+     * Test one instance against the fields as they stand, not as they are
+     * saved — replacing "save it and see if the dashboard goes green", which
+     * writes a URL you already suspect is wrong and answers on another page.
+     * The candidate is built exactly as a save would build it and thrown away.
      *
-     * "Save it and see if the dashboard goes green" is the loop this replaces,
-     * and it is a bad one: it writes a URL you already suspect is wrong, and it
-     * answers on a different page. So the candidate config is built exactly as
-     * a save would build it, validated, and thrown away — nothing reaches disk,
-     * and a blank credential still means *unchanged*, so testing a card you
-     * have not touched tests what is already configured.
+     * The add dialog posts here too, with no `instance`. That candidate comes
+     * from `addInstance`, the same call Add makes, so a passing test is one Add
+     * will accept — and it inherits Add's validation, so an unnamed second
+     * radarr answers "name it" rather than a latency.
      *
-     * The add dialog posts here too, with no `instance` — there is not one yet.
-     * That candidate is built by `addInstance`, the same call Add itself makes,
-     * so a test that passes is a test that Add will accept. It inherits Add's
-     * validation along with it: testing a second radarr before naming it
-     * answers "name the new radarr instance" rather than a latency, which is
-     * the thing you needed to hear either way.
-     *
-     * Not a `configMutation`, despite the shape: that helper's whole contract
-     * is that it ends in `saveConfig`.
+     * Not a `configMutation`, despite the shape: that helper ends in
+     * `saveConfig`.
      */
     app.post('/ui/config/test', async c => {
         const session = guard(c);
@@ -474,15 +466,12 @@ function sessionOf(c: Context, runtime: Runtime): string | undefined {
 }
 
 /**
- * Resolves which of the three streams was asked for, and what that means as a
- * query.
+ * Which of the three streams was asked for, as a query.
  *
- * The service filter is parsed through `ServiceIdSchema`, so an unknown value
- * becomes "no filter" rather than reaching the store — the ids are a closed
- * set, and validating against it costs nothing.
- *
- * The "by service" stream with no service chosen defaults to the first that
- * has actually logged, so the tab is never a blank page with a dropdown.
+ * The service filter goes through `ServiceIdSchema`, so an unknown value
+ * becomes "no filter" rather than reaching the store. "By service" with none
+ * chosen defaults to the first that has actually logged, so the tab is never a
+ * blank page with a dropdown.
  */
 function logQuery(
     c: Context,
@@ -506,15 +495,12 @@ function logQuery(
 }
 
 /**
- * The instance fields a card's form carries.
+ * The instance fields a card's form carries, under bare names — each card is
+ * its own form, and an id containing a `/` has no sensible prefix anyway.
  *
- * Bare names, because each card is its own form — there is no `svc.<id>.`
- * prefix to parse any more, and with instance ids containing a `/` there is no
- * sensible prefix to invent.
- *
- * A blank credential means "unchanged", never "clear": the page never renders a
- * secret back, so blank is what an untouched field always looks like. Clearing
- * is expressed by removing the instance, which is unambiguous and confirmed.
+ * A blank credential means "unchanged", never "clear". The page never renders a
+ * secret back, so blank is what an untouched field always looks like; clearing
+ * is expressed by removing the instance, which is confirmed.
  */
 export function instanceFieldsFrom(form: Record<string, unknown>): InstanceFields {
     const timeout = Number(str(form.timeout_ms));

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -123,12 +123,10 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
         const password = str(form.password);
         const auth = runtime.config.auth;
 
-        // One message for both wrong-username and wrong-password, and the
-        // password check runs either way: a login form that answers faster for
-        // an unknown user tells an attacker which names exist.
-        //
-        // The hash is present by the time we get here, but the type no longer
-        // proves it, and a missing hash must never read as a valid login.
+        // One message for both wrong username and wrong password, and the hash
+        // check runs either way — a form that answers faster for an unknown
+        // user tells an attacker which names exist. A missing hash must never
+        // read as a valid login.
         const nameOk = username === auth.username;
         const passOk = auth.password_hash !== undefined && verifyPassword(password, auth.password_hash);
 
@@ -161,10 +159,9 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
 
         const snapshot = runtime.current;
 
-        // Gathered through `buildStackHealth`, the same function `stack_health`
-        // answers from, rather than by calling the adapters again here. Two
-        // implementations of "is the stack healthy" is how the page and the
-        // tool come to disagree — the same reason keeps one library join.
+        // Through `buildStackHealth`, the same function `stack_health` answers
+        // from. Two implementations of "is the stack healthy" is how the page
+        // and the tool come to disagree.
         // It is live, not cached: a dashboard showing cached status is one
         // that tells you a dead service is fine, and it degrades rather than
         // failing when a service is unreachable.
@@ -296,11 +293,10 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
             const session = guard(c);
             if (session === undefined) return c.redirect(entry(), 302);
 
-            // Asks the services who their users are on the way out, the same as
-            // a plain page load: a save that dropped the suggestions would have
-            // the card claim the service went quiet when nothing of the sort
-            // happened, and a save that changed a Jellyfin key is exactly when
-            // the list is worth refreshing.
+            // Re-asks who the users are, as a plain page load does: a save that
+            // dropped the suggestions would have the card claim the service went
+            // quiet, and a save that changed a Jellyfin key is exactly when the
+            // list is worth refreshing.
             const render = async (
                 message: { kind: 'ok' | 'err'; text: string } | undefined,
                 status: 200 | 400 | 403,
@@ -401,13 +397,11 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
         const id = str(form.instance);
         const isAdd = id === '';
 
-        // The dialog's Test is fetched rather than posted, so its result can
-        // land in a dialog that still holds what you typed. A page re-render
-        // could not: `addDialog` renders its fields blank, and filling them
-        // back in would mean writing the API key into the HTML — which is the
-        // one thing `configPage` is built never to do. The unscripted path
-        // falls through to the same render as everything else, blank fields
-        // and all, exactly as a refused Add already behaves.
+        // The dialog's Test is fetched, not posted, so the result lands in a
+        // dialog that still holds what you typed. A re-render could not:
+        // `addDialog` renders its fields blank, and refilling them would mean
+        // writing the API key into the HTML — the one thing `configPage` never
+        // does. Unscripted falls through to the ordinary render.
         const wantsJson = c.req.header('accept')?.includes('application/json') === true;
 
         const render = async (status: 200 | 400 | 403, extra: Partial<Parameters<typeof configPage>[0]>) =>

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -41,7 +41,7 @@ const MIN_PASSWORD = 12;
 export type WebDeps = { runtime: Runtime; audit: WriteAudit; logs: LogStore; name: string; version: string };
 
 /**
- * The config UI (design spec §6): a dashboard, connection tests that diagnose
+ * The config UI: a dashboard, connection tests that diagnose
  * rather than pass/fail, log streams, the write audit, and configuration
  * editing that applies without a restart.
  *
@@ -164,7 +164,7 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
         // Gathered through `buildStackHealth`, the same function `stack_health`
         // answers from, rather than by calling the adapters again here. Two
         // implementations of "is the stack healthy" is how the page and the
-        // tool come to disagree — the same reason §8 keeps one library join.
+        // tool come to disagree — the same reason keeps one library join.
         // It is live, not cached: a dashboard showing cached status is one
         // that tells you a dead service is fine, and it degrades rather than
         // failing when a service is unreachable.

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -185,7 +185,7 @@ describe('the advertised tool surface', () => {
      * tool rather than raising an error. This asserts the exact set, so any
      * change to it has to be deliberate enough to edit a test.
      */
-    it('exposes exactly the thirteen tools of the frozen surface', async () => {
+    it('exposes exactly the frozen surface, no more and no fewer', async () => {
         expect((await listTools()).map(t => t.name).sort()).toEqual([...TOOL_NAMES].sort());
     });
 
@@ -324,12 +324,19 @@ describe('prompts and resources, beside the tools rather than instead of them', 
      * degrades past roughly forty, and a phase that quietly spent four of that
      * budget on convenience would be the wrong trade.
      */
-    it('still advertises exactly nineteen tools', async () => {
+    /**
+     * The count is asserted against TOOL_NAMES rather than a literal, because a
+     * literal in a test is a second place the number lives and the two drift.
+     * `CONTRIBUTING.md` caps this near forty — accuracy degrades past it — so
+     * the guard that matters is the ceiling, not the exact figure.
+     */
+    it('advertises exactly the frozen tool list, well inside the ceiling', async () => {
         const res = await app().request(
             'http://localhost:6060/mcp',
             rpc(toolsList, { Authorization: `Bearer ${TOKEN}` })
         );
         const { result } = (await rpcPayload(res)) as { result: { tools: unknown[] } };
-        expect(result.tools).toHaveLength(19);
+        expect(result.tools).toHaveLength(TOOL_NAMES.length);
+        expect(TOOL_NAMES.length).toBeLessThan(40);
     });
 });

--- a/test/searchTools.test.ts
+++ b/test/searchTools.test.ts
@@ -247,7 +247,7 @@ describe('lookup_media', () => {
             seerrConfig,
             serving({
                 '/api/v1/search': {
-                    results: [{ id: 550, mediaType: 'movie', title: 'Some Film', releaseDate: '2026-03-01' }]
+                    results: [{ id: 550, kind: 'movie', title: 'Some Film', releaseDate: '2026-03-01' }]
                 }
             })
         );
@@ -260,7 +260,7 @@ describe('lookup_media', () => {
             seerrConfig,
             serving({
                 '/api/v1/search': {
-                    results: [{ id: 1, mediaType: 'tv', name: 'Some Show', firstAirDate: '2024-06-01' }]
+                    results: [{ id: 1, kind: 'series', name: 'Some Show', firstAirDate: '2024-06-01' }]
                 }
             })
         );
@@ -490,8 +490,8 @@ describe('get_media_details', () => {
 describe('discover_media', () => {
     const RESULTS = {
         results: [
-            { id: 550, mediaType: 'movie', title: 'Some Film', releaseDate: '2026-03-01' },
-            { id: 551, mediaType: 'movie', title: 'Other Film', releaseDate: '2025-06-01' }
+            { id: 550, kind: 'movie', title: 'Some Film', releaseDate: '2026-03-01' },
+            { id: 551, kind: 'movie', title: 'Other Film', releaseDate: '2025-06-01' }
         ]
     };
 
@@ -506,29 +506,29 @@ describe('discover_media', () => {
 
     it('returns TMDB-backed results as search hits', async () => {
         const { adapter } = recording();
-        const result = await buildDiscoverMedia(adapter, { mediaType: 'movie', detail: 'full', limit: 50 });
+        const result = await buildDiscoverMedia(adapter, { kind: 'movie', detail: 'full', limit: 50 });
         expect(result.items[0]).toMatchObject({ service: 'seerr', source: 'discover', kind: 'movie', ids: { tmdb: 550 } });
     });
 
     it('asks Seerr for the movie endpoint for films and the tv endpoint for series', async () => {
         const movies = recording();
-        await buildDiscoverMedia(movies.adapter, { mediaType: 'movie', detail: 'full', limit: 50 });
+        await buildDiscoverMedia(movies.adapter, { kind: 'movie', detail: 'full', limit: 50 });
         expect(movies.urls[0]).toContain('/api/v1/discover/movies');
 
         const tv = recording();
-        await buildDiscoverMedia(tv.adapter, { mediaType: 'tv', detail: 'full', limit: 50 });
+        await buildDiscoverMedia(tv.adapter, { kind: 'series', detail: 'full', limit: 50 });
         expect(tv.urls[0]).toContain('/api/v1/discover/tv');
     });
 
     it('passes the rating floor to TMDB rather than filtering after the fact', async () => {
         const { adapter, urls } = recording();
-        await buildDiscoverMedia(adapter, { mediaType: 'movie', minRating: 8, detail: 'full', limit: 50 });
+        await buildDiscoverMedia(adapter, { kind: 'movie', minRating: 8, detail: 'full', limit: 50 });
         expect(new URL(urls[0] ?? '').searchParams.get('voteAverageGte')).toBe('8');
     });
 
     it('passes genre and year through', async () => {
         const { adapter, urls } = recording();
-        await buildDiscoverMedia(adapter, { mediaType: 'movie', genre: '28', year: 2026, detail: 'full', limit: 50 });
+        await buildDiscoverMedia(adapter, { kind: 'movie', genre: '28', year: 2026, detail: 'full', limit: 50 });
 
         const params = new URL(urls[0] ?? '').searchParams;
         expect(params.get('genre')).toBe('28');
@@ -538,12 +538,12 @@ describe('discover_media', () => {
 
     it('fences titles', async () => {
         const { adapter } = recording();
-        const result = await buildDiscoverMedia(adapter, { mediaType: 'movie', detail: 'full', limit: 50 });
+        const result = await buildDiscoverMedia(adapter, { kind: 'movie', detail: 'full', limit: 50 });
         expect(result.items.every(i => i.title.startsWith('<<untrusted:seerr.title>>'))).toBe(true);
     });
 
     it('returns an empty result rather than throwing when Seerr is not configured', async () => {
-        expect(await buildDiscoverMedia(undefined, { mediaType: 'movie', detail: 'full', limit: 50 })).toMatchObject({
+        expect(await buildDiscoverMedia(undefined, { kind: 'movie', detail: 'full', limit: 50 })).toMatchObject({
             items: [],
             total: 0,
             degraded: []
@@ -557,7 +557,7 @@ describe('discover_media', () => {
                 throw Object.assign(new Error('refused'), { code: 'ECONNREFUSED' });
             }) as unknown as typeof fetch
         );
-        const result = await buildDiscoverMedia(broken, { mediaType: 'movie', detail: 'full', limit: 50 });
+        const result = await buildDiscoverMedia(broken, { kind: 'movie', detail: 'full', limit: 50 });
         expect(result.degraded).toEqual(['seerr']);
     });
 });
@@ -667,7 +667,7 @@ describe('discovering without Seerr', () => {
     const query = { detail: 'standard' as const, limit: 10 };
 
     it('answers from the dataset when Seerr is not configured', async () => {
-        const result = await buildDiscoverMedia(undefined, { ...query, mediaType: 'movie', genre: 'Crime' }, dataset());
+        const result = await buildDiscoverMedia(undefined, { ...query, kind: 'movie', genre: 'Crime' }, dataset());
 
         // Fenced, like every external string that reaches model context — a
         // dataset row is no more trusted than an indexer's release name.
@@ -677,12 +677,12 @@ describe('discovering without Seerr', () => {
     });
 
     it('maps the tv media type onto series', async () => {
-        const result = await buildDiscoverMedia(undefined, { ...query, mediaType: 'tv' }, dataset());
+        const result = await buildDiscoverMedia(undefined, { ...query, kind: 'series' }, dataset());
         expect(result.items.map(i => unfenced(i.title))).toEqual(['Breaking Bad']);
     });
 
     it('filters by minimum rating', async () => {
-        const result = await buildDiscoverMedia(undefined, { ...query, mediaType: 'movie', minRating: 9.4 }, dataset());
+        const result = await buildDiscoverMedia(undefined, { ...query, kind: 'movie', minRating: 9.4 }, dataset());
         expect(result.items).toHaveLength(0);
     });
 
@@ -694,12 +694,12 @@ describe('discovering without Seerr', () => {
      */
     it('refuses a TMDB genre id it cannot possibly match', async () => {
         await expect(
-            buildDiscoverMedia(undefined, { ...query, mediaType: 'movie', genre: '28' }, dataset())
+            buildDiscoverMedia(undefined, { ...query, kind: 'movie', genre: '28' }, dataset())
         ).rejects.toThrow(/TMDB id/);
     });
 
     it('returns the same empty result as before when neither is available', async () => {
-        const result = await buildDiscoverMedia(undefined, { ...query, mediaType: 'movie' }, undefined);
+        const result = await buildDiscoverMedia(undefined, { ...query, kind: 'movie' }, undefined);
         expect(result).toMatchObject({ items: [], total: 0 });
     });
 });

--- a/test/shape.test.ts
+++ b/test/shape.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { DEFAULT_LIMIT, DetailSchema, LimitSchema, MAX_LIMIT, applyLimit } from '../src/core/shape.ts';
+import { DEFAULT_LIMIT, DetailSchema, LimitSchema, MAX_LIMIT, applyLimit, preferred } from '../src/core/shape.ts';
 
 describe('applyLimit', () => {
     it('reports truncation honestly when the list is longer than the limit', () => {
@@ -83,5 +83,60 @@ describe('schemas', () => {
 
     it('rejects a fractional limit', () => {
         expect(LimitSchema.safeParse(1.5).success).toBe(false);
+    });
+});
+
+/**
+ * 1.0 froze the tool surface with two names inconsistent: `discover_media`
+ * asked for `media_type` in a vocabulary it did not answer in, and
+ * `get_library` called a Jellyfin user `watched_by` where two other tools call
+ * it `user`. Both keep working forever — removing a spelling breaks a saved
+ * prompt silently, which is the failure the freeze exists to prevent.
+ */
+describe('honouring an older spelling', () => {
+    const of = (value?: string, aliasValue?: string) =>
+        preferred({ name: 'kind', value, alias: 'media_type', aliasValue });
+
+    it('takes the documented name when only it was given', () => {
+        expect(of('series', undefined)).toBe('series');
+    });
+
+    it('takes the old spelling when only it was given', () => {
+        expect(of(undefined, 'series')).toBe('series');
+    });
+
+    it('is undefined when neither was given', () => {
+        expect(of(undefined, undefined)).toBeUndefined();
+    });
+
+    it('accepts both when they agree, since nothing is ambiguous', () => {
+        expect(of('series', 'series')).toBe('series');
+    });
+
+    /**
+     * Refused rather than resolved. Silently preferring one would make the
+     * answer depend on a precedence rule nobody wrote down, and the caller
+     * would never learn which half of their request was dropped.
+     */
+    it('refuses a request that contradicts itself, naming both spellings', () => {
+        expect(() => of('movie', 'series')).toThrow(/kind/);
+        expect(() => of('movie', 'series')).toThrow(/media_type/);
+    });
+
+    /** The alias may speak a different vocabulary — `tv` where the documented
+     *  name says `series` — so agreement is judged after translating. */
+    it('translates the old vocabulary before comparing', () => {
+        const tv = (value?: string, aliasValue?: string) =>
+            preferred({
+                name: 'kind',
+                value,
+                alias: 'media_type',
+                aliasValue,
+                translate: v => (v === 'tv' ? 'series' : v)
+            });
+
+        expect(tv(undefined, 'tv')).toBe('series');
+        expect(tv('series', 'tv')).toBe('series');
+        expect(() => tv('movie', 'tv')).toThrow();
     });
 });

--- a/test/toolSurface.test.ts
+++ b/test/toolSurface.test.ts
@@ -1,0 +1,104 @@
+import { McpServer } from '@modelcontextprotocol/server';
+import { describe, expect, it } from 'vitest';
+import type { IndexInput } from '../src/core/resolver.ts';
+import type { ServiceAdapter } from '../src/services/types.ts';
+import { registerDiscoverMedia } from '../src/tools/discoverMedia.ts';
+import { registerGetLibrary } from '../src/tools/getLibrary.ts';
+import { LibraryLoader } from '../src/tools/library.ts';
+
+/**
+ * The surface a client actually sees, driven through real registrations.
+ *
+ * 1.0 froze it with two names inconsistent, and both old spellings keep working
+ * forever while only the new ones are described. That property is only real at
+ * the registration layer — the build functions below it speak one vocabulary —
+ * so it has to be tested here.
+ */
+
+const film = (title: string, tmdb: number): IndexInput => ({
+    kind: 'movie',
+    title,
+    ids: { tmdb },
+    acquisition: { service: 'radarr', monitored: true, hasFile: true },
+    playback: { user: 'Someone', watched: true }
+});
+
+const radarr = (): ServiceAdapter =>
+    ({
+        id: 'radarr',
+        type: 'radarr',
+        testConnection: async () => ({ ok: true, service: 'radarr', latency_ms: 1 }),
+        getVersion: async () => '5.0.0',
+        listLibrary: async () => [film('Have it', 1)]
+    }) as unknown as ServiceAdapter;
+
+type Handler = (args: Record<string, unknown>, extra: Record<string, unknown>) => Promise<{
+    structuredContent?: Record<string, unknown>;
+}>;
+
+// The SDK stores a tool's callback as `handler`, the same as a prompt's, and
+// calls it with (args, extra) — confirmed by inspecting a real registration.
+const toolsOf = (register: (s: McpServer) => void): Record<string, { handler: Handler }> => {
+    const server = new McpServer({ name: 'test', version: '0' });
+    register(server);
+    return (server as unknown as { _registeredTools: Record<string, { handler: Handler }> })._registeredTools;
+};
+
+const callLibrary = (args: Record<string, unknown>) =>
+    toolsOf(s => registerGetLibrary(s, new LibraryLoader([radarr()], undefined))).get_library!.handler(
+        { detail: 'standard', limit: 50, ...args },
+        {}
+    );
+
+const callDiscover = (args: Record<string, unknown>) =>
+    toolsOf(s => registerDiscoverMedia(s, undefined)).discover_media!.handler(
+        { detail: 'standard', limit: 10, ...args },
+        {}
+    );
+
+describe('discover_media speaks the vocabulary it answers in', () => {
+    it('accepts `kind`, which is what the returned items carry', async () => {
+        await expect(callDiscover({ kind: 'series' })).resolves.toBeDefined();
+    });
+
+    /** Never removed: dropping a spelling is the one change that breaks a saved
+     *  prompt silently, which is what freezing the surface exists to stop. */
+    it('still accepts the older media_type spelling', async () => {
+        await expect(callDiscover({ media_type: 'tv' })).resolves.toBeDefined();
+    });
+
+    it('accepts both when they agree', async () => {
+        await expect(callDiscover({ kind: 'series', media_type: 'tv' })).resolves.toBeDefined();
+    });
+
+    /** Refused rather than resolved: preferring one silently would make the
+     *  answer depend on a precedence rule nobody wrote down. */
+    it('refuses a request that contradicts itself', async () => {
+        await expect(callDiscover({ kind: 'movie', media_type: 'tv' })).rejects.toThrow(/contradict/i);
+    });
+});
+
+describe('get_library names a Jellyfin user the way every other tool does', () => {
+    it('accepts `user`, as get_playback and get_requests already did', async () => {
+        await expect(callLibrary({ user: 'Someone', watched: true })).resolves.toBeDefined();
+    });
+
+    it('still accepts the older watched_by spelling', async () => {
+        await expect(callLibrary({ watched_by: 'Someone', watched: true })).resolves.toBeDefined();
+    });
+
+    it('refuses a request naming two different users', async () => {
+        await expect(callLibrary({ user: 'Someone', watched_by: 'Someone Else' })).rejects.toThrow(/contradict/i);
+    });
+});
+
+describe('what 1.0 documents', () => {
+    /** An undocumented alias that is documented is not undocumented. */
+    it('describes only the new spellings', () => {
+        const discover = toolsOf(s => registerDiscoverMedia(s, undefined)).discover_media as unknown as {
+            inputSchema: { shape: Record<string, { description?: string }> };
+        };
+        expect(discover.inputSchema.shape.kind?.description).toBeDefined();
+        expect(discover.inputSchema.shape.media_type?.description).toBeUndefined();
+    });
+});

--- a/test/triggerScan.test.ts
+++ b/test/triggerScan.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it, vi } from 'vitest';
+import * as z from 'zod/v4';
+import type { AnyServiceConfig, KeyedServiceConfig, MultiUserServiceConfig, ServiceId } from '../src/config/schema.ts';
+import { WriteAudit } from '../src/core/audit.ts';
+import { ConfirmTokens } from '../src/core/confirm.ts';
+import { permissionSourceFrom } from '../src/core/permissions.ts';
+import { JellyfinAdapter } from '../src/services/jellyfin.ts';
+import { ProwlarrAdapter } from '../src/services/prowlarr.ts';
+import { RadarrAdapter } from '../src/services/radarr.ts';
+import type { ServiceAdapter } from '../src/services/types.ts';
+import type { LibraryLoader } from '../src/tools/library.ts';
+import { registerTriggerScan } from '../src/tools/triggerScan.ts';
+import type { WriteToolResult } from '../src/tools/write.ts';
+import { instancesOf } from './helpers/instances.ts';
+import { jsonResponse } from './helpers/serve.ts';
+
+/**
+ * The write `diagnose` was missing. Until 1.0 it could report that a library
+ * had not been scanned and nothing here could start one, so its best answer
+ * ended "now go and do it yourself".
+ */
+
+const keyed = (port: number): KeyedServiceConfig => ({
+    url: `http://192.0.2.10:${port}`,
+    api_key: 'k',
+    timeout_ms: 10_000,
+    permissions: { safe_write: false, destructive: false }
+});
+
+const multiUser = (port: number): MultiUserServiceConfig => ({ ...keyed(port), allow_other_users: false });
+
+const permissive = (safe_write: boolean, destructive = false): AnyServiceConfig =>
+    ({ ...keyed(7878), permissions: { safe_write, destructive } }) as AnyServiceConfig;
+
+function recordingFetch(routes: Record<string, unknown>) {
+    const sent: { url: string; method: string }[] = [];
+    const impl = (async (input: string | URL | Request, init?: RequestInit) => {
+        const url = new URL(input instanceof Request ? input.url : String(input));
+        sent.push({ url: url.pathname, method: init?.method ?? 'GET' });
+        if (url.pathname in routes) return jsonResponse(routes[url.pathname]);
+        return jsonResponse({ message: 'not found' }, 404);
+    }) as unknown as typeof fetch;
+
+    return { impl, sent };
+}
+
+/** Jellyfin's ids are per-install GUIDs, so the task is found by `Key`. */
+const TASKS = [
+    { Id: 'guid-1', Key: 'SomethingElse', Name: 'Other', State: 'Idle' },
+    { Id: 'guid-scan', Key: 'RefreshLibrary', Name: 'Mediabibliotheek scannen', State: 'Idle' }
+];
+
+describe('JellyfinAdapter.startLibraryScan', () => {
+    it('finds the task by key, not by its localised name', async () => {
+        const { impl, sent } = recordingFetch({
+            '/ScheduledTasks': TASKS,
+            '/ScheduledTasks/Running/guid-scan': {}
+        });
+
+        await new JellyfinAdapter(multiUser(8096), impl).startLibraryScan();
+
+        const post = sent.find(s => s.method === 'POST');
+        expect(post?.url).toBe('/ScheduledTasks/Running/guid-scan');
+    });
+
+    /** The name is localised — a Dutch install returns "Mediabibliotheek
+     *  scannen" — so matching on it would work only in English. */
+    it('does not post when no task carries the key', async () => {
+        const { impl, sent } = recordingFetch({ '/ScheduledTasks': [TASKS[0]] });
+
+        await expect(new JellyfinAdapter(multiUser(8096), impl).startLibraryScan()).rejects.toThrow(/scan task/i);
+        expect(sent.filter(s => s.method === 'POST')).toHaveLength(0);
+    });
+});
+
+describe('RadarrAdapter.startLibraryScan', () => {
+    it('queues the same command getScanState reads the last run of', async () => {
+        const { impl, sent } = recordingFetch({ '/api/v3/command': { id: 12, name: 'RefreshMovie' } });
+        const handle = await new RadarrAdapter(keyed(7878), impl).startLibraryScan();
+
+        expect(sent.find(s => s.method === 'POST')?.url).toBe('/api/v3/command');
+        expect(handle).toMatchObject({ service: 'radarr', commandId: 12, name: 'RefreshMovie' });
+    });
+});
+
+// --- the tool ------------------------------------------------------------
+
+type Call = (args: Record<string, unknown>) => Promise<{
+    content: { type: 'text'; text: string }[];
+    structuredContent: WriteToolResult;
+}>;
+
+function harness(opts: { permissions?: Partial<Record<ServiceId, AnyServiceConfig>>; adapters?: ServiceAdapter[] } = {}) {
+    const jellyfin = recordingFetch({
+        '/ScheduledTasks': TASKS,
+        '/ScheduledTasks/Running/guid-scan': {}
+    });
+    const prowlarr = recordingFetch({});
+
+    const adapters = opts.adapters ?? [
+        new JellyfinAdapter(multiUser(8096), jellyfin.impl),
+        new ProwlarrAdapter(keyed(9696), prowlarr.impl)
+    ];
+
+    let call: Call = () => Promise.reject(new Error('not registered'));
+    const server = {
+        registerTool(_name: string, config: { inputSchema: z.ZodObject }, handler: Call) {
+            call = args => handler(config.inputSchema.parse(args) as Record<string, unknown>);
+        }
+    };
+
+    registerTriggerScan(
+        server as never,
+        {
+            permissions: permissionSourceFrom(
+                instancesOf(opts.permissions ?? { jellyfin: permissive(true), prowlarr: permissive(true) })
+            ),
+            confirm: new ConfirmTokens(),
+            audit: WriteAudit.ephemeral(),
+            library: { invalidate: vi.fn() } as unknown as LibraryLoader
+        },
+        adapters
+    );
+
+    return { call: (args: Record<string, unknown>) => call(args), jellyfin };
+}
+
+describe('trigger_scan', () => {
+    it('previews without scanning, and hands back a token', async () => {
+        const h = harness();
+        const { structuredContent } = await h.call({ service: 'jellyfin' });
+
+        expect(structuredContent.applied).toBe(false);
+        expect(structuredContent.confirm_token).toBeDefined();
+        expect(h.jellyfin.sent.filter(s => s.method === 'POST')).toHaveLength(0);
+    });
+
+    /**
+     * `dry_run: true` is a different question from an unconfirmed call: it is
+     * "tell me what this would do", not "let me do it". So it issues no token,
+     * and a caller who only wanted to look cannot accidentally hold one.
+     */
+    it('issues no token for an explicit dry run', async () => {
+        const { structuredContent } = await harness().call({ service: 'jellyfin', dry_run: true });
+
+        expect(structuredContent.dry_run).toBe(true);
+        expect(structuredContent.confirm_token).toBeUndefined();
+    });
+
+    it('says in the preview that it runs in the background', async () => {
+        const { structuredContent } = await harness().call({ service: 'jellyfin', dry_run: true });
+        expect(structuredContent.effects?.join(' ')).toMatch(/background|minutes/i);
+    });
+
+    it('scans once confirmed', async () => {
+        const h = harness();
+        const preview = await h.call({ service: 'jellyfin' });
+
+        await h.call({ service: 'jellyfin', confirm: preview.structuredContent.confirm_token });
+        expect(h.jellyfin.sent.filter(s => s.method === 'POST')).toHaveLength(1);
+    });
+
+    /**
+     * Safe, not destructive: a scan reads the filesystem and updates a
+     * database. Nothing is deleted and nothing is grabbed, so running one you
+     * did not need costs time rather than data.
+     */
+    it('needs safe_write, and nothing more', async () => {
+        const denied = await harness({ permissions: { jellyfin: permissive(false) } }).call({
+            service: 'jellyfin',
+            dry_run: true
+        });
+        expect(denied.structuredContent.applied).toBe(false);
+
+        const allowed = await harness({ permissions: { jellyfin: permissive(true, false) } }).call({
+            service: 'jellyfin'
+        });
+        expect(allowed.structuredContent.confirm_token).toBeDefined();
+    });
+
+    /**
+     * Refused rather than accepted as a no-op. An indexer has no library, and
+     * reporting success for something that could never happen is how a model
+     * concludes the scan is done and stops looking.
+     */
+    it('refuses a service with no library to scan', async () => {
+        await expect(harness().call({ service: 'prowlarr', dry_run: true })).rejects.toThrow(/no library/i);
+    });
+});


### PR DESCRIPTION
The audit phase. Spec and plan in `docs/superpowers/`.

**Carries `Release-As: 1.0.0`** on its final commit, per `RELEASING.md`.

## What the audit found

Less than expected, which is the good outcome. Verified rather than assumed:

- **Authentication is sound.** `timingSafeEqual` for the bearer token, sessions and confirmation tokens; `tokenMatches` deliberately burns an equivalent comparison on a length mismatch so a wrong-length token isn't distinguishable from a wrong-bytes one.
- **Session cookie**: `HttpOnly` + `SameSite=Strict`, with `Secure` *reasoned* absent rather than forgotten — this is served over plain http on a LAN by design, and a Secure cookie would never be stored.
- **Secret redaction**, uniform response shapes, all-snake_case parameters, **no TODO/FIXME/XXX anywhere**, negligible dead code.

Four things were real, and are fixed.

## 1. Two inconsistencies, frozen forever if left

`discover_media` accepted `media_type: 'tv'` and returned items carrying `kind: 'series'` — the mismatch was **inside a single response**, since Seerr's `#toHit` takes `'movie' | 'series'` like everything else. And `get_library` called a Jellyfin user `watched_by` where `get_playback` and `get_requests` call it `user`, all three backed by the same schema.

Both now take the documented spelling. **Neither old spelling is removed** — that's the one change that breaks a saved prompt silently, which is exactly what freezing the surface exists to prevent. They keep working forever, undocumented, and a test asserts they carry no description. Given a name and its alias with *different* values, the call is refused rather than resolved: preferring one silently would make the answer depend on a precedence rule nobody wrote down.

## 2. `trigger_scan`

`diagnose` names a stale library scan as the usual reason something downloaded still won't play — and nothing could start one, so its best answer ended "now go to Jellyfin yourself."

Safe tier: a scan reads the filesystem and updates a database; nothing is deleted or grabbed. **Jellyfin's first write path** — that adapter had only `#http.get`. The task is found by `Key`, not hard-coded, because Jellyfin's ids are per-install GUIDs and its task names are localised (a Dutch install returns "Mediabibliotheek scannen"). A service with no library is refused rather than accepted as a no-op.

## 3. 106 references to a document nobody can read

Comments cited a design spec — `§12`, `§8`, up to `§21.2` — plus phase numbers and an internal review. None of it is in the repo or ever will be. At 1.0 the repo is the only context a reader has, and a pointer to something they can't see is worse than no pointer.

Gone from 51 files, 149 lines, **comments only, no code**. Worth noting honestly: my script was wrong three times — it collapsed code indentation, ate legitimate `foo()` references, then capitalised every wrapped line. The tests stayed green through all three; I caught them by reading diffs.

## 4. Docs

README loses the roadmap and status block, gains **what 1.0 promises** and a **contributing section**. `CONTRIBUTING.md`'s versioning table now describes the scheme actually in effect.

The contributing note states the constraint that sets the bar: the maintainer doesn't run every service this could support, so an adapter for Lidarr or qBittorrent can't be exercised in review, only read — which makes the contributor's testing the only testing it gets.

## Partially done, deliberately

**Comment compression.** Density is 26% before and after. I compressed the densest blocks (`library.ts` 51%→40%, plus `resolver.ts`, `confirm.ts`, `pages.ts`), but that's ~60 lines of 3577 — reaching ~13% means rewriting essentially every comment across 40+ files, and a script is provably the wrong tool. It's documentation only, so it continues as 1.0.1 rather than gating the release. The reference strip in #3 did more for readability anyway.

## Verification

- `npm test` — **1194 passing**, 61 files; typecheck and lint clean at all six commits
- Tool count **20**, against CONTRIBUTING's ~40 ceiling, asserted against `TOOL_NAMES` rather than a literal

## After merging

Against a live stack: **`trigger_scan` on each of the three services**, since it's the phase's only new write and the part fixtures can't really verify. And a saved prompt using `media_type`, confirming it still works untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
