### PR TITLE
chore: cut 1.0.0 — the squash ate the footer

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,33 +18,46 @@ bleeding edge. Nothing else. The release workflow fails the job when a release
 computes no version tag — a release that publishes only `latest` is a silent
 policy violation, and it has happened once.
 
-## Cutting a phase whose verification runs after the merge
+## Forcing a version, and the three ways it has gone wrong
 
-`CONTRIBUTING.md` says the minor is cut with a `Release-As: X.Y.0` footer on the
-last commit of the phase. That assumes the phase is fully verified before it
-merges. Twice now it has not been — 0.8 and 0.9 both ended with a manual gate
-that needs a live stack, and neither could be run before the PR went in.
+`CONTRIBUTING.md` reserves minors for roadmap phases. **The `Release-As` footer
+goes on the phase's last commit, in the phase PR itself** — not in a follow-up,
+and not conditional on anything.
 
-Leaving the footer off is the right call there: it is honest about what was
-verified. But `bump-patch-for-minor-pre-major` then does exactly its job and
-proposes a **patch**, so the phase would ship as `0.8.4` under a number the
-README roadmap has already promised to something else.
+The temptation is to withhold it when a phase ends with verification that needs
+a live stack. That reasoning is wrong here: phase features are off by default or
+additive, pre-1.0 patches are cheap, and the README has *already published* what
+the number means — so shipping a phase under a patch number leaves the tags and
+the docs permanently disagreeing. **Cut the version, then run the gate.**
+Anything it finds is a patch.
 
-So the second step is deliberate, not a mistake to avoid:
+It has still gone wrong three times, in three different ways:
 
+| What happened | Result |
+| --- | --- |
+| Footer withheld pending verification (0.8) | Proposed `0.7.4` |
+| Same again (0.9) | Proposed `0.8.1` |
+| Footer present four times, **eaten by the squash** (1.0) | Proposed `0.9.1` |
+
+The third is the subtle one. **Squashing concatenates every commit body into one
+message**, so a footer that was the last line of the last commit ends up in the
+*middle* of the squashed body — and release-please only honours `Release-As:` as
+a trailing footer. Having it four times over made no difference.
+
+So when a version is being forced, either merge **without** squashing, or set
+the squash message yourself:
+
+```bash
+gh pr merge <n> --squash --body "$(printf 'summary line
+
+Release-As: 1.0.0')"
 ```
-merge the phase PR        →  release-please proposes X.Y.(Z+1)
-merge a follow-up commit  →  Release-As: X.(Y+1).0
-                          →  the same release PR re-cuts itself
-```
 
-The follow-up may be empty (`git commit --allow-empty`) when its only job is the
-footer, though a small docs change is better — an empty commit in the log gives
-a future reader nothing to work with.
+If it is missed anyway, the repair is a follow-up commit carrying the footer,
+which makes the open release PR re-cut itself.
 
-**Check the version on the release PR before merging it**, every time. The title
-says which it is, and it is far cheaper to notice there than after the tag
-exists.
+**Read the version on the release PR title before merging it**, every time. It
+is far cheaper to notice there than after the tag exists.
 
 ## If the release PR is BLOCKED with nothing failing
 


### PR DESCRIPTION
#80 merged carrying `Release-As: 1.0.0` in **four** of its commits, and release-please proposed **0.9.1** anyway.

## Why

**Squashing concatenates every commit body into one message.** A footer that was the last line of the last commit ends up in the *middle* of the squashed body — and release-please only honours `Release-As:` as a trailing footer. Having it four times over made no difference, because none of them were last.

This is the third distinct way forcing a version has gone wrong here:

| What happened | Result |
| --- | --- |
| Footer withheld pending verification (0.8) | Proposed `0.7.4` |
| Same again (0.9) | Proposed `0.8.1` |
| Footer present four times, eaten by the squash (1.0) | Proposed `0.9.1` |

`RELEASING.md` now tables all three, and says to merge **without** squashing when a version is being forced — or to set the squash body explicitly:

```bash
gh pr merge <n> --squash --body "$(printf 'summary\n\nRelease-As: 1.0.0')"
```

## Also restores a correction that never landed

PR #79 merged carrying **only its first commit**. The second one — which replaced "the follow-up PR is the routine" with "the footer goes on the phase commit; a follow-up is the repair" — never reached `main`, so `RELEASING.md` was still recommending the thing we'd decided against. That section is now rewritten with both corrections in it.

**Merge this one without squashing**, or the footer goes the same way again. After it lands, PR #81 re-cuts itself as `chore(main): release 1.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
