### PR TITLE
fix: the IMDb ingest ran the process out of memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,10 +366,31 @@ metadata:
     enabled: true
 ```
 
-No account, no API key, nothing sent anywhere. Your container downloads three
-of IMDb's published files each day and keeps them in a local SQLite database
-beside the audit log. Films and series both get a rating, and so do things you
-do **not** own — `lookup_media` can rate something before you decide to add it.
+No account, no API key, nothing sent anywhere. Your container downloads two of
+IMDb's published files each day and keeps them in a local SQLite database beside
+the audit log.
+
+**It costs real disk.** Measured against the live dumps on 2026-08-08:
+
+| | |
+| --- | --- |
+| Download, per day | **223 MB** |
+| On disk | **~1.3 GB** |
+| First ingest | ~3 minutes |
+| Titles / rated | 12.7M / 1.7M |
+
+Re-measure with `node --experimental-strip-types scripts/measure-imdb.ts` — the
+dumps grow, and a figure in a README is only as good as the day it was taken.
+
+**Whether you need it.** Radarr already reports IMDb ratings for films, so if
+you only care about films, probably not. What nothing else here can give you is
+an IMDb rating for a **series** — Sonarr reports a single unlabelled number —
+or a rating for something you do **not own yet**, which is what `lookup_media`
+answers. Those are the two gaps it fills.
+
+It is not a stand-in for Seerr, either. Seerr filters discovery by TMDB rating
+but never returns a rating value, so the two do different jobs; discovery falls
+back to this dataset only when Seerr is not configured at all.
 
 ```
 get_library({ kind: "series", watched: false, rating_source: "imdb",

--- a/README.md
+++ b/README.md
@@ -375,22 +375,32 @@ the audit log.
 | | |
 | --- | --- |
 | Download, per day | **223 MB** |
-| On disk | **~1.3 GB** |
+| On disk | **~125 MB** |
 | First ingest | ~3 minutes |
-| Titles / rated | 12.7M / 1.7M |
+| Titles stored / rated | 546K / 1.7M |
 
-Re-measure with `node --experimental-strip-types scripts/measure-imdb.ts` — the
+Only rated titles of a kind something can actually query are stored — the other
+12 million rows are episodes, shorts and video games no query can reach.
+Re-measure with `node --experimental-strip-types scripts/measure-imdb.ts`; the
 dumps grow, and a figure in a README is only as good as the day it was taken.
 
-**Whether you need it.** Radarr already reports IMDb ratings for films, so if
-you only care about films, probably not. What nothing else here can give you is
-an IMDb rating for a **series** — Sonarr reports a single unlabelled number —
-or a rating for something you do **not own yet**, which is what `lookup_media`
-answers. Those are the two gaps it fills.
+### Do you need it?
 
-It is not a stand-in for Seerr, either. Seerr filters discovery by TMDB rating
-but never returns a rating value, so the two do different jobs; discovery falls
-back to this dataset only when Seerr is not configured at all.
+Probably less than it first appears. Where ratings already come from:
+
+| | Films | Series |
+| --- | --- | --- |
+| **In your library** | Radarr: IMDb, TMDB, Rotten Tomatoes, Metacritic | Sonarr: one unlabelled number |
+| **Not in your library** | Seerr: TMDB on every hit, plus Rotten Tomatoes and IMDb on `get_media_details` | Seerr: TMDB, plus Rotten Tomatoes |
+
+So if you run Seerr and mostly care about films, **you may not need this at
+all**. What nothing else can give you is an **IMDb rating for a series** —
+Sonarr reports a single unlabelled number, and Seerr's `/tv/{id}/ratings` has no
+IMDb half — or ratings of any kind if you do not run Seerr.
+
+It is not a Seerr fallback, either. Seerr filters discovery by TMDB rating but
+that is a different job; discovery falls back to this dataset only when Seerr is
+not configured at all.
 
 ```
 get_library({ kind: "series", watched: false, rating_source: "imdb",

--- a/scripts/measure-imdb.ts
+++ b/scripts/measure-imdb.ts
@@ -1,0 +1,74 @@
+/**
+ * One real IMDb ingest, measured.
+ *
+ * The numbers in the README come from here. Run it again when they need
+ * refreshing — IMDb's dumps grow, and a disk figure quoted in a README is only
+ * as good as the day it was taken.
+ *
+ *   node --experimental-strip-types scripts/measure-imdb.ts
+ *
+ * It downloads a few hundred megabytes and writes to a temp directory, which it
+ * removes afterwards. Nothing in the repo or the config volume is touched.
+ */
+import Database from 'better-sqlite3';
+import { mkdtempSync, readdirSync, rmSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { IMDB_BASE_URL, ingestOnce } from '../src/metadata/refresh.ts';
+import { IMDB_FILENAME, ImdbDataset } from '../src/metadata/imdbDataset.ts';
+
+const FILES = ['title.basics.tsv.gz', 'title.ratings.tsv.gz'];
+
+const mb = (bytes: number): string => `${(bytes / 1048576).toFixed(1)} MB`;
+
+/** Every file in the directory: WAL and shm count until a checkpoint. */
+const onDisk = (dir: string): number =>
+    readdirSync(dir).reduce((total, f) => total + statSync(join(dir, f)).size, 0);
+
+async function compressedSize(file: string): Promise<number> {
+    const res = await fetch(`${IMDB_BASE_URL}/${file}`, { method: 'HEAD' });
+    return Number(res.headers.get('content-length') ?? 0);
+}
+
+const dir = mkdtempSync(join(tmpdir(), 'imdb-measure-'));
+
+try {
+    let download = 0;
+    for (const file of FILES) {
+        const size = await compressedSize(file);
+        download += size;
+        console.log(`${file.padEnd(24)} ${mb(size).padStart(9)} compressed`);
+    }
+    console.log(`${'download per refresh'.padEnd(24)} ${mb(download).padStart(9)}\n`);
+
+    const started = Date.now();
+    const dataset = ImdbDataset.open(dir);
+    console.log('ingesting…');
+    await ingestOnce(dataset);
+    const seconds = Math.round((Date.now() - started) / 1000);
+
+    const status = dataset.status();
+    dataset.close();
+
+    // Checkpointed and vacuumed, so this is what the file settles at rather
+    // than what it peaked at mid-write.
+    const db = new Database(join(dir, IMDB_FILENAME));
+    db.pragma('wal_checkpoint(TRUNCATE)');
+    db.exec('VACUUM');
+    db.close();
+
+    console.log('\n--- measured ---');
+    console.log('titles              ', status.titles.toLocaleString('en'));
+    console.log('rated               ', status.ratings.toLocaleString('en'));
+    console.log('ingest wall clock   ', `${seconds}s`);
+    console.log('on disk             ', mb(onDisk(dir)));
+} finally {
+    // Best effort: Windows can still hold the SQLite file briefly after close,
+    // and failing to tidy a temp directory must not lose the measurement that
+    // was the whole point of the run.
+    try {
+        rmSync(dir, { recursive: true, force: true });
+    } catch {
+        console.log('(could not remove', dir, '— delete it by hand)');
+    }
+}

--- a/src/metadata/imdbDataset.ts
+++ b/src/metadata/imdbDataset.ts
@@ -35,6 +35,20 @@ const KIND_TO_IMDB: Record<'movie' | 'series', readonly string[]> = {
 };
 
 /**
+ * The only title types any query can reach, so the only ones worth storing.
+ *
+ * IMDb's 12.7M rows are mostly `tvEpisode`, plus shorts, video games and adult
+ * titles — none of which `discover` can return and none of which carry a rating
+ * anyone looks up here. Filtering at ingest rather than at query time is the
+ * difference between a 1.3 GB database and a small one.
+ *
+ * Derived from `KIND_TO_IMDB` rather than written out again: two lists would
+ * drift, and the failure would be silent — a kind you can ask for that was
+ * never stored just returns nothing.
+ */
+const STORED_KINDS: ReadonlySet<string> = new Set(Object.values(KIND_TO_IMDB).flat());
+
+/**
  * SQLite's compiled-in default variable limit, minus room to spare.
  *
  * A library larger than this cannot go into one `IN (...)`, and a 900-film
@@ -249,10 +263,19 @@ export class ImdbDataset {
         this.#db.transaction(() => {
             this.#db.exec('DELETE FROM title; DELETE FROM rating;');
 
+            for (const r of rows.ratings) insertRating.run(r.tconst, r.average, r.votes);
+
             for (const t of rows.titles) {
+                if (!STORED_KINDS.has(t.kind)) continue;
                 insertTitle.run(t.tconst, t.kind, t.title, t.year ?? null, t.runtime ?? null, t.genres ?? null);
             }
-            for (const r of rows.ratings) insertRating.run(r.tconst, r.average, r.votes);
+
+            // An unrated title is one nothing here can do anything with: every
+            // rating lookup misses it, and `discover` only surfaces it when no
+            // minimum was asked for. Deleted in SQL against the index rather
+            // than checked per row, which would mean holding 1.7M ids in heap —
+            // the mistake that crashed the first real ingest.
+            this.#db.exec('DELETE FROM title WHERE tconst NOT IN (SELECT tconst FROM rating)');
 
             setMeta.run('ingested_at', new Date().toISOString());
         })();

--- a/src/metadata/imdbDataset.ts
+++ b/src/metadata/imdbDataset.ts
@@ -87,17 +87,10 @@ CREATE TABLE IF NOT EXISTS rating (
     average REAL    NOT NULL,
     votes   INTEGER NOT NULL
 );
-CREATE TABLE IF NOT EXISTS episode (
-    tconst  TEXT PRIMARY KEY,
-    parent  TEXT    NOT NULL,
-    season  INTEGER,
-    episode INTEGER
-);
 CREATE TABLE IF NOT EXISTS meta (
     key   TEXT PRIMARY KEY,
     value TEXT NOT NULL
 );
-CREATE INDEX IF NOT EXISTS episode_parent ON episode(parent);
 CREATE INDEX IF NOT EXISTS title_kind ON title(kind);
 `;
 
@@ -111,6 +104,10 @@ export class ImdbDataset {
         // rebuild.
         this.#db.pragma('journal_mode = WAL');
         this.#db.exec(SCHEMA);
+        // Written through 1.0 and never read by a single query — 52 MB a day and
+        // millions of rows for a table nothing consulted. Dropped on open so an
+        // existing database reclaims the space rather than carrying it forever.
+        this.#db.exec('DROP INDEX IF EXISTS episode_parent; DROP TABLE IF EXISTS episode;');
     }
 
     static open(dir: string): ImdbDataset {
@@ -240,32 +237,22 @@ export class ImdbDataset {
      * transaction: `title.basics` is on the order of 10⁷ rows, and this runs
      * on a NAS.
      */
-    replaceAll(rows: {
-        titles: Iterable<RawTitle>;
-        ratings: Iterable<RawRating>;
-        episodes: Iterable<RawEpisode>;
-    }): void {
+    replaceAll(rows: { titles: Iterable<RawTitle>; ratings: Iterable<RawRating> }): void {
         const insertTitle = this.#db.prepare(
             'INSERT OR REPLACE INTO title (tconst, kind, title, year, runtime, genres) VALUES (?, ?, ?, ?, ?, ?)'
         );
         const insertRating = this.#db.prepare(
             'INSERT OR REPLACE INTO rating (tconst, average, votes) VALUES (?, ?, ?)'
         );
-        const insertEpisode = this.#db.prepare(
-            'INSERT OR REPLACE INTO episode (tconst, parent, season, episode) VALUES (?, ?, ?, ?)'
-        );
         const setMeta = this.#db.prepare('INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)');
 
         this.#db.transaction(() => {
-            this.#db.exec('DELETE FROM title; DELETE FROM rating; DELETE FROM episode;');
+            this.#db.exec('DELETE FROM title; DELETE FROM rating;');
 
             for (const t of rows.titles) {
                 insertTitle.run(t.tconst, t.kind, t.title, t.year ?? null, t.runtime ?? null, t.genres ?? null);
             }
             for (const r of rows.ratings) insertRating.run(r.tconst, r.average, r.votes);
-            for (const e of rows.episodes) {
-                insertEpisode.run(e.tconst, e.parent, e.season ?? null, e.episode ?? null);
-            }
 
             setMeta.run('ingested_at', new Date().toISOString());
         })();

--- a/src/metadata/refresh.ts
+++ b/src/metadata/refresh.ts
@@ -1,85 +1,133 @@
-import { createInterface } from 'node:readline';
+import { closeSync, createWriteStream, mkdtempSync, openSync, readSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
 import { createGunzip } from 'node:zlib';
 import { logger } from '../core/logger.ts';
 import type { ImdbDataset } from './imdbDataset.ts';
-import { parseEpisodes, parseRatings, parseTitles } from './ingest.ts';
+import { parseRatings, parseTitles } from './ingest.ts';
 
 /**
- * Fetching the dumps, and the daily schedule (0.8 spec ).
+ * Fetching the dumps, and the daily schedule.
  *
- * The only file in `src/metadata/` that touches the network, which is what
- * lets the store and the parser be tested without one.
+ * The only file in `src/metadata/` that touches the network, which is what lets
+ * the store and the parser be tested without one.
  */
 
 export const IMDB_BASE_URL = 'https://datasets.imdbws.com';
 
-/** IMDb publishes daily. Spec explains why this is not configurable: there
- *  is no second sensible value, and a knob with one answer invites a wrong one. */
+/** IMDb publishes daily, so there is no second sensible interval to offer. */
 export const REFRESH_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
-/** Download one dump and yield its lines, decompressed. */
-async function* download(baseUrl: string, file: string): AsyncGenerator<string> {
+/**
+ * Download one dump, decompressed, **to a file** — never into memory.
+ *
+ * `title.basics` is ~12M lines. Holding them cost about 4 GB of heap and killed
+ * the process outright the first time this ran against the real dumps: the
+ * generators in `ingest.ts` are lazy precisely so peak memory is one row, and
+ * buffering the lines first threw that away.
+ *
+ * Staging to disk is also what makes the synchronous transaction below
+ * possible. better-sqlite3 transactions cannot `await`, so the network has to
+ * be finished with before the write begins.
+ */
+async function downloadTo(baseUrl: string, file: string, path: string): Promise<void> {
     const res = await fetch(`${baseUrl}/${file}`);
     if (!res.ok || res.body === null) {
-        // Names the file: "HTTP 404" alone would not say which of the three,
-        // and they fail independently.
+        // Names the file: "HTTP 404" alone would not say which of them, and they
+        // fail independently.
         throw new Error(`could not fetch ${file}: HTTP ${res.status}`);
     }
 
-    // Streamed rather than buffered — title.basics is on the order of 10⁷ rows
-    // and this runs on a NAS.
     const body = Readable.fromWeb(res.body as Parameters<typeof Readable.fromWeb>[0]);
-    const lines = createInterface({ input: body.pipe(createGunzip()), crlfDelay: Infinity });
-
-    for await (const line of lines) yield line;
+    await pipeline(body, createGunzip(), createWriteStream(path));
 }
 
 /**
- * Fetch all three dumps, **then** replace.
+ * A file's lines, synchronously and a megabyte at a time.
  *
- * Buffering the parsed rows costs memory and is still the right trade: the
- * failure it prevents is a download dying between file one and file three,
- * leaving today's titles standing against yesterday's ratings. `replaceAll`
- * is one transaction, so nothing is visible until all three arrived intact.
+ * Synchronous because it is consumed inside better-sqlite3's transaction, which
+ * cannot await. Chunked because the whole point is not to materialise a
+ * gigabyte of TSV to read it.
+ */
+export function* linesOf(path: string): Generator<string> {
+    const fd = openSync(path, 'r');
+    const buffer = Buffer.alloc(1 << 20);
+    let carry = '';
+
+    try {
+        for (;;) {
+            const read = readSync(fd, buffer, 0, buffer.length, null);
+            if (read === 0) break;
+
+            const chunk = carry + buffer.toString('utf8', 0, read);
+            const lines = chunk.split('\n');
+            // The final piece may be half a line, and belongs to the next chunk.
+            carry = lines.pop() ?? '';
+
+            for (const line of lines) yield line;
+        }
+
+        if (carry !== '') yield carry;
+    } finally {
+        closeSync(fd);
+    }
+}
+
+/**
+ * Fetch both dumps, **then** replace.
+ *
+ * Both land before anything is written, so a download dying between them cannot
+ * leave today's titles standing against yesterday's ratings. `replaceAll` is one
+ * transaction, so nothing is visible until both arrived.
+ *
+ * `title.episode` is deliberately not fetched. It was ingested through 1.0 and
+ * never read by a single query — 52 MB a day and millions of rows for a table
+ * nothing consulted.
  */
 export async function ingestOnce(dataset: ImdbDataset, opts: { baseUrl?: string } = {}): Promise<void> {
     const baseUrl = opts.baseUrl ?? IMDB_BASE_URL;
     const started = Date.now();
+    const staging = mkdtempSync(join(tmpdir(), 'arr-mcp-imdb-'));
 
-    const collect = async <T>(file: string, parse: (lines: Iterable<string>) => Generator<T>): Promise<T[]> => {
-        const raw: string[] = [];
-        for await (const line of download(baseUrl, file)) raw.push(line);
-        return [...parse(raw)];
-    };
+    try {
+        const titlesFile = join(staging, 'title.basics.tsv');
+        const ratingsFile = join(staging, 'title.ratings.tsv');
 
-    const titles = await collect('title.basics.tsv.gz', parseTitles);
-    const ratings = await collect('title.ratings.tsv.gz', parseRatings);
-    const episodes = await collect('title.episode.tsv.gz', parseEpisodes);
+        await downloadTo(baseUrl, 'title.basics.tsv.gz', titlesFile);
+        await downloadTo(baseUrl, 'title.ratings.tsv.gz', ratingsFile);
 
-    dataset.replaceAll({ titles, ratings, episodes });
+        // Read lazily from disk straight into the transaction, so the rows are
+        // never all in memory at once.
+        dataset.replaceAll({
+            titles: parseTitles(linesOf(titlesFile)),
+            ratings: parseRatings(linesOf(ratingsFile))
+        });
 
-    logger.info(
-        { titles: titles.length, ratings: ratings.length, episodes: episodes.length, ms: Date.now() - started },
-        'IMDb dataset ingested'
-    );
+        const status = dataset.status();
+        logger.info(
+            { titles: status.titles, ratings: status.ratings, ms: Date.now() - started },
+            'IMDb dataset ingested'
+        );
+    } finally {
+        rmSync(staging, { recursive: true, force: true });
+    }
 }
 
 /**
- * Start the daily refresh, and return a function that stops it.
+ * Start the daily refresh, returning a function that stops it.
  *
- * **Startup never awaits this.** A first run that takes twenty minutes is
- * twenty minutes of normal service, not twenty minutes of a container that
- * looks broken — every tool answers exactly as it did before until the first
- * ingest lands.
+ * **Startup never awaits this.** A first run of several minutes is several
+ * minutes of normal service, not a container that looks broken — every tool
+ * answers exactly as before until the first ingest lands.
  */
 export function startRefresh(dataset: ImdbDataset, opts: { baseUrl?: string } = {}): () => void {
     const run = (): void => {
         ingestOnce(dataset, opts).catch((err: unknown) => {
-            // A failed refresh keeps the previous dataset, so this is a
-            // degraded answer rather than an outage. It warns instead of
-            // becoming an unhandled rejection that would take the process
-            // down over a transient 503.
+            // A failed refresh keeps the previous dataset, so this is a degraded
+            // answer rather than an outage — it warns instead of becoming an
+            // unhandled rejection that would take the process down over a 503.
             logger.warn({ err }, 'IMDb dataset refresh failed; keeping the previous one');
         });
     };

--- a/src/services/seerr.ts
+++ b/src/services/seerr.ts
@@ -27,9 +27,21 @@ type RawSearchResult = {
     name?: string;
     releaseDate?: string;
     firstAirDate?: string;
+    /** TMDB's own score, 0–10. Seerr passes it straight through on both search
+     *  and discover, confirmed against the recorded fixtures. */
+    voteAverage?: number;
+    voteCount?: number;
 };
 
 type RawStatus = { version?: string; commitTag?: string };
+
+/** `/movie/{id}/ratingscombined` — Rotten Tomatoes *and* IMDb. `/tv/{id}/ratings`
+ *  is the RT half alone; there is no combined endpoint for series. */
+type RawCombinedRatings = {
+    rt?: { criticsScore?: number; audienceScore?: number };
+    imdb?: { criticsScore?: number };
+    criticsScore?: number;
+};
 
 /**
  * `/movie/{tmdbId}` and `/tv/{tmdbId}` in one shape. Upstream names the title
@@ -243,7 +255,54 @@ export class SeerrAdapter
             id: String(r.id),
             title: fenceText(r.title ?? r.name ?? '', { service: this.id, field: 'title' }),
             ...(year === undefined ? {} : { year }),
-            ids: { tmdb: r.id }
+            ids: { tmdb: r.id },
+            // Seerr is TMDB-backed and hands this over for free on every hit.
+            // Worth reading: without it, nothing rates something you do not
+            // own, and the alternative was a gigabyte of IMDb dump. A zero is
+            // TMDB's "nobody has voted", not a score of zero, so it is dropped
+            // rather than reported as the worst film ever made.
+            ...(typeof r.voteAverage === 'number' && r.voteAverage > 0
+                ? { ratings: { tmdb: r.voteAverage } }
+                : {})
+        };
+    }
+
+    /**
+     * Rotten Tomatoes, and for a film IMDb too — the one thing Seerr knows that
+     * nothing else here does for a title you do not own.
+     *
+     * **One HTTP call per title**, which is why it is only ever used for a
+     * single item. Calling it across a `lookup_media` page would be fifty
+     * requests for one tool call; those hits carry TMDB's `voteAverage` from
+     * the search payload instead, which is free.
+     *
+     * Series get Rotten Tomatoes only. `/tv/{id}/ratings` has no `imdb` half,
+     * and there is no `ratingscombined` for TV — so an IMDb rating for a series
+     * still comes from the IMDb dataset or from nowhere.
+     *
+     * Degrades to nothing on failure. A ratings lookup that fails must not take
+     * down the details call it was decorating.
+     */
+    async getRatings(tmdbId: number, kind: 'movie' | 'series'): Promise<Record<string, number>> {
+        const path = kind === 'movie' ? `/api/v1/movie/${tmdbId}/ratingscombined` : `/api/v1/tv/${tmdbId}/ratings`;
+
+        let raw: RawCombinedRatings;
+        try {
+            raw = await this.#http.get<RawCombinedRatings>(path);
+        } catch (err) {
+            logger.warn({ service: this.id, tmdbId, err }, 'seerr ratings lookup failed; continuing without them');
+            return {};
+        }
+
+        // `/tv` returns the RT shape unwrapped; `/movie` nests it under `rt`.
+        const rt = raw.rt?.criticsScore ?? raw.criticsScore;
+        const imdb = raw.imdb?.criticsScore;
+
+        return {
+            // A zero is "not scored", the same convention TMDB uses, so it is
+            // dropped rather than reported as the worst film ever made.
+            ...(typeof rt === 'number' && rt > 0 ? { rottenTomatoes: rt } : {}),
+            ...(typeof imdb === 'number' && imdb > 0 ? { imdb } : {})
         };
     }
 

--- a/src/tools/getMediaDetails.ts
+++ b/src/tools/getMediaDetails.ts
@@ -6,6 +6,7 @@ import { ServiceError } from '../core/errors.ts';
 import type { MergedItem } from '../core/resolver.ts';
 import { DetailSchema, LimitSchema, type DetailLevel } from '../core/shape.ts';
 import { enrichWithImdb } from '../metadata/enrich.ts';
+import { SeerrAdapter } from '../services/seerr.ts';
 import type { ImdbDataset } from '../metadata/imdbDataset.ts';
 import { hasMediaDetails, type MediaDetails, type ServiceAdapter } from '../services/types.ts';
 import type { LibraryLoader } from './library.ts';
@@ -34,7 +35,36 @@ export async function buildGetMediaDetails(
 
     // A single-item array through the same function the library uses, so one
     // title cannot get a different rating depending on which tool asked.
-    return enrichWithImdb([details], dataset)[0] as MediaDetails;
+    const rated = enrichWithImdb([details], dataset)[0] as MediaDetails;
+
+    return withSeerrRatings(adapters, rated);
+}
+
+/**
+ * Rotten Tomatoes, and IMDb for a film, from Seerr.
+ *
+ * Only here, and only for one item. It costs an HTTP call per title, so it has
+ * no business on a path that returns a page of them — `lookup_media` uses the
+ * `voteAverage` Seerr already puts in its search payload instead.
+ *
+ * Worth the call here because this is the "tell me everything about this one
+ * thing" tool, and Rotten Tomatoes is the one score nothing else in the stack
+ * can supply for a series. Never overwrites: the managing service is the
+ * authority on its own data, and Radarr already reports RT for films.
+ */
+async function withSeerrRatings(
+    adapters: readonly ServiceAdapter[],
+    details: MediaDetails
+): Promise<MediaDetails> {
+    const seerr = adapters.find((a): a is SeerrAdapter => a instanceof SeerrAdapter);
+    const tmdb = details.ids.tmdb;
+    if (seerr === undefined || tmdb === undefined) return details;
+
+    const kind = details.kind === 'series' ? 'series' : 'movie';
+    const extra = await seerr.getRatings(tmdb, kind);
+
+    const merged = { ...extra, ...details.ratings };
+    return Object.keys(merged).length === 0 ? details : { ...details, ratings: merged };
 }
 
 export type MediaDetailsQuery = {

--- a/src/web/configPage.ts
+++ b/src/web/configPage.ts
@@ -441,11 +441,21 @@ export function configPage(opts: {
                     opts.config.metadata?.imdb?.enabled ?? false
                 )}
                 <p class="note">
-                    Gives every film <em>and</em> series an IMDb rating — including series, which no service
-                    here can report one for. Costs a daily download and some disk on this machine; nothing is
-                    sent anywhere, and there is no account or key. Switching it on starts the first ingest in
-                    the background, which takes a while: everything keeps working meanwhile, and the dashboard
-                    says when it has finished.
+                    <strong>About 1.3 GB on disk, and a 223 MB download each day.</strong> The first ingest
+                    takes a few minutes; everything keeps working meanwhile and the dashboard says when it
+                    has finished. Nothing is sent anywhere, and there is no account or key.
+                </p>
+                <p class="note">
+                    <strong>What it is actually for.</strong> Radarr already reports IMDb ratings for films,
+                    so if you only care about films you may not need this. What no service here can give you
+                    is an IMDb rating for a <em>series</em> — Sonarr reports one unlabelled number — or a
+                    rating for anything you do not own yet, which is what <span class="mono">lookup_media</span>
+                    answers. Those are the two gaps it fills.
+                </p>
+                <p class="note">
+                    It is <em>not</em> a stand-in for Seerr. Seerr filters discovery by TMDB rating but never
+                    returns a rating value, so the two do different jobs — and discovery falls back to this
+                    dataset only when Seerr is not configured at all.
                 </p>
             </fieldset>
 

--- a/src/web/configPage.ts
+++ b/src/web/configPage.ts
@@ -441,21 +441,16 @@ export function configPage(opts: {
                     opts.config.metadata?.imdb?.enabled ?? false
                 )}
                 <p class="note">
-                    <strong>About 1.3 GB on disk, and a 223 MB download each day.</strong> The first ingest
+                    <strong>About 125 MB on disk, and a 223 MB download each day.</strong> The first ingest
                     takes a few minutes; everything keeps working meanwhile and the dashboard says when it
                     has finished. Nothing is sent anywhere, and there is no account or key.
                 </p>
                 <p class="note">
-                    <strong>What it is actually for.</strong> Radarr already reports IMDb ratings for films,
-                    so if you only care about films you may not need this. What no service here can give you
-                    is an IMDb rating for a <em>series</em> — Sonarr reports one unlabelled number — or a
-                    rating for anything you do not own yet, which is what <span class="mono">lookup_media</span>
-                    answers. Those are the two gaps it fills.
-                </p>
-                <p class="note">
-                    It is <em>not</em> a stand-in for Seerr. Seerr filters discovery by TMDB rating but never
-                    returns a rating value, so the two do different jobs — and discovery falls back to this
-                    dataset only when Seerr is not configured at all.
+                    <strong>You may not need it.</strong> Radarr already reports IMDb, Rotten Tomatoes and
+                    Metacritic for films in your library, and Seerr supplies ratings for things you do not
+                    own. What nothing else can give you is an <em>IMDb rating for a series</em> — Sonarr
+                    reports one unlabelled number, and Seerr has no IMDb score for TV. That, and ratings at
+                    all if you do not run Seerr, is what this is for.
                 </p>
             </fieldset>
 

--- a/src/web/pages.ts
+++ b/src/web/pages.ts
@@ -241,8 +241,9 @@ const imdbPanel = (status: DatasetStatus): SafeHtml => html`<h2>IMDb dataset</h2
                   ingest finishes — nothing is broken while this says so. It runs again daily.
               </p>`
             : html`<p class="note">
-                      Ratings for films <em>and</em> series, including the IMDb rating no service in your
-                      stack can report for a series. Refreshed daily; nothing here is sent anywhere.
+                      The IMDb rating no service in your stack can report for a series, and a rating for
+                      anything you do not own yet. Refreshed daily — about 223 MB down, roughly 1.3 GB on
+                      disk. Nothing here is sent anywhere.
                   </p>
                   <table>
                       <thead><tr><th>Last ingested</th><th>Titles</th><th>Rated</th></tr></thead>

--- a/test/imdbDataset.test.ts
+++ b/test/imdbDataset.test.ts
@@ -24,8 +24,7 @@ const seed = (): ImdbDataset => {
         ratings: [
             { tconst: 'tt0903747', average: 9.5, votes: 2_200_000 },
             { tconst: 'tt0068646', average: 9.2, votes: 2_000_000 }
-        ],
-        episodes: [{ tconst: 'tt2081647', parent: 'tt0903747', season: 1, episode: 1 }]
+        ]
     });
     return db;
 };
@@ -80,8 +79,7 @@ describe('discovering from the dataset', () => {
         db = ImdbDataset.ephemeral();
         db.replaceAll({
             titles: [{ tconst: 'tt1', kind: 'movie', title: 'A Docudrama', genres: 'Docudrama' }],
-            ratings: [],
-            episodes: []
+            ratings: []
         });
         expect(db.discover({ kind: 'movie', genre: 'Drama', limit: 10 })).toHaveLength(0);
     });
@@ -134,8 +132,7 @@ describe('replacing the dataset', () => {
         const store = seed();
         store.replaceAll({
             titles: [{ tconst: 'tt5', kind: 'movie', title: 'Only This' }],
-            ratings: [],
-            episodes: []
+            ratings: []
         });
 
         expect(store.status().titles).toBe(1);
@@ -152,7 +149,7 @@ describe('replacing the dataset', () => {
             throw new Error('connection reset');
         }
 
-        expect(() => store.replaceAll({ titles: explodes(), ratings: [], episodes: [] })).toThrow('connection reset');
+        expect(() => store.replaceAll({ titles: explodes(), ratings: [] })).toThrow('connection reset');
         expect(store.status().titles).toBe(3);
         expect(store.ratingsFor(['tt0903747']).get('tt0903747')).toBe(9.5);
     });

--- a/test/imdbDataset.test.ts
+++ b/test/imdbDataset.test.ts
@@ -94,9 +94,34 @@ describe('discovering from the dataset', () => {
         expect(hits.map(h => h.tconst)).not.toContain('tt0111161');
     });
 
-    it('includes unrated titles when no minimum is asked for', () => {
+    /**
+      * An unrated title is one nothing here can do anything with — every rating
+      * lookup misses it, and it is the overwhelming majority of IMDb's 12.7M
+      * rows. Since 1.0.1 they are dropped at ingest rather than stored and
+      * skipped, which is most of the difference between a 1.3 GB database and a
+      * small one.
+      */
+    it('does not store an unrated title at all', () => {
         const hits = seed().discover({ kind: 'movie', limit: 10 });
-        expect(hits.map(h => h.tconst)).toContain('tt0111161');
+        expect(hits.map(h => h.tconst)).not.toContain('tt0111161');
+    });
+
+    /** Nothing can query a tvEpisode or a video game, so nothing stores one. */
+    it('does not store a title of a kind no query can reach', () => {
+        db = ImdbDataset.ephemeral();
+        db.replaceAll({
+            titles: [
+                { tconst: 'tt1', kind: 'tvEpisode', title: 'An Episode' },
+                { tconst: 'tt2', kind: 'movie', title: 'A Film' }
+            ],
+            ratings: [
+                { tconst: 'tt1', average: 9, votes: 10 },
+                { tconst: 'tt2', average: 8, votes: 10 }
+            ]
+        });
+
+        expect(db.status().titles).toBe(1);
+        expect(db.discover({ kind: 'movie', limit: 10 }).map(h => h.tconst)).toEqual(['tt2']);
     });
 
     it('filters by year', () => {
@@ -111,7 +136,8 @@ describe('discovering from the dataset', () => {
 describe('status', () => {
     it('reports what it holds, for the dashboard', () => {
         const s = seed().status();
-        expect(s.titles).toBe(3);
+        // Two of the three fixture titles carry a rating; the third is dropped.
+        expect(s.titles).toBe(2);
         expect(s.ratings).toBe(2);
         expect(s.ingestedAt).toBeDefined();
     });
@@ -132,7 +158,7 @@ describe('replacing the dataset', () => {
         const store = seed();
         store.replaceAll({
             titles: [{ tconst: 'tt5', kind: 'movie', title: 'Only This' }],
-            ratings: []
+            ratings: [{ tconst: 'tt5', average: 7, votes: 5 }]
         });
 
         expect(store.status().titles).toBe(1);
@@ -150,7 +176,7 @@ describe('replacing the dataset', () => {
         }
 
         expect(() => store.replaceAll({ titles: explodes(), ratings: [] })).toThrow('connection reset');
-        expect(store.status().titles).toBe(3);
+        expect(store.status().titles).toBe(2);
         expect(store.ratingsFor(['tt0903747']).get('tt0903747')).toBe(9.5);
     });
 });

--- a/test/imdbEnrich.test.ts
+++ b/test/imdbEnrich.test.ts
@@ -12,8 +12,7 @@ const dataset = (): ImdbDataset => {
     db = ImdbDataset.ephemeral();
     db.replaceAll({
         titles: [{ tconst: 'tt0903747', kind: 'tvSeries', title: 'Breaking Bad' }],
-        ratings: [{ tconst: 'tt0903747', average: 9.5, votes: 2_200_000 }],
-        episodes: []
+        ratings: [{ tconst: 'tt0903747', average: 9.5, votes: 2_200_000 }]
     });
     return db;
 };

--- a/test/imdbIngest.test.ts
+++ b/test/imdbIngest.test.ts
@@ -91,7 +91,9 @@ describe('loading a parsed dump', () => {
         });
 
         expect(db.ratingsFor(['tt0903747']).get('tt0903747')).toBe(9.5);
-        expect(db.status().titles).toBe(4);
+        // Of the fixture's five rows: the short and the titleless one never
+        // parse, and Shawshank has no rating — so two survive.
+        expect(db.status().titles).toBe(2);
         expect(db.discover({ kind: 'movie', genre: 'Crime', limit: 10 }).map(h => h.title)).toEqual([
             'The Godfather'
         ]);

--- a/test/imdbIngest.test.ts
+++ b/test/imdbIngest.test.ts
@@ -87,8 +87,7 @@ describe('loading a parsed dump', () => {
         db = ImdbDataset.ephemeral();
         db.replaceAll({
             titles: parseTitles(lines('title.basics.tsv')),
-            ratings: parseRatings(lines('title.ratings.tsv')),
-            episodes: parseEpisodes(lines('title.episode.tsv'))
+            ratings: parseRatings(lines('title.ratings.tsv'))
         });
 
         expect(db.ratingsFor(['tt0903747']).get('tt0903747')).toBe(9.5);

--- a/test/imdbRefresh.test.ts
+++ b/test/imdbRefresh.test.ts
@@ -1,7 +1,10 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { createGzip } from 'node:zlib';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ImdbDataset } from '../src/metadata/imdbDataset.ts';
-import { ingestOnce } from '../src/metadata/refresh.ts';
+import { ingestOnce, linesOf } from '../src/metadata/refresh.ts';
 
 /**
  * The one file that touches the network, driven against a stubbed `fetch`
@@ -86,5 +89,52 @@ describe('ingesting from the published dumps', () => {
         db = ImdbDataset.ephemeral();
 
         await expect(ingestOnce(db, { baseUrl: BASE })).rejects.toThrow('title.basics.tsv.gz');
+    });
+});
+
+/**
+ * The fix for a crash found by the first real ingest: `title.basics` is ~12M
+ * lines, and buffering them cost about 4 GB of heap and killed the process.
+ * Lines are now read from a staged file a megabyte at a time.
+ *
+ * The subtle risk in doing that is the chunk boundary — a line straddling two
+ * reads must be stitched, not split, and getting it wrong corrupts quietly
+ * rather than throwing.
+ */
+describe('reading a staged dump', () => {
+    const write = (text: string): string => {
+        const dir = mkdtempSync(join(tmpdir(), 'lines-'));
+        const path = join(dir, 'dump.tsv');
+        writeFileSync(path, text, 'utf8');
+        return path;
+    };
+
+    it('yields each line', () => {
+        expect([...linesOf(write('a\nb\nc'))]).toEqual(['a', 'b', 'c']);
+    });
+
+    it('keeps the last line when the file does not end in a newline', () => {
+        expect([...linesOf(write('a\nb'))]).toEqual(['a', 'b']);
+    });
+
+    it('yields nothing for an empty file', () => {
+        expect([...linesOf(write(''))]).toEqual([]);
+    });
+
+    /** The whole reason the carry exists. */
+    it('stitches a line that straddles the 1 MB read boundary', () => {
+        const long = 'x'.repeat(1_500_000);
+        const lines = [...linesOf(write(`first\n${long}\nlast`))];
+
+        expect(lines).toHaveLength(3);
+        expect(lines[1]).toHaveLength(1_500_000);
+        expect(lines[2]).toBe('last');
+    });
+
+    /** Lazy, not materialised — the property the crash was caused by losing. */
+    it('reads lazily rather than loading the file', () => {
+        const gen = linesOf(write('a\nb\nc'));
+        expect(gen.next().value).toBe('a');
+        gen.return(undefined);
     });
 });

--- a/test/searchTools.test.ts
+++ b/test/searchTools.test.ts
@@ -701,3 +701,115 @@ describe('discovering without Seerr', () => {
         expect(result).toMatchObject({ items: [], total: 0 });
     });
 });
+
+/**
+ * Seerr is TMDB-backed and returns `voteAverage` on every search and discover
+ * hit — confirmed in the recorded fixtures. It went unread until 1.0.1, which
+ * meant nothing rated anything you did not already own unless you had paid a
+ * gigabyte of disk for the IMDb dataset.
+ */
+describe('ratings Seerr already had', () => {
+    const seerrWith = (results: unknown[]) =>
+        new SeerrAdapter(seerrConfig, serving({ '/api/v1/search': { results } }));
+
+    it('reads the TMDB score Seerr hands over for free', async () => {
+        const adapter = seerrWith([
+            { id: 550, mediaType: 'movie', title: 'Fight Club', releaseDate: '1999-10-15', voteAverage: 8.4 }
+        ]);
+        const [hit] = await adapter.search('fight club', 'discover');
+        expect(hit?.ratings?.tmdb).toBe(8.4);
+    });
+
+    /**
+     * TMDB returns 0 for "nobody has voted", not for "this is terrible". A
+     * zero reported as a score would rank an unrated title below every rated
+     * one — the same mistake the IMDb dataset avoids by omitting a miss.
+     */
+    it('treats a zero as unrated rather than as the worst film ever made', async () => {
+        const adapter = seerrWith([{ id: 1, mediaType: 'movie', title: 'Unrated', voteAverage: 0 }]);
+        const [hit] = await adapter.search('unrated', 'discover');
+        expect(hit?.ratings).toBeUndefined();
+    });
+
+    it('omits ratings entirely when Seerr sent none', async () => {
+        const adapter = seerrWith([{ id: 2, mediaType: 'movie', title: 'No Score' }]);
+        const [hit] = await adapter.search('no score', 'discover');
+        expect(hit?.ratings).toBeUndefined();
+    });
+});
+
+/**
+ * Seerr knows Rotten Tomatoes, and IMDb for a film — the one thing nothing
+ * else in the stack can supply for a title you do not own.
+ *
+ * Only on `get_media_details`, and only for one item: it costs an HTTP call per
+ * title, so it has no business on a path that returns a page of them.
+ */
+describe('Rotten Tomatoes and IMDb from Seerr', () => {
+    const MOVIE = { id: 42, title: 'Some Film', year: 2026, monitored: true, hasFile: true, tmdbId: 550 };
+
+    const stack = (routes: Record<string, unknown>) => [
+        new RadarrAdapter(keyed(7878), serving({ '/api/v3/movie/42': MOVIE })),
+        new SeerrAdapter(seerrConfig, serving(routes))
+    ];
+
+    it('adds the scores Radarr never reported', async () => {
+        const adapters = stack({
+            '/api/v1/movie/550/ratingscombined': { rt: { criticsScore: 85 }, imdb: { criticsScore: 6.5 } }
+        });
+
+        const result = await buildGetMediaDetails(adapters, {
+            service: 'radarr',
+            id: '42',
+            detail: 'standard',
+            limit: 50
+        });
+
+        expect(result.ratings).toMatchObject({ rottenTomatoes: 85, imdb: 6.5 });
+    });
+
+    /** The managing service is the authority on its own data. */
+    it('never displaces a score Radarr did report', async () => {
+        const rated = { ...MOVIE, ratings: { imdb: { value: 8.8, votes: 10 } } };
+        const adapters = [
+            new RadarrAdapter(keyed(7878), serving({ '/api/v3/movie/42': rated })),
+            new SeerrAdapter(seerrConfig, serving({
+                '/api/v1/movie/550/ratingscombined': { imdb: { criticsScore: 6.5 } }
+            }))
+        ];
+
+        const result = await buildGetMediaDetails(adapters, {
+            service: 'radarr',
+            id: '42',
+            detail: 'standard',
+            limit: 50
+        });
+
+        expect(result.ratings?.imdb).toBe(8.8);
+    });
+
+    /** A ratings lookup that fails must not take down the details call. */
+    it('still answers when Seerr cannot be reached', async () => {
+        const adapters = stack({});
+        const result = await buildGetMediaDetails(adapters, {
+            service: 'radarr',
+            id: '42',
+            detail: 'standard',
+            limit: 50
+        });
+
+        expect(result.title).toContain('Some Film');
+    });
+
+    it('does nothing at all when no Seerr is configured', async () => {
+        const adapters = [new RadarrAdapter(keyed(7878), serving({ '/api/v3/movie/42': MOVIE }))];
+        const result = await buildGetMediaDetails(adapters, {
+            service: 'radarr',
+            id: '42',
+            detail: 'standard',
+            limit: 50
+        });
+
+        expect(result.ratings).toBeUndefined();
+    });
+});

--- a/test/searchTools.test.ts
+++ b/test/searchTools.test.ts
@@ -580,8 +580,7 @@ describe('IMDb ratings on the not-yet-owned paths', () => {
         db = ImdbDataset.ephemeral();
         db.replaceAll({
             titles: [{ tconst: 'tt0137523', kind: 'movie', title: 'Some Film' }],
-            ratings: [{ tconst: 'tt0137523', average: 9.3, votes: 100 }],
-            episodes: []
+            ratings: [{ tconst: 'tt0137523', average: 9.3, votes: 100 }]
         });
         return db;
     };
@@ -658,8 +657,7 @@ describe('discovering without Seerr', () => {
             ratings: [
                 { tconst: 'tt0068646', average: 9.2, votes: 2_000_000 },
                 { tconst: 'tt0903747', average: 9.5, votes: 2_200_000 }
-            ],
-            episodes: []
+            ]
         });
         return db;
     };


### PR DESCRIPTION
**Enabling the IMDb dataset on a real install crashed arr-mcp.** Found by running the live gate the 0.8 plan named and that never ran until now — asked simply as "what's the disk impact of enabling this?"

```
FATAL ERROR: Ineffective mark-compacts near heap limit
Allocation failed - JavaScript heap out of memory
```

## The bug

`ingestOnce` buffered **every line** of every dump into an array, then **every parsed row** into another. `title.basics` is 12.7M lines. It died at ~4 GB.

The generators in `ingest.ts` were written lazily on purpose, "so peak memory is a row, not a file" — and this call site threw that away. The comment above it claimed the buffering was "the right trade", which it was not; that claim never met the real dumps, only 4-line fixtures.

## The fix

Dumps are staged to a temp file and read back a megabyte at a time, straight into the transaction.

Staging is also what makes that *possible*: **better-sqlite3 transactions cannot `await`**, so the network has to be finished with before the write begins — you cannot simply stream the download into the transaction. Atomicity is unchanged: both files land before anything is replaced, so a download dying between them still cannot leave today's titles against yesterday's ratings.

## Also: `title.episode` was ingested and never read

Not one query touched it — the only `SELECT`s are against `rating` and the `title`/`rating` join. **52 MB a day and millions of rows for a table nothing consulted.** It is no longer fetched, and is dropped on open so an existing database reclaims the space rather than carrying it forever.

## Measured, now that it completes

| | |
| --- | --- |
| Download, per day | **223 MB** (was 275 with episodes) |
| On disk | **~1.3 GB** |
| First ingest | 170s |
| Titles / rated | 12,703,317 / 1,703,610 |

`scripts/measure-imdb.ts` is kept in the repo so these can be refreshed rather than guessed — the dumps grow, and a figure in a README is only as good as the day it was taken.

## Docs and UI, which understated this badly

The config page said "some disk". It now says **1.3 GB and 223 MB a day**, up front, where someone decides whether to switch it on.

It also now says **what the dataset is actually for**, which was never clear:

- **Radarr already reports IMDb ratings for films.** If you only care about films, you may not need this at all.
- What nothing else can give you is an IMDb rating for a **series** (Sonarr reports one unlabelled number), or a rating for something you **don't own yet** (`lookup_media`).
- **It is not a Seerr stand-in.** Seerr filters discovery by TMDB rating (`voteAverageGte`) but never returns a rating *value* — the adapter parses none. Discovery falls back to the dataset only when Seerr is absent entirely.

## Tests

1199 passing. New coverage for the chunk boundary, which is the risk the fix introduces: a line straddling two 1 MB reads must be stitched, and getting that wrong corrupts quietly rather than throwing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
