### PR TITLE
chore: cut 1.1.0 — the squash subject decided the bump

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -56,6 +56,19 @@ Release-As: 1.0.0')"
 If it is missed anyway, the repair is a follow-up commit carrying the footer,
 which makes the open release PR re-cut itself.
 
+**The squash subject decides the bump.** A branch holding both a `feat:` and a
+`fix:` squashes to whichever commit's subject GitHub picks — usually the first —
+and release-please reads only that. A feature merged behind a fix ships as a
+patch, silently. Set `--subject` when a branch mixes types:
+
+```bash
+gh pr merge <n> --squash --subject 'feat: what it adds (#83)'
+```
+
+Both traps are the same shape: **squashing flattens the message, and only the
+flattened message is read.** Footers stop being footers; subjects other than the
+first stop existing.
+
 **Read the version on the release PR title before merging it**, every time. It
 is far cheaper to notice there than after the tag exists.
 


### PR DESCRIPTION
#83 held both a `fix:` and a `feat:`. Squashing took the first commit's subject, so release-please read `fix:` and proposed **1.0.1** — a feature shipped as a patch, silently.

Reading Seerr's ratings is new capability, so this should be **1.1.0**.

Same shape as the footer trap when 1.0 was cut: **squashing flattens the message, and only the flattened message is read.** Footers stop being footers; subjects other than the first stop existing. `RELEASING.md` now covers both, and says to set `--subject` when a branch mixes types.

Merge this and PR #84 re-cuts itself as `release 1.1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)