### PR TITLE
refactor: remove the episode parser nothing calls any more

### DIFF
--- a/src/metadata/imdbDataset.ts
+++ b/src/metadata/imdbDataset.ts
@@ -68,13 +68,6 @@ export type RawTitle = {
 
 export type RawRating = { tconst: string; average: number; votes: number };
 
-export type RawEpisode = {
-    tconst: string;
-    parent: string;
-    season?: number | undefined;
-    episode?: number | undefined;
-};
-
 export type DatasetTitle = {
     tconst: string;
     title: string;

--- a/src/metadata/ingest.ts
+++ b/src/metadata/ingest.ts
@@ -1,4 +1,4 @@
-import type { RawEpisode, RawRating, RawTitle } from './imdbDataset.ts';
+import type { RawRating, RawTitle } from './imdbDataset.ts';
 
 /**
  * IMDb's dumps into rows (0.8 spec ).
@@ -88,24 +88,5 @@ export function* parseRatings(lines: Iterable<string>): Generator<RawRating> {
         if (tconst === undefined || average === undefined || votes === undefined) continue;
 
         yield { tconst, average, votes };
-    }
-}
-
-/** `tconst parentTconst seasonNumber episodeNumber` */
-export function* parseEpisodes(lines: Iterable<string>): Generator<RawEpisode> {
-    for (const cols of rows(lines)) {
-        const tconst = value(cols[0]);
-        const parent = value(cols[1]);
-        if (tconst === undefined || parent === undefined) continue;
-
-        const season = number(cols[2]);
-        const episode = number(cols[3]);
-
-        yield {
-            tconst,
-            parent,
-            ...(season === undefined ? {} : { season }),
-            ...(episode === undefined ? {} : { episode })
-        };
     }
 }

--- a/test/fixtures/imdb/title.episode.tsv
+++ b/test/fixtures/imdb/title.episode.tsv
@@ -1,3 +1,0 @@
-tconst	parentTconst	seasonNumber	episodeNumber
-tt2081647	tt0903747	1	1
-tt2301451	tt0903747	\N	\N

--- a/test/imdbIngest.test.ts
+++ b/test/imdbIngest.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { ImdbDataset } from '../src/metadata/imdbDataset.ts';
-import { parseEpisodes, parseRatings, parseTitles } from '../src/metadata/ingest.ts';
+import { parseRatings, parseTitles } from '../src/metadata/ingest.ts';
 
 /**
  * Parsing IMDb's dumps, against hand-written fixtures in the real format —
@@ -65,10 +65,6 @@ describe('parsing the dumps', () => {
         });
     });
 
-    it('reads an episode with no season or number as absent', () => {
-        const loose = [...parseEpisodes(lines('title.episode.tsv'))].find(e => e.tconst === 'tt2301451');
-        expect(loose).toEqual({ tconst: 'tt2301451', parent: 'tt0903747' });
-    });
 
     it('yields nothing for a file that is only a header', () => {
         expect([...parseTitles(['tconst\ttitleType\tprimaryTitle'])]).toEqual([]);

--- a/test/imdbRefresh.test.ts
+++ b/test/imdbRefresh.test.ts
@@ -43,12 +43,10 @@ const BASICS =
     'tconst\ttitleType\tprimaryTitle\toriginalTitle\tisAdult\tstartYear\tendYear\truntimeMinutes\tgenres\n' +
     'tt0903747\ttvSeries\tBreaking Bad\tBreaking Bad\t0\t2008\t2013\t49\tCrime,Drama';
 const RATINGS = 'tconst\taverageRating\tnumVotes\ntt0903747\t9.5\t2200000';
-const EPISODES = 'tconst\tparentTconst\tseasonNumber\tepisodeNumber\ntt2081647\ttt0903747\t1\t1';
 
 const ALL = {
     'title.basics.tsv.gz': BASICS,
-    'title.ratings.tsv.gz': RATINGS,
-    'title.episode.tsv.gz': EPISODES
+    'title.ratings.tsv.gz': RATINGS
 };
 
 const BASE = 'https://example.test';


### PR DESCRIPTION
1.1.0 stopped downloading `title.episode` and left the machinery for reading it behind:

- `parseEpisodes` — a parser for a file that is never fetched
- `RawEpisode` — a row type for rows that are never stored
- `test/fixtures/imdb/title.episode.tsv` — a fixture for both
- The tests exercising all three

Which is exactly what the 1.0 audit went looking for and found almost none of — created an hour *after* that audit shipped, by the change that removed the ingest. Dead code is rarely written; it is usually left behind.

38 lines out, no behaviour change, 1206 tests passing. `refactor:` produces no release, so it rides along with whatever ships next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)