### PR TITLE
docs: say plainly that the IMDb dataset is a fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,23 +384,25 @@ Only rated titles of a kind something can actually query are stored — the othe
 Re-measure with `node --experimental-strip-types scripts/measure-imdb.ts`; the
 dumps grow, and a figure in a README is only as good as the day it was taken.
 
-### Do you need it?
+### Do you need it? Probably not, if you run Seerr
 
-Probably less than it first appears. Where ratings already come from:
+**This is a fallback.** Seerr already supplies ratings for both films and
+series, and it needs no disk at all:
 
 | | Films | Series |
 | --- | --- | --- |
 | **In your library** | Radarr: IMDb, TMDB, Rotten Tomatoes, Metacritic | Sonarr: one unlabelled number |
-| **Not in your library** | Seerr: TMDB on every hit, plus Rotten Tomatoes and IMDb on `get_media_details` | Seerr: TMDB, plus Rotten Tomatoes |
+| **Not in your library** | Seerr: TMDB, Rotten Tomatoes, IMDb | Seerr: TMDB, Rotten Tomatoes |
 
-So if you run Seerr and mostly care about films, **you may not need this at
-all**. What nothing else can give you is an **IMDb rating for a series** —
-Sonarr reports a single unlabelled number, and Seerr's `/tv/{id}/ratings` has no
-IMDb half — or ratings of any kind if you do not run Seerr.
+So switch the dataset on if:
 
-It is not a Seerr fallback, either. Seerr filters discovery by TMDB rating but
-that is a different job; discovery falls back to this dataset only when Seerr is
-not configured at all.
+- **you do not run Seerr**, or want ratings to survive Seerr being down; or
+- **you specifically want an IMDb number for a series.** Seerr's
+  `/tv/{id}/ratings` returns Rotten Tomatoes only — there is no combined
+  endpoint for TV upstream — so that one figure has no other source.
+
+That second reason is a footnote, not a feature. If TMDB and Rotten Tomatoes are
+enough for your series, you do not need this.
 
 ```
 get_library({ kind: "series", watched: false, rating_source: "imdb",

--- a/src/web/configPage.ts
+++ b/src/web/configPage.ts
@@ -441,16 +441,19 @@ export function configPage(opts: {
                     opts.config.metadata?.imdb?.enabled ?? false
                 )}
                 <p class="note">
-                    <strong>About 125 MB on disk, and a 223 MB download each day.</strong> The first ingest
-                    takes a few minutes; everything keeps working meanwhile and the dashboard says when it
-                    has finished. Nothing is sent anywhere, and there is no account or key.
+                    <strong>A fallback — most stacks do not need this.</strong> If you run Seerr you already
+                    have ratings for films <em>and</em> series, with no disk cost: Seerr supplies TMDB and
+                    Rotten Tomatoes for both, plus IMDb for films. Radarr covers films in your own library.
                 </p>
                 <p class="note">
-                    <strong>You may not need it.</strong> Radarr already reports IMDb, Rotten Tomatoes and
-                    Metacritic for films in your library, and Seerr supplies ratings for things you do not
-                    own. What nothing else can give you is an <em>IMDb rating for a series</em> — Sonarr
-                    reports one unlabelled number, and Seerr has no IMDb score for TV. That, and ratings at
-                    all if you do not run Seerr, is what this is for.
+                    Switch it on if you <strong>do not run Seerr</strong>, or want ratings to keep working
+                    when Seerr is down — or if you specifically want an <strong>IMDb number for a series</strong>,
+                    which is the one figure nothing else has (Seerr returns Rotten Tomatoes only for TV).
+                </p>
+                <p class="note">
+                    <strong>About 125 MB on disk, and a 223 MB download each day.</strong> The first ingest
+                    takes a few minutes; everything keeps working meanwhile, and the dashboard says when it
+                    has finished. Nothing is sent anywhere, and there is no account or key.
                 </p>
             </fieldset>
 

--- a/src/web/pages.ts
+++ b/src/web/pages.ts
@@ -241,9 +241,9 @@ const imdbPanel = (status: DatasetStatus): SafeHtml => html`<h2>IMDb dataset</h2
                   ingest finishes — nothing is broken while this says so. It runs again daily.
               </p>`
             : html`<p class="note">
-                      The IMDb rating no service in your stack can report for a series, and a rating for
-                      anything you do not own yet. Refreshed daily — about 223 MB down, roughly 1.3 GB on
-                      disk. Nothing here is sent anywhere.
+                      A fallback for ratings when Seerr is not configured or not answering, plus the IMDb
+                      number for a series that nothing else reports. Refreshed daily — about 223 MB down,
+                      roughly 125 MB on disk. Nothing here is sent anywhere.
                   </p>
                   <table>
                       <thead><tr><th>Last ingested</th><th>Titles</th><th>Rated</th></tr></thead>


### PR DESCRIPTION
The copy shipped with 1.1.0 still led with *"what nothing else can give you is an IMDb rating for a series"* — which reads as the reason to enable it. It is not. It is a footnote.

## What Seerr actually covers

| | Films | Series |
| --- | --- | --- |
| **In your library** | Radarr: IMDb, TMDB, Rotten Tomatoes, Metacritic | Sonarr: one unlabelled number |
| **Not in your library** | Seerr: TMDB, Rotten Tomatoes, IMDb | Seerr: TMDB, Rotten Tomatoes |

So the dataset is a **fallback**: for stacks without Seerr, or for when Seerr is down.

## The one exception, verified against upstream

Checked the **current** spec at `seerr-team/seerr` rather than our vendored copy: there is still no `/tv/{tvId}/ratingscombined`, and `/tv/{tvId}/ratings` returns Rotten Tomatoes alone — `criticsScore`, `criticsRating`, no `imdb` object.

So an IMDb *number for a series* genuinely has no other source. But that is one figure against 125 MB and a daily download, and the copy now presents it in that proportion.

## Where it changed

- **Config page** leads with "a fallback — most stacks do not need this", because that is the page where someone decides. Cost comes last, after the decision.
- **Dashboard** describes it as a fallback rather than as the only source of ratings.
- **README** section retitled "Do you need it? Probably not, if you run Seerr".

1206 tests passing. No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)