### PR TITLE
feat: make a series' IMDb rating actually reachable

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,11 @@ belong on a list of things to chase.
 `get_library`'s `quality` filter is films only — a series has no series-level
 quality. Its rating filters are mostly films only too, because Sonarr carries
 one flat TVDB rating rather than per-source scores; the exception is `imdb`,
-which the [IMDb dataset](#imdb-ratings) supplies for series as well. Asking for
-a combination that cannot exist returns a refusal explaining why, not an empty
-list.
+which the [IMDb dataset](#imdb-ratings) supplies for series as well — **and only
+it does**, so asking for a series' IMDb rating with the dataset off finds
+nothing. Asking for a combination that cannot exist returns a refusal explaining
+why, not an empty list; asking for one that needs the dataset says so in
+`ratingCoverage.note` rather than reporting a bare zero.
 
 The first thirteen are reads. The last six write, and are gated as described
 under [Writes](#writes) — off by default, previewed before they act, recorded
@@ -351,14 +353,23 @@ tier.
 
 ### IMDb ratings
 
+> **If you want IMDb scores for TV series, you need the IMDb dataset. There is
+> no other way to get them.** Nothing else in this stack has that number —
+> not Sonarr, not Seerr, not Jellyfin. Leave the dataset off and
+> `rating_source: imdb` on a series matches nothing, which reads as "your shows
+> are unrated" rather than "this server cannot look that up". Skip to
+> [switching it on](#switching-it-on). Films are unaffected.
+
 Ratings across this stack are inconsistent, and for series they are absent.
 Radarr returns a per-source map, so a film can carry IMDb, TMDB, Rotten
 Tomatoes and Metacritic scores at once. Sonarr returns a single unlabelled
-number, which arr-mcp can only honestly record as TVDB's — so **no service here
-can tell you a series' IMDb rating**, and asking `get_library` for one used to
-be refused outright.
+number, which arr-mcp can only honestly record as TVDB's. Seerr's
+`/tv/{id}/ratings` is Rotten Tomatoes only — the combined endpoint that carries
+the IMDb half exists for films alone, upstream. So **no service here can tell
+you a series' IMDb rating**, and asking `get_library` for one used to be
+refused outright.
 
-Switching on IMDb's daily dataset fixes that:
+#### Switching it on
 
 ```yaml
 metadata:
@@ -366,15 +377,20 @@ metadata:
     enabled: true
 ```
 
+Or tick **IMDb dataset** in the config UI, which applies immediately — the
+download starts when you save, with no restart.
+
 No account, no API key, nothing sent anywhere. Your container downloads two of
-IMDb's published files each day and keeps them in a local SQLite database beside
-the audit log.
+IMDb's published files and keeps them in a local SQLite database beside the
+audit log. The first ingest takes a few minutes; every tool answers exactly as
+it did before until it lands, and the dashboard says when it has finished.
 
 **It costs real disk.** Measured against the live dumps on 2026-08-08:
 
 | | |
 | --- | --- |
-| Download, per day | **223 MB** |
+| Download, per refresh | **223 MB** |
+| Refreshed | **weekly** |
 | On disk | **~125 MB** |
 | First ingest | ~3 minutes |
 | Titles stored / rated | 546K / 1.7M |
@@ -384,25 +400,36 @@ Only rated titles of a kind something can actually query are stored — the othe
 Re-measure with `node --experimental-strip-types scripts/measure-imdb.ts`; the
 dumps grow, and a figure in a README is only as good as the day it was taken.
 
-### Do you need it? Probably not, if you run Seerr
+**Weekly, though IMDb publishes daily.** What this holds is average ratings for
+titles that already exist, and an average over millions of votes moves by
+hundredths across a year — a nightly re-download spent 6.5 GB a month to answer
+every question exactly as it did the night before. The cost is that a title
+published in the last week may not be there yet, so a brand-new release can be
+missing from `discover_media` and a series added the day it premiered goes
+without an IMDb rating until the next refresh. The interval is not configurable.
 
-**This is a fallback.** Seerr already supplies ratings for both films and
-series, and it needs no disk at all:
+### Do you need it? For series IMDb scores, yes — otherwise probably not
+
+**For everything except a series' IMDb rating, this is a fallback.** Seerr
+already supplies ratings for both films and series, and it needs no disk at all:
 
 | | Films | Series |
 | --- | --- | --- |
 | **In your library** | Radarr: IMDb, TMDB, Rotten Tomatoes, Metacritic | Sonarr: one unlabelled number |
 | **Not in your library** | Seerr: TMDB, Rotten Tomatoes, IMDb | Seerr: TMDB, Rotten Tomatoes |
 
+Read the bottom-right cell: **no IMDb, either column, for a series.** That gap
+is the one thing the dataset uniquely fills.
+
 So switch the dataset on if:
 
-- **you do not run Seerr**, or want ratings to survive Seerr being down; or
-- **you specifically want an IMDb number for a series.** Seerr's
-  `/tv/{id}/ratings` returns Rotten Tomatoes only — there is no combined
-  endpoint for TV upstream — so that one figure has no other source.
+- **you want an IMDb number for a series** — the dataset is the only source,
+  in your library or out of it; or
+- **you do not run Seerr**, or want ratings to survive Seerr being down.
 
-That second reason is a footnote, not a feature. If TMDB and Rotten Tomatoes are
-enough for your series, you do not need this.
+The second is a footnote, not a feature. If TMDB and Rotten Tomatoes are enough
+for your series, you do not need this — but if you came here for IMDb scores on
+TV, the first reason is the whole answer.
 
 ```
 get_library({ kind: "series", watched: false, rating_source: "imdb",

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -195,9 +195,10 @@ const ServicesSchema = z
  * or can be tested, and none of it is a credential.
  *
  * `.strict()` at both levels because the setting a user is most likely to
- * invent is a refresh interval, and IMDb publishes daily — there is no second
- * answer. Quietly ignoring one that was set is worse than refusing it, since
- * the user believes it took effect.
+ * invent is a refresh interval, and there is no value they could pick that
+ * would serve them better than the weekly one `REFRESH_INTERVAL_MS` explains.
+ * Quietly ignoring one that was set is worse than refusing it, since the user
+ * believes it took effect.
  */
 export const MetadataSchema = z
     .object({

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -32,10 +32,24 @@ export type RuntimeSnapshot = {
  */
 const NO_CONFIG_DIR = '';
 
+/**
+ * Keeping an open dataset current, and how to stop.
+ *
+ * A seam rather than a direct call to `startRefresh`, for the property the
+ * `#dataset` doc claims: constructing a Runtime must not reach the network
+ * unless the caller asked it to. `src/index.ts` passes the real one; every
+ * test that never mentions the dataset gets `NO_REFRESH` and no download.
+ */
+export type Refresher = (dataset: ImdbDataset) => () => void;
+
+/** The default. Nothing to keep fresh, and nothing to stop. */
+const NO_REFRESH: Refresher = () => () => {};
+
 export class Runtime {
     #snapshot: RuntimeSnapshot;
     readonly #configDir: string;
     readonly #audit: WriteAudit;
+    readonly #refresh: Refresher;
 
     /**
      * Deliberately outside the snapshot, and so **not** rebuilt on reload.
@@ -59,20 +73,27 @@ export class Runtime {
      * reload only opens or closes it when the config's answer actually
      * changed.
      *
-     * Opening is all this class does. Keeping it *fresh* is `startRefresh`,
-     * which the entry point calls — so constructing a Runtime never reaches
-     * the network, and no test has to opt out of a download it did not ask
-     * for.
+     * Opening it and keeping it *fresh* are the same decision, so both live
+     * here. Through 1.1 they did not: `startRefresh` was called once at
+     * startup from the entry point, so switching the dataset on from the
+     * config UI opened an empty database that nothing ever ingested into, and
+     * every rating stayed missing until the container was restarted — a
+     * feature that looks broken rather than one that looks off. What the
+     * entry point supplies now is the *refresher*, not the timing.
      */
     #dataset: ImdbDataset | undefined;
+
+    /** Stops the refresh belonging to `#dataset`, and only while one is open. */
+    #stopRefresh: (() => void) | undefined;
 
     get dataset(): ImdbDataset | undefined {
         return this.#dataset;
     }
 
-    private constructor(configDir: string, audit: WriteAudit, config: Config) {
+    private constructor(configDir: string, audit: WriteAudit, config: Config, refresh: Refresher) {
         this.#configDir = configDir;
         this.#audit = audit;
+        this.#refresh = refresh;
         this.confirm = new ConfirmTokens();
         this.sessions = new Sessions();
         // Before the snapshot, not after: the tool context closes over the
@@ -82,8 +103,14 @@ export class Runtime {
     }
 
     /**
-     * Open or close the dataset to match the config, and do nothing at all
-     * when the answer has not changed — which is the common case on reload.
+     * Open or close the dataset to match the config — and start or stop its
+     * refresh with it — doing nothing at all when the answer has not changed,
+     * which is the common case on reload.
+     *
+     * The "unchanged" branch is what stops every unrelated save from stacking
+     * up refreshers: editing a timeout reloads the runtime, and a second timer
+     * per edit would mean a day of configuring left a pile of them all
+     * downloading 223 MB on the same schedule.
      *
      * `ImdbDataset.open` touches the filesystem, so it is skipped entirely
      * when there is no real config directory: `fromConfig`'s default is a
@@ -96,19 +123,34 @@ export class Runtime {
         if (wanted && this.#dataset === undefined) {
             this.#dataset = ImdbDataset.open(this.#configDir);
             logger.info({ file: IMDB_FILENAME }, 'IMDb dataset opened');
+            // After the open, and pointed at the database that was just
+            // opened: a refresh filling a dataset nothing reads would be the
+            // same bug this call exists to fix, wearing a different hat.
+            this.#stopRefresh = this.#refresh(this.#dataset);
             return;
         }
 
         if (!wanted && this.#dataset !== undefined) {
+            // Stopped *before* the close, so no further ingest is scheduled
+            // against a database about to go away. An ingest already in flight
+            // is not cancellable — it will fail on the closed handle and be
+            // logged by the refresher's own catch, which is the right outcome:
+            // a warning about a download nobody wants any more.
+            this.#stopRefresh?.();
+            this.#stopRefresh = undefined;
             this.#dataset.close();
             this.#dataset = undefined;
             logger.info('IMDb dataset closed — no longer enabled');
         }
     }
 
-    static async start(configDir: string, audit: WriteAudit): Promise<{ runtime: Runtime; created: boolean }> {
+    static async start(
+        configDir: string,
+        audit: WriteAudit,
+        opts: { refresh?: Refresher } = {}
+    ): Promise<{ runtime: Runtime; created: boolean }> {
         const { config, created } = await loadConfig(configDir);
-        return { runtime: new Runtime(configDir, audit, config), created };
+        return { runtime: new Runtime(configDir, audit, config, opts.refresh ?? NO_REFRESH), created };
     }
 
     /**
@@ -127,9 +169,14 @@ export class Runtime {
     static fromConfig(
         config: Config,
         audit: WriteAudit,
-        opts: { configDir?: string; adapters?: readonly ServiceAdapter[] } = {}
+        opts: { configDir?: string; adapters?: readonly ServiceAdapter[]; refresh?: Refresher } = {}
     ): Runtime {
-        const runtime = new Runtime(opts.configDir ?? NO_CONFIG_DIR, audit, config);
+        const runtime = new Runtime(
+            opts.configDir ?? NO_CONFIG_DIR,
+            audit,
+            config,
+            opts.refresh ?? NO_REFRESH
+        );
         if (opts.adapters !== undefined) {
             runtime.#snapshot = {
                 config,

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,11 @@ attachLogStore(logs);
 // watching `docker logs`, rather than the first time they ask for a deletion.
 const audit = WriteAudit.open(CONFIG_DIR);
 
-const { runtime } = await Runtime.start(CONFIG_DIR, audit);
+// The refresher, not the timing: `Runtime` owns *when* to start and stop one,
+// because only it knows when the dataset was opened or closed. Passing it here
+// is also the only thing that lets this process reach the network for a
+// dataset — a test that constructs a Runtime without it never downloads.
+const { runtime } = await Runtime.start(CONFIG_DIR, audit, { refresh: dataset => startRefresh(dataset) });
 
 if (runtime.config.auth.password_hash === undefined) {
     // Deliberately the loudest line at startup: until someone claims it, this
@@ -38,13 +42,17 @@ if (runtime.config.auth.password_hash === undefined) {
     );
 }
 
-// Deliberately not awaited. The first ingest downloads and parses on the order
-// of 10^7 rows, which on a NAS is minutes — and every tool answers exactly as
-// it did before until it lands, so blocking here would turn a slow cache warm
-// into a container that looks broken.
+// The refresh itself is already running if the dataset is on — `Runtime`
+// started it as it opened the database, and will start one just the same when
+// somebody switches the dataset on from the config UI, which is the case this
+// line used to be the only cover for and could not reach.
+//
+// Nothing is awaited: the first ingest downloads and parses on the order of
+// 10^7 rows, which on a NAS is minutes — and every tool answers exactly as it
+// did before until it lands, so blocking here would turn a slow cache warm into
+// a container that looks broken.
 if (runtime.dataset !== undefined) {
     logger.info('IMDb dataset enabled — refreshing in the background; ratings appear once the first ingest finishes');
-    startRefresh(runtime.dataset);
 }
 
 serve({ fetch: buildApp({ runtime, audit, logs }).fetch, port: PORT, hostname: '0.0.0.0' }, info => {

--- a/src/metadata/imdbDataset.ts
+++ b/src/metadata/imdbDataset.ts
@@ -9,7 +9,7 @@ import { join } from 'node:path';
  * Its own file, and its own module, for the reason those two are separate
  * from each other: three different retention stories. Write records survive
  * forever, log lines are a ring buffer, and this is a cache that is wholly
- * replaced every day and can be deleted at any moment without losing anything
+ * replaced every week and can be deleted at any moment without losing anything
  * a user typed. Losing it costs a download, not data.
  *
  * **Nothing here touches the network.** Downloading lives in `refresh.ts` and
@@ -106,7 +106,7 @@ export class ImdbDataset {
 
     private constructor(db: Db) {
         this.#db = db;
-        // WAL for the reason audit.ts uses it: the daily ingest writes while
+        // WAL for the reason audit.ts uses it: the weekly ingest writes while
         // tool calls read, and a reader must never block on a twenty-minute
         // rebuild.
         this.#db.pragma('journal_mode = WAL');

--- a/src/metadata/refresh.ts
+++ b/src/metadata/refresh.ts
@@ -9,7 +9,7 @@ import type { ImdbDataset } from './imdbDataset.ts';
 import { parseRatings, parseTitles } from './ingest.ts';
 
 /**
- * Fetching the dumps, and the daily schedule.
+ * Fetching the dumps, and the weekly schedule.
  *
  * The only file in `src/metadata/` that touches the network, which is what lets
  * the store and the parser be tested without one.
@@ -17,8 +17,27 @@ import { parseRatings, parseTitles } from './ingest.ts';
 
 export const IMDB_BASE_URL = 'https://datasets.imdbws.com';
 
-/** IMDb publishes daily, so there is no second sensible interval to offer. */
-export const REFRESH_INTERVAL_MS = 24 * 60 * 60 * 1000;
+/**
+ * Weekly, though IMDb publishes daily — the publish cadence is not the useful
+ * one here.
+ *
+ * What this database holds is average ratings for titles that already exist. An
+ * average over two million votes moves by hundredths across a *year*; refetching
+ * 223 MB every night to change a third decimal place spent 6.5 GB a month of a
+ * NAS's bandwidth to answer every question exactly as it did the night before.
+ * Weekly is under a gigabyte a month for the same answers.
+ *
+ * **What this costs, stated plainly:** a title IMDb published in the last week
+ * may have no row yet, so a brand-new release can be missing from `discover`,
+ * and a series added to your library the day it premiered goes without an IMDb
+ * rating until the next refresh. Ratings for anything older — which is nearly
+ * everything anybody owns — are unaffected.
+ *
+ * Still not configurable, for the reason it never was: there is no interval a
+ * user could pick that would serve them better than this one, and a setting
+ * that cannot help can still be set wrong.
+ */
+export const REFRESH_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000;
 
 /**
  * Download one dump, decompressed, **to a file** — never into memory.
@@ -116,7 +135,12 @@ export async function ingestOnce(dataset: ImdbDataset, opts: { baseUrl?: string 
 }
 
 /**
- * Start the daily refresh, returning a function that stops it.
+ * Start the weekly refresh, returning a function that stops it.
+ *
+ * Runs once immediately, then on the interval — which is what makes switching
+ * the dataset on from the config UI produce ratings rather than an empty
+ * database that waits a week. `Runtime` calls this the moment it opens the
+ * database, and calls the returned stop function when it closes it.
  *
  * **Startup never awaits this.** A first run of several minutes is several
  * minutes of normal service, not a container that looks broken — every tool

--- a/src/tools/getLibrary.ts
+++ b/src/tools/getLibrary.ts
@@ -88,7 +88,12 @@ export type GetLibraryResult = {
     truncated: boolean;
     degraded: string[];
     counts: Partial<Record<ServiceId, number>>;
-    ratingCoverage?: { source: RatingSource; rated: number; unrated: number };
+    /**
+     * `note` is set only when the count needs defending — see
+     * `imdbUnavailableNote`. Additive and optional, so a caller reading
+     * `source`/`rated`/`unrated` is unaffected.
+     */
+    ratingCoverage?: { source: RatingSource; rated: number; unrated: number; note?: string };
 };
 
 const ratingOf = (item: MergedItem, source: RatingSource): number | undefined => item.ratings?.[source];
@@ -203,6 +208,31 @@ const project = (item: MergedItem, detail: DetailLevel): MergedItem => {
     return rest;
 };
 
+/**
+ * Why an IMDb query found nothing — when the reason is this server rather than
+ * the library.
+ *
+ * "0 rated, 40 unrated" is true and useless on its own. It reads as *your
+ * series are unrated*, and a model handed that number reasonably tells the user
+ * their question cannot be answered — which is how someone came to be told that
+ * IMDb scores for their own shows were impossible, when the answer was one
+ * config line away.
+ *
+ * Only ever attached to a **zero**. A partial count speaks for itself, and
+ * qualifying a real answer with an excuse would be worse than saying nothing.
+ * `ready` returns nothing for the same reason: a loaded dataset that does not
+ * cover these titles is a genuine fact about the library.
+ */
+function imdbUnavailableNote(state: 'off' | 'ingesting' | 'ready'): string | undefined {
+    if (state === 'off') {
+        return 'No IMDb rating was available for anything here, because the IMDb dataset is not enabled — set `metadata.imdb.enabled: true` (Configuration → IMDb dataset). For a series this is the only source there is: Sonarr reports one flat TVDB number, and Seerr’s /tv ratings are Rotten Tomatoes only. This is a gap in what this server can look up, not a verdict on the library.';
+    }
+    if (state === 'ingesting') {
+        return 'The IMDb dataset is enabled but has not finished its first ingest, so no IMDb rating is available yet — it takes a few minutes and the dashboard reports when it lands. Nothing needs changing; ask again shortly. This is not a verdict on the library.';
+    }
+    return undefined;
+}
+
 export async function buildGetLibrary(loader: LibraryLoader, opts: LibraryQuery): Promise<GetLibraryResult> {
     rejectImpossibleFilters(opts);
 
@@ -279,12 +309,22 @@ export async function buildGetLibrary(loader: LibraryLoader, opts: LibraryQuery)
     const ordered = opts.sort === undefined ? matching : applySort(matching, opts.sort, source);
     const shaped = applyLimit(ordered, opts.limit);
 
+    // Only for `imdb`, and only for a zero: every other source is supplied by a
+    // service that either answered or is already named in `degraded`.
+    const note =
+        source === 'imdb' && rated.length === 0 ? imdbUnavailableNote(loader.imdbDatasetState) : undefined;
+
     return {
         ...shaped,
         items: shaped.items.map(i => project(i, opts.detail)),
         degraded,
         counts,
-        ratingCoverage: { source, rated: rated.length, unrated: filtered.length - rated.length }
+        ratingCoverage: {
+            source,
+            rated: rated.length,
+            unrated: filtered.length - rated.length,
+            ...(note === undefined ? {} : { note })
+        }
     };
 }
 
@@ -293,7 +333,7 @@ export function registerGetLibrary(server: McpServer, loader: LibraryLoader): vo
         'get_library',
         {
             description:
-                'Your library, joined across Radarr, Sonarr and Jellyfin on shared external ids. `presence` is what no single service can tell you — but only when the absent half’s service actually answered: `arr_only` with a file means Jellyfin *was reachable and* cannot see a file the *arr believes is on disk (a likely broken import); `jellyfin_only` means nothing here is managing it, read the same way — it assumes Radarr/Sonarr answered too, and (unlike `arr_only`) is not yet hedged against their own outage. If Jellyfin is degraded, an item Radarr/Sonarr manages reports `unknown` instead of `arr_only`, and the top-level `degraded` list names it. If Jellyfin is not configured at all, `unknown` fires the same way but `degraded` stays empty — there is nothing to name as degraded — so check whether `jellyfin` even appears in your config instead. `has_file: false` with `monitored: true` is "what am I still waiting for". Two limits: `quality` applies to films only (a series’ quality is per-episode), and a series carries Sonarr’s one flat TVDB rating plus an IMDb rating when the IMDb dataset is enabled — `rating_source` still defaults to `tvdb` for a series, so ask for `imdb` explicitly. A rating filter also reports how much of the library that source actually covers.',
+                'Your library, joined across Radarr, Sonarr and Jellyfin on shared external ids. `presence` is what no single service can tell you — but only when the absent half’s service actually answered: `arr_only` with a file means Jellyfin *was reachable and* cannot see a file the *arr believes is on disk (a likely broken import); `jellyfin_only` means nothing here is managing it, read the same way — it assumes Radarr/Sonarr answered too, and (unlike `arr_only`) is not yet hedged against their own outage. If Jellyfin is degraded, an item Radarr/Sonarr manages reports `unknown` instead of `arr_only`, and the top-level `degraded` list names it. If Jellyfin is not configured at all, `unknown` fires the same way but `degraded` stays empty — there is nothing to name as degraded — so check whether `jellyfin` even appears in your config instead. `has_file: false` with `monitored: true` is "what am I still waiting for". Two limits: `quality` applies to films only (a series’ quality is per-episode), and a series carries Sonarr’s one flat TVDB rating plus an IMDb rating **only when the IMDb dataset is enabled** — nothing else in this stack has a series’ IMDb number, so with the dataset off `rating_source: "imdb"` on a series matches nothing. `rating_source` still defaults to `tvdb` for a series, so ask for `imdb` explicitly. A rating filter also reports how much of the library that source actually covers; if that count is zero because the dataset is off or still ingesting, `ratingCoverage.note` says so — report that reason rather than telling the user their library is unrated or that the question cannot be answered.',
             inputSchema: z.object({
                 kind: z.enum(['movie', 'series']).optional().describe('Films or series. Omit for both.'),
                 year: z.number().int().optional(),
@@ -354,7 +394,12 @@ export function registerGetLibrary(server: McpServer, loader: LibraryLoader): vo
             const coverage =
                 result.ratingCoverage === undefined
                     ? ''
-                    : ` ${result.ratingCoverage.unrated} item(s) carry no ${result.ratingCoverage.source} rating and could not be judged.`;
+                    : ` ${result.ratingCoverage.unrated} item(s) carry no ${result.ratingCoverage.source} rating and could not be judged.` +
+                      // In the text too, not only the structured half: this is
+                      // the sentence that stops "0 rated" being read as a fact
+                      // about the library, and it has to reach a reader who
+                      // only ever sees the summary line.
+                      (result.ratingCoverage.note === undefined ? '' : ` ${result.ratingCoverage.note}`);
             const missing =
                 result.degraded.length === 0 ? '' : ` ${result.degraded.join(', ')} could not be reached.`;
 

--- a/src/tools/library.ts
+++ b/src/tools/library.ts
@@ -47,6 +47,26 @@ export class LibraryLoader {
         this.#dataset = dataset;
     }
 
+    /**
+     * Whether an IMDb rating is *obtainable* here, which is not the same
+     * question as whether one was found.
+     *
+     * `get_library` needs this to tell three situations apart that all arrive
+     * as "0 rated": the dataset is off, it is on but has not finished its first
+     * ingest, or it is loaded and genuinely does not cover these titles. Only
+     * the last is an answer about the library; the other two are answers about
+     * this server, and a caller told "0 rated" without them reasonably
+     * concludes the library is the problem — which is exactly what happened.
+     *
+     * A getter rather than a field on the snapshot: the state changes when the
+     * ingest lands, which is not a library read and must not wait for the cache
+     * to expire.
+     */
+    get imdbDatasetState(): 'off' | 'ingesting' | 'ready' {
+        if (this.#dataset === undefined) return 'off';
+        return this.#dataset.status().ingestedAt === undefined ? 'ingesting' : 'ready';
+    }
+
     async load(user?: string): Promise<LibrarySnapshot> {
         const resolved = await this.#resolveUser(user);
 

--- a/src/web/configPage.ts
+++ b/src/web/configPage.ts
@@ -12,7 +12,12 @@ import { layout } from './pages.ts';
  * therefore never means "clear this" — removing the instance does.
  *
  * **Each card is its own form**, so a save touches exactly the instance it came
- * from rather than rewriting every other service on screen.
+ * from rather than rewriting every other service on screen. That holds for the
+ * three access cards at the bottom too, and did not always: they shared one
+ * button, which by sitting last on the page read as a global save while every
+ * card above saved itself. One rule now — the card you edited is the card you
+ * save — and one route per card in `routes.ts` to enforce it, each carrying
+ * forward the config it does not own.
  *
  * **Nothing here is `type="password"`.** That attribute is what makes browsers
  * and password managers read a card as a login form and fill the URL and key on
@@ -417,67 +422,91 @@ export function configPage(opts: {
         ${addDialog(opts.config, opts.csrf, opts.openAdd === true, opts.testedAdd)}
 
         <h2>Access</h2>
-        <form method="post" action="/ui/config/access" ${IGNORE_FORM}>
+        <p class="note" style="margin:-.5rem 0 1rem">
+            Three separate settings, saved separately — like the service cards above. Each Save writes only
+            its own card.
+        </p>
+
+        <form method="post" action="/ui/config/account" class="panel" ${IGNORE_FORM}>
             <input type="hidden" name="csrf" value="${opts.csrf}">
-            <fieldset>
-                <legend>Config UI</legend>
-                ${field({ id: 'auth.username', name: 'auth.username', label: 'Username', value: opts.config.auth.username })}
-                ${field({
-                    id: 'auth.password',
-                    name: 'auth.password',
-                    label: 'New password',
-                    secret: true,
-                    placeholder: 'unchanged',
-                    note: 'Leave blank to keep the current password. Only a hash is stored — it cannot be read back.'
-                })}
-            </fieldset>
-
-            <fieldset>
-                <legend>IMDb dataset</legend>
-                ${checkbox(
-                    'metadata.imdb',
-                    'metadata.imdb',
-                    'Download IMDb’s daily dataset for ratings',
-                    opts.config.metadata?.imdb?.enabled ?? false
-                )}
-                <p class="note">
-                    <strong>A fallback — most stacks do not need this.</strong> If you run Seerr you already
-                    have ratings for films <em>and</em> series, with no disk cost: Seerr supplies TMDB and
-                    Rotten Tomatoes for both, plus IMDb for films. Radarr covers films in your own library.
-                </p>
-                <p class="note">
-                    Switch it on if you <strong>do not run Seerr</strong>, or want ratings to keep working
-                    when Seerr is down — or if you specifically want an <strong>IMDb number for a series</strong>,
-                    which is the one figure nothing else has (Seerr returns Rotten Tomatoes only for TV).
-                </p>
-                <p class="note">
-                    <strong>About 125 MB on disk, and a 223 MB download each day.</strong> The first ingest
-                    takes a few minutes; everything keeps working meanwhile, and the dashboard says when it
-                    has finished. Nothing is sent anywhere, and there is no account or key.
-                </p>
-            </fieldset>
-
-            <fieldset>
-                <legend>MCP endpoint</legend>
-                ${checkbox('auth.rotate_token', 'auth.rotate_token', 'Generate a new bearer token', false)}
-                <p class="note">
-                    Rotating invalidates the current token immediately; every MCP client will need the new one,
-                    which appears on the dashboard.
-                </p>
-                ${field({
-                    id: 'auth.allowed_hosts',
-                    name: 'auth.allowed_hosts',
-                    label: 'Allowed hosts (comma separated)',
-                    value: opts.config.auth.allowed_hosts.join(', '),
-                    note: 'Leave empty to accept any Host — right for a LAN container reached by IP. Applies immediately; pin the wrong name and you will lock yourself out until you edit config.yaml by hand.'
-                })}
-            </fieldset>
-
-            <div class="row">
-                <button type="submit">Save access settings</button>
-                <a href="/ui" style="margin-left:.5rem">Back to the dashboard</a>
+            <h3 style="margin:0 0 .75rem">Config UI sign-in</h3>
+            ${field({ id: 'auth.username', name: 'auth.username', label: 'Username', value: opts.config.auth.username })}
+            ${field({
+                id: 'auth.password',
+                name: 'auth.password',
+                label: 'New password',
+                secret: true,
+                placeholder: 'unchanged',
+                note: 'Leave blank to keep the current password. Only a hash is stored — it cannot be read back.'
+            })}
+            <div class="row" style="margin-top:1rem">
+                <button type="submit">Save sign-in</button>
             </div>
-        </form>`;
+        </form>
+
+        <form method="post" action="/ui/config/imdb" class="panel" ${IGNORE_FORM}>
+            <input type="hidden" name="csrf" value="${opts.csrf}">
+            <h3 style="margin:0 0 .75rem">IMDb dataset</h3>
+            ${checkbox(
+                'metadata.imdb',
+                'metadata.imdb',
+                'Download IMDb’s dataset for ratings',
+                opts.config.metadata?.imdb?.enabled ?? false
+            )}
+            <!-- The required-for-series line comes first and is unhedged. It
+                 used to be the second half of the second paragraph, under a
+                 heading that said "most stacks do not need this" — so someone
+                 looking for a series' IMDb score read the discouragement and
+                 stopped. That is not a hypothetical: it is how this page was
+                 found to be wrong. -->
+            <p class="note">
+                <strong>Required for IMDb ratings on TV series.</strong> Leave this off and
+                <span class="mono">rating_source: imdb</span> on a series matches nothing at all — not
+                because your shows are unrated, but because nothing else in the stack has that number.
+                Sonarr reports one flat TVDB rating, and Seerr’s <span class="mono">/tv</span> ratings are
+                Rotten Tomatoes only; there is no combined endpoint for TV upstream. Films are unaffected —
+                Radarr and Seerr both supply IMDb for those.
+            </p>
+            <p class="note">
+                <strong>For everything else it is only a fallback.</strong> If you run Seerr you already have
+                TMDB and Rotten Tomatoes for films and series, plus IMDb for films, at no disk cost. So the
+                other reasons to switch this on are that you <strong>do not run Seerr</strong>, or you want
+                ratings to keep working while Seerr is down.
+            </p>
+            <p class="note">
+                <strong>About 125 MB on disk, and a 223 MB download each week.</strong> Refreshed weekly
+                rather than daily: an average over millions of votes barely moves, so a nightly re-download
+                spent 6.5 GB a month to change third decimal places. The cost is that a title published in
+                the last week may not be there yet. The first ingest takes a few minutes; everything keeps
+                working meanwhile, and the dashboard says when it has finished. Nothing is sent anywhere,
+                and there is no account or key.
+            </p>
+            <div class="row" style="margin-top:1rem">
+                <button type="submit">Save IMDb settings</button>
+            </div>
+        </form>
+
+        <form method="post" action="/ui/config/mcp" class="panel" ${IGNORE_FORM}>
+            <input type="hidden" name="csrf" value="${opts.csrf}">
+            <h3 style="margin:0 0 .75rem">MCP endpoint</h3>
+            ${checkbox('auth.rotate_token', 'auth.rotate_token', 'Generate a new bearer token', false)}
+            <p class="note">
+                Rotating invalidates the current token immediately; every MCP client will need the new one,
+                which appears on the dashboard.
+            </p>
+            ${field({
+                id: 'auth.allowed_hosts',
+                name: 'auth.allowed_hosts',
+                label: 'Allowed hosts (comma separated)',
+                value: opts.config.auth.allowed_hosts.join(', '),
+                note: 'Leave empty to accept any Host — right for a LAN container reached by IP. Applies immediately; pin the wrong name and you will lock yourself out until you edit config.yaml by hand.'
+            })}
+            <div class="row" style="margin-top:1rem">
+                <button type="submit">Save MCP settings</button>
+            </div>
+        </form>
+
+        <p class="note"><a href="/ui">Back to the dashboard</a></p>`;
 
     return layout({
         title: 'Configuration',

--- a/src/web/pages.ts
+++ b/src/web/pages.ts
@@ -238,12 +238,15 @@ const imdbPanel = (status: DatasetStatus): SafeHtml => html`<h2>IMDb dataset</h2
         ${status.ingestedAt === undefined
             ? html`<p class="note">
                   Enabled, still downloading. Every tool answers exactly as it did before until the first
-                  ingest finishes — nothing is broken while this says so. It runs again daily.
+                  ingest finishes — nothing is broken while this says so, but <strong>IMDb ratings for
+                  series are not available yet</strong>, because this is the only thing that supplies them.
+                  It runs again weekly.
               </p>`
             : html`<p class="note">
-                      A fallback for ratings when Seerr is not configured or not answering, plus the IMDb
-                      number for a series that nothing else reports. Refreshed daily — about 223 MB down,
-                      roughly 125 MB on disk. Nothing here is sent anywhere.
+                      A fallback for ratings when Seerr is not configured or not answering — and the only
+                      source of an <strong>IMDb rating for a series</strong>, which no service in this stack
+                      reports. Refreshed weekly — about 223 MB down, roughly 125 MB on disk. Nothing here is
+                      sent anywhere.
                   </p>
                   <table>
                       <thead><tr><th>Last ingested</th><th>Titles</th><th>Rated</th></tr></thead>

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -370,9 +370,21 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
         })
     );
 
+    // One route per card, matching one form per card. A single `/access` route
+    // taking all three was what let the page grow a button that looked global.
     app.post(
-        '/ui/config/access',
-        configMutation('Access settings saved.', form => buildAuthConfig(runtime.config, form))
+        '/ui/config/account',
+        configMutation('Config UI sign-in saved.', form => buildAccountConfig(runtime.config, form))
+    );
+
+    app.post(
+        '/ui/config/imdb',
+        configMutation('IMDb dataset settings saved.', form => buildImdbConfig(runtime.config, form))
+    );
+
+    app.post(
+        '/ui/config/mcp',
+        configMutation('MCP endpoint settings saved.', form => buildMcpConfig(runtime.config, form))
     );
 
     /**
@@ -540,24 +552,26 @@ export function addCandidateFrom(
 }
 
 /**
- * The `auth` half of the old `buildConfig`, unchanged in behaviour.
+ * The three cards below the services, one builder each.
  *
- * The services half is gone: instances are added, edited and removed one at a
- * time through `src/config/mutate.ts`, so nothing rebuilds all eight services
- * from one form any more.
+ * They were a single `buildAuthConfig` behind a single button, which is what
+ * made the page have two save models at once — every service card saved
+ * itself, and then one button at the bottom of the page saved three unrelated
+ * things together while looking, by position, like it saved everything.
+ *
+ * Splitting them makes the rule uniform: **the card you edited is the card you
+ * save.** It also creates the one hazard worth naming, which is why each of
+ * these carries forward every field it does not own rather than rebuilding the
+ * config from its own form. A form that never contained `auth.allowed_hosts`
+ * submits nothing for it, and "nothing" is indistinguishable from "the user
+ * cleared the box" unless the builder knows which fields are its business.
+ * `test/configUi.test.ts` holds one test per way of getting that wrong.
  */
-export function buildAuthConfig(current: Config, form: Record<string, unknown>): Config {
-    // The dataset toggle rides along with the access form because it is the
-    // only other thing on the page that is not an instance card. Off is
-    // expressed by dropping the block entirely rather than by `enabled: false`,
-    // so a config nobody touched stays exactly as clean as it started.
-    const imdb = on(form['metadata.imdb']);
+
+/** The Config UI's own credentials. Owns `username` and `password_hash`. */
+export function buildAccountConfig(current: Config, form: Record<string, unknown>): Config {
     const username = str(form['auth.username']).trim();
     const password = str(form['auth.password']);
-    const hosts = str(form['auth.allowed_hosts'])
-        .split(',')
-        .map(h => h.trim())
-        .filter(h => h !== '');
 
     // Refused rather than carried forward as `undefined`. Since `password_hash`
     // became optional this assignment type-checks either way, so nothing but
@@ -570,15 +584,47 @@ export function buildAuthConfig(current: Config, form: Record<string, unknown>):
     }
 
     return {
+        ...current,
         auth: {
+            ...current.auth,
+            username: username === '' ? current.auth.username : username,
+            password_hash: carriedHash
+        }
+    };
+}
+
+/**
+ * The IMDb dataset. Owns `metadata` and nothing else.
+ *
+ * Its checkbox is authoritative because an unchecked box submits nothing, and
+ * this is the only form that carries it — so absent genuinely means off here,
+ * where on any other card it would mean "not mine to touch". Off is expressed
+ * by dropping the block entirely rather than by `enabled: false`, so a config
+ * nobody touched stays exactly as clean as it started.
+ */
+export function buildImdbConfig(current: Config, form: Record<string, unknown>): Config {
+    const { metadata: _dropped, ...rest } = current;
+    return {
+        ...rest,
+        ...(on(form['metadata.imdb']) ? { metadata: { imdb: { enabled: true } } } : {})
+    };
+}
+
+/** The MCP endpoint. Owns `bearer_token` and `allowed_hosts`. */
+export function buildMcpConfig(current: Config, form: Record<string, unknown>): Config {
+    const hosts = str(form['auth.allowed_hosts'])
+        .split(',')
+        .map(h => h.trim())
+        .filter(h => h !== '');
+
+    return {
+        ...current,
+        auth: {
+            ...current.auth,
             bearer_token: on(form['auth.rotate_token'])
                 ? generateBearerToken()
                 : current.auth.bearer_token,
-            username: username === '' ? current.auth.username : username,
-            password_hash: carriedHash,
             allowed_hosts: hosts
-        },
-        services: current.services,
-        ...(imdb ? { metadata: { imdb: { enabled: true } } } : {})
+        }
     };
 }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -374,10 +374,12 @@ describe('the metadata block', () => {
     });
 
     /**
-     * IMDb publishes daily, so there is no second sensible interval to choose
-     * between. The setting a user is most likely to invent is therefore one
-     * that cannot mean anything — and silently ignoring it is worse than
-     * refusing it, because a user who sets it believes it took effect.
+     * There is no interval a user could choose that would serve them better
+     * than the weekly one — see `REFRESH_INTERVAL_MS`, which explains why the
+     * publish cadence is not the useful cadence. The setting a user is most
+     * likely to invent is therefore one that cannot help them, and silently
+     * ignoring it is worse than refusing it, because a user who sets it
+     * believes it took effect.
      */
     it('refuses a refresh interval, which is not a setting', () => {
         expect(() =>

--- a/test/configUi.test.ts
+++ b/test/configUi.test.ts
@@ -821,16 +821,127 @@ describe('removing an instance', () => {
     });
 });
 
+/**
+ * Three cards where there was one form, each saving only itself.
+ *
+ * The page had a single button at the bottom covering Config UI credentials,
+ * the IMDb dataset and the MCP endpoint at once — which read as a global save
+ * because it was the last thing on the page, while every service card above
+ * saved itself. Two save models on one page, and no way to tell which button
+ * owned what you had just typed.
+ *
+ * Splitting them introduces exactly one new way to be wrong, and it is a bad
+ * one: a form that no longer carries a field can look identical to a user
+ * clearing it. Saving the IMDb card must not wipe `allowed_hosts` just because
+ * that input is now on a different card, and saving the MCP card must not
+ * switch the dataset off. These tests exist for that, and each one failed
+ * against the naive split.
+ */
+describe('each access card saves only itself', () => {
+    /**
+     * A host worth pinning, and the reason every call below carries it.
+     *
+     * `app.request()` sends no `Host` header of its own, and a non-empty
+     * `allowed_hosts` rejects a request with no matching one — so a fixture
+     * that pins a host and then posts without setting it gets 403 on every
+     * save. The first draft did exactly that, and two of these tests passed
+     * anyway because they asserted values the failed save would have left
+     * alone. Hence `post`, and hence the explicit status assertion in it.
+     */
+    const PINNED = 'arr.example.com';
+
+    /**
+     * A config with all three cards' settings non-default at once, so a save
+     * that clobbers one is visible. Sign in *before* calling this: pinning
+     * locks out `/ui/login` too.
+     */
+    const withDataset = async () => {
+        await writeFile(
+            join(dir, 'config.yaml'),
+            `auth:\n  bearer_token: ${BEARER}\n  username: admin\n  password_hash: ${hashPassword(PASSWORD)}\n  allowed_hosts: [${PINNED}]\nservices: {}\nmetadata:\n  imdb:\n    enabled: true\n`,
+            'utf8'
+        );
+        await runtime.reload();
+    };
+
+    /** A save through the pinned host, asserting it was actually accepted —
+     *  without which every test here risks passing on a 403. */
+    const post = async (path: string, body: Record<string, string> = {}) => {
+        const page = await (await call('/ui/config', { headers: { host: PINNED } })).text();
+        const csrf = /name="csrf" value="([^"]+)"/.exec(page)?.[1] ?? '';
+
+        const res = await call(path, {
+            ...form({ csrf, ...body }),
+            headers: { 'content-type': 'application/x-www-form-urlencoded', host: PINNED }
+        });
+        expect(res.status).toBe(200);
+        return res;
+    };
+
+    const ready = async () => {
+        await signIn();
+        await withDataset();
+    };
+
+    it('saving the IMDb card leaves the pinned hosts and the token alone', async () => {
+        await ready();
+
+        await post('/ui/config/imdb', { 'metadata.imdb': 'on' });
+
+        expect(runtime.config.auth.allowed_hosts).toEqual([PINNED]);
+        expect(runtime.config.auth.bearer_token).toBe(BEARER);
+        expect(runtime.config.metadata?.imdb?.enabled).toBe(true);
+    });
+
+    it('saving the MCP card does not switch the dataset off', async () => {
+        await ready();
+
+        await post('/ui/config/mcp', { 'auth.allowed_hosts': PINNED });
+
+        expect(runtime.config.metadata?.imdb?.enabled).toBe(true);
+    });
+
+    it('saving the account card touches neither the dataset, the hosts nor the token', async () => {
+        await ready();
+
+        await post('/ui/config/account', { 'auth.username': 'someone-else' });
+
+        expect(runtime.config.auth.username).toBe('someone-else');
+        expect(runtime.config.metadata?.imdb?.enabled).toBe(true);
+        expect(runtime.config.auth.allowed_hosts).toEqual([PINNED]);
+        expect(runtime.config.auth.bearer_token).toBe(BEARER);
+    });
+
+    /** The dataset still has to be switchable *off*, which is the one case the
+     *  "absent means unchanged" rule above cannot express — so the IMDb card
+     *  reads its own checkbox as authoritative, and only its own. */
+    it('still switches the dataset off from its own card', async () => {
+        await ready();
+
+        await post('/ui/config/imdb');
+
+        expect(runtime.config.metadata).toBeUndefined();
+        expect(runtime.config.auth.allowed_hosts).toEqual([PINNED]);
+    });
+
+    it('gives each card its own button, and the page no button that spans them', async () => {
+        await signIn();
+        const page = await (await call('/ui/config')).text();
+
+        expect(page).toContain('/ui/config/account');
+        expect(page).toContain('/ui/config/imdb');
+        expect(page).toContain('/ui/config/mcp');
+        expect(page).not.toContain('Save access settings');
+    });
+});
+
 describe('access settings', () => {
     it('rotates the bearer token only when asked', async () => {
         await signIn();
-        await call('/ui/config/access', form({ csrf: await csrfFrom(), 'auth.username': 'admin' }));
+        await call('/ui/config/mcp', form({ csrf: await csrfFrom() }));
         expect(runtime.config.auth.bearer_token).toBe(BEARER);
 
-        await call(
-            '/ui/config/access',
-            form({ csrf: await csrfFrom(), 'auth.username': 'admin', 'auth.rotate_token': 'on' })
-        );
+        await call('/ui/config/mcp', form({ csrf: await csrfFrom(), 'auth.rotate_token': 'on' }));
         expect(runtime.config.auth.bearer_token).not.toBe(BEARER);
         expect(runtime.config.auth.bearer_token).toMatch(/^[0-9a-f]{64}$/);
     });
@@ -839,10 +950,7 @@ describe('access settings', () => {
     // or the old token keeps working until a restart.
     it('makes a rotated token effective immediately on /mcp', async () => {
         await signIn();
-        await call(
-            '/ui/config/access',
-            form({ csrf: await csrfFrom(), 'auth.username': 'admin', 'auth.rotate_token': 'on' })
-        );
+        await call('/ui/config/mcp', form({ csrf: await csrfFrom(), 'auth.rotate_token': 'on' }));
 
         const res = await app.request('http://localhost:6060/mcp', {
             method: 'POST',
@@ -860,7 +968,7 @@ describe('access settings', () => {
         await seed('  radarr:\n    url: http://192.0.2.10:7878\n    api_key: k\n');
         await signIn();
 
-        await call('/ui/config/access', form({ csrf: await csrfFrom(), 'auth.username': 'admin' }));
+        await call('/ui/config/account', form({ csrf: await csrfFrom(), 'auth.username': 'admin' }));
 
         expect(runtime.current.adapters.map(a => a.id)).toEqual(['radarr']);
     });
@@ -868,7 +976,7 @@ describe('access settings', () => {
     it('changes the password, and the old one stops working', async () => {
         await signIn();
         await call(
-            '/ui/config/access',
+            '/ui/config/account',
             form({ csrf: await csrfFrom(), 'auth.username': 'admin', 'auth.password': 'a-new-password' })
         );
 
@@ -879,7 +987,7 @@ describe('access settings', () => {
 
     it('leaves the password alone when the field is blank', async () => {
         await signIn();
-        await call('/ui/config/access', form({ csrf: await csrfFrom(), 'auth.username': 'admin', 'auth.password': '' }));
+        await call('/ui/config/account', form({ csrf: await csrfFrom(), 'auth.username': 'admin', 'auth.password': '' }));
 
         cookie = '';
         expect((await call('/ui/login', form({ username: 'admin', password: PASSWORD }))).status).toBe(302);
@@ -899,8 +1007,8 @@ describe('allowed_hosts', () => {
     it('applies a pinned host immediately, with no restart', async () => {
         await signIn();
         await call(
-            '/ui/config/access',
-            form({ csrf: await csrfFrom(), 'auth.username': 'admin', 'auth.allowed_hosts': 'arr.example.com' })
+            '/ui/config/mcp',
+            form({ csrf: await csrfFrom(), 'auth.allowed_hosts': 'arr.example.com' })
         );
 
         expect((await get('arr.example.com')).status).toBe(200);
@@ -912,8 +1020,8 @@ describe('allowed_hosts', () => {
     it('matches a pinned bare hostname when the request carries a port', async () => {
         await signIn();
         await call(
-            '/ui/config/access',
-            form({ csrf: await csrfFrom(), 'auth.username': 'admin', 'auth.allowed_hosts': 'arr.example.com' })
+            '/ui/config/mcp',
+            form({ csrf: await csrfFrom(), 'auth.allowed_hosts': 'arr.example.com' })
         );
 
         expect((await get('arr.example.com:6060')).status).toBe(200);
@@ -931,8 +1039,8 @@ describe('allowed_hosts', () => {
     it('locks out an unlisted host, and can be undone from a listed one', async () => {
         await signIn();
         await call(
-            '/ui/config/access',
-            form({ csrf: await csrfFrom(), 'auth.username': 'admin', 'auth.allowed_hosts': 'arr.example.com' })
+            '/ui/config/mcp',
+            form({ csrf: await csrfFrom(), 'auth.allowed_hosts': 'arr.example.com' })
         );
         expect((await get('other.example.com')).status).toBe(403);
 
@@ -941,8 +1049,8 @@ describe('allowed_hosts', () => {
 
         const page = await (await call('/ui/config', { headers: { host: 'arr.example.com' } })).text();
         const csrf = /name="csrf" value="([^"]+)"/.exec(page)?.[1] ?? '';
-        await call('/ui/config/access', {
-            ...form({ csrf, 'auth.username': 'admin', 'auth.allowed_hosts': '' }),
+        await call('/ui/config/mcp', {
+            ...form({ csrf, 'auth.allowed_hosts': '' }),
             headers: {
                 'content-type': 'application/x-www-form-urlencoded',
                 host: 'arr.example.com'
@@ -1156,10 +1264,7 @@ describe('the IMDb dataset in the config UI', () => {
      *  place, so a key nothing writes is a key that silently never persists. */
     it('writes the block to disk when switched on', async () => {
         await signIn();
-        await call(
-            '/ui/config/access',
-            form({ csrf: await csrfFrom(), 'auth.username': 'admin', 'metadata.imdb': 'on' })
-        );
+        await call('/ui/config/imdb', form({ csrf: await csrfFrom(), 'metadata.imdb': 'on' }));
 
         expect(await readFile(join(dir, 'config.yaml'), 'utf8')).toContain('metadata:');
         expect(runtime.config.metadata?.imdb?.enabled).toBe(true);
@@ -1173,7 +1278,7 @@ describe('the IMDb dataset in the config UI', () => {
     it('removes the block entirely when switched off', async () => {
         await seedWithDataset();
         await signIn();
-        await call('/ui/config/access', form({ csrf: await csrfFrom(), 'auth.username': 'admin' }));
+        await call('/ui/config/imdb', form({ csrf: await csrfFrom() }));
 
         const onDisk = await readFile(join(dir, 'config.yaml'), 'utf8');
         expect(onDisk).not.toContain('metadata:');

--- a/test/getLibrary.test.ts
+++ b/test/getLibrary.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { LibraryIndex, type IndexInput } from '../src/core/resolver.ts';
 import type { IdentityResolver } from '../src/core/identity.ts';
+import { ImdbDataset } from '../src/metadata/imdbDataset.ts';
 import { LibraryLoader } from '../src/tools/library.ts';
 import { buildGetLibrary } from '../src/tools/getLibrary.ts';
 import type { ServiceAdapter } from '../src/services/types.ts';
@@ -416,6 +417,86 @@ describe('series ratings, once the dataset can supply them', () => {
  */
 const rated = (title: string, imdb: number, over: Partial<IndexInput> = {}): IndexInput =>
     film({ title, ids: { tmdb: title.length * 977 + Math.round(imdb * 10) }, ratings: { imdb }, ...over });
+
+/**
+ * The bug a user actually hit: they asked for their series' IMDb scores, every
+ * one came back unrated, and nothing anywhere said why.
+ *
+ * `ratingCoverage` already reported "0 rated, 40 unrated", which is true and
+ * useless — it reads as "your library has no good series" rather than "the one
+ * thing that could answer this is switched off". A model handed that number
+ * reasonably concludes the question cannot be answered, which is what it told
+ * them.
+ *
+ * The distinction worth drawing is three-way, because the remedies differ: not
+ * enabled (turn it on), enabled but still ingesting (wait), and genuinely
+ * covering nothing (a real answer about a real library).
+ */
+describe('explaining an imdb rating nothing could supply', () => {
+    const loaderWith = (dataset: ImdbDataset | undefined, items: IndexInput[]) =>
+        new LibraryLoader([stub('sonarr', items), jellyfinStub()], healthyJellyfinIdentity, undefined, dataset);
+
+    let db: ImdbDataset | undefined;
+    afterEach(() => {
+        db?.close();
+        db = undefined;
+    });
+
+    const seriesQuery = { ...base, kind: 'series' as const, rating_source: 'imdb' as const, min_rating: 1 };
+
+    it('names the dataset when it is off and nothing carries an imdb rating', async () => {
+        const result = await buildGetLibrary(loaderWith(undefined, [series()]), seriesQuery);
+
+        expect(result.ratingCoverage).toMatchObject({ source: 'imdb', rated: 0, unrated: 1 });
+        expect(result.ratingCoverage?.note).toMatch(/not enabled/i);
+        // The remedy has to be findable, not merely implied.
+        expect(result.ratingCoverage?.note).toContain('metadata.imdb.enabled');
+    });
+
+    /** Enabled but empty is a wait, not a config change — and saying "turn it
+     *  on" to someone who already did would send them in a circle. */
+    it('says to wait when the dataset is on but has not ingested yet', async () => {
+        db = ImdbDataset.ephemeral();
+        const result = await buildGetLibrary(loaderWith(db, [series()]), seriesQuery);
+
+        expect(result.ratingCoverage?.note).toMatch(/still|not finished|ingest/i);
+        expect(result.ratingCoverage?.note).not.toMatch(/not enabled/i);
+    });
+
+    /** A real answer about a real library gets no excuse attached to it. */
+    it('says nothing when the dataset is ingested and simply does not know these titles', async () => {
+        db = ImdbDataset.ephemeral();
+        db.replaceAll({
+            titles: [{ tconst: 'tt0000009', kind: 'tvSeries', title: 'Something Else' }],
+            ratings: [{ tconst: 'tt0000009', average: 7, votes: 10 }]
+        });
+
+        const result = await buildGetLibrary(loaderWith(db, [series()]), seriesQuery);
+
+        expect(result.ratingCoverage).toMatchObject({ rated: 0 });
+        expect(result.ratingCoverage?.note).toBeUndefined();
+    });
+
+    /** Coverage that speaks for itself needs no note, however partial. */
+    it('says nothing when at least one item is rated', async () => {
+        const items = [series({ ratings: { imdb: 9.5 } }), series({ title: 'Other', ids: { tvdb: 1, imdb: 'tt1' } })];
+        const result = await buildGetLibrary(loaderWith(undefined, items), seriesQuery);
+
+        expect(result.ratingCoverage).toMatchObject({ rated: 1, unrated: 1 });
+        expect(result.ratingCoverage?.note).toBeUndefined();
+    });
+
+    /** Films reach IMDb through Radarr, so an off dataset is not the whole
+     *  story — but it is still the only thing that would fill the gap. */
+    it('explains a film query that found no imdb ratings too', async () => {
+        const result = await buildGetLibrary(
+            new LibraryLoader([stub('radarr', [film()]), jellyfinStub()], healthyJellyfinIdentity),
+            { ...base, kind: 'movie', rating_source: 'imdb', min_rating: 1 }
+        );
+
+        expect(result.ratingCoverage?.note).toMatch(/not enabled/i);
+    });
+});
 
 describe('ordering', () => {
     it('orders before truncating, so the top result survives the limit', async () => {

--- a/test/imdbLifecycle.test.ts
+++ b/test/imdbLifecycle.test.ts
@@ -1,0 +1,171 @@
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { loadConfig } from '../src/config/load.ts';
+import { WriteAudit } from '../src/core/audit.ts';
+import { Runtime } from '../src/core/runtime.ts';
+import type { ImdbDataset } from '../src/metadata/imdbDataset.ts';
+
+/**
+ * Who keeps the dataset *fresh*, and when.
+ *
+ * Opening `imdb.db` and ingesting into it are two different things, and through
+ * 1.1 only the first followed the config. `startRefresh` was called once, at
+ * startup, from `src/index.ts` — so ticking the box in the config UI opened an
+ * empty database that nothing ever filled, and every rating stayed missing
+ * until someone restarted the container. That failure is indistinguishable from
+ * the feature not working: `get_library` reports "0 rated" either way.
+ *
+ * The refresher is injected rather than imported, so these run without a
+ * network and without waiting a day for an interval — and so `Runtime` keeps
+ * the property its own doc comment claims, that constructing one never reaches
+ * the network unless the caller asked for it.
+ */
+
+const BEARER = 'a'.repeat(64);
+
+let dir: string;
+let audit: WriteAudit;
+
+/** Every dataset the refresher was handed, and whether it has been stopped. */
+type Started = { dataset: ImdbDataset; stopped: boolean };
+
+const spy = (): { started: Started[]; refresh: (d: ImdbDataset) => () => void } => {
+    const started: Started[] = [];
+    return {
+        started,
+        refresh: (dataset: ImdbDataset) => {
+            const record: Started = { dataset, stopped: false };
+            started.push(record);
+            return () => {
+                record.stopped = true;
+            };
+        }
+    };
+};
+
+const write = async (imdb: boolean): Promise<void> => {
+    await writeFile(
+        join(dir, 'config.yaml'),
+        `auth:\n  bearer_token: ${BEARER}\n  username: admin\n  allowed_hosts: []\nservices: {}\n` +
+            (imdb ? 'metadata:\n  imdb:\n    enabled: true\n' : ''),
+        'utf8'
+    );
+};
+
+const runtimeFrom = async (opts: { refresh: (d: ImdbDataset) => () => void }): Promise<Runtime> => {
+    const { config } = await loadConfig(dir);
+    return Runtime.fromConfig(config, audit, { configDir: dir, refresh: opts.refresh });
+};
+
+beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'arr-mcp-imdb-life-'));
+    audit = WriteAudit.ephemeral();
+});
+
+afterEach(() => {
+    audit.close();
+});
+
+describe('the IMDb refresh follows the config', () => {
+    /** The reported bug, as a test. */
+    it('starts refreshing when the dataset is switched on by a reload', async () => {
+        await write(false);
+        const { started, refresh } = spy();
+        const runtime = await runtimeFrom({ refresh });
+
+        expect(started).toHaveLength(0);
+        expect(runtime.dataset).toBeUndefined();
+
+        await write(true);
+        await runtime.reload();
+
+        expect(runtime.dataset).toBeDefined();
+        expect(started).toHaveLength(1);
+        // The refresh must be pointed at the database that was just opened,
+        // not at some other one — filling a dataset nothing reads is the same
+        // bug wearing a different hat.
+        expect(started[0]?.dataset).toBe(runtime.dataset);
+    });
+
+    it('stops refreshing when the dataset is switched off', async () => {
+        await write(true);
+        const { started, refresh } = spy();
+        const runtime = await runtimeFrom({ refresh });
+        expect(started).toHaveLength(1);
+
+        await write(false);
+        await runtime.reload();
+
+        expect(runtime.dataset).toBeUndefined();
+        expect(started[0]?.stopped).toBe(true);
+    });
+
+    /**
+     * The common case on reload, and the one that would leak. Every unrelated
+     * config save — a timeout, a permission — reloads the runtime; if each
+     * started another refresh, a day of editing would leave a stack of timers
+     * all downloading 223 MB on the same schedule.
+     */
+    it('does not start a second refresh when the answer has not changed', async () => {
+        await write(true);
+        const { started, refresh } = spy();
+        const runtime = await runtimeFrom({ refresh });
+
+        await runtime.reload();
+        await runtime.reload();
+
+        expect(started).toHaveLength(1);
+        expect(started[0]?.stopped).toBe(false);
+    });
+
+    it('starts one refresh when the dataset is already on at startup', async () => {
+        await write(true);
+        const { started, refresh } = spy();
+        const runtime = await runtimeFrom({ refresh });
+
+        expect(runtime.dataset).toBeDefined();
+        expect(started).toHaveLength(1);
+    });
+
+    it('never refreshes when the dataset is off', async () => {
+        await write(false);
+        const { started, refresh } = spy();
+        const runtime = await runtimeFrom({ refresh });
+
+        expect(runtime.dataset).toBeUndefined();
+        expect(started).toHaveLength(0);
+    });
+
+    /**
+     * Off, then on again. The stopped refresher must not be reused — a cleared
+     * interval does not restart, so carrying the old stop function forward
+     * would leave the second dataset with nothing refreshing it.
+     */
+    it('starts a fresh refresh when the dataset is switched off and on again', async () => {
+        await write(true);
+        const { started, refresh } = spy();
+        const runtime = await runtimeFrom({ refresh });
+
+        await write(false);
+        await runtime.reload();
+        await write(true);
+        await runtime.reload();
+
+        expect(started).toHaveLength(2);
+        expect(started[0]?.stopped).toBe(true);
+        expect(started[1]?.stopped).toBe(false);
+        expect(started[1]?.dataset).toBe(runtime.dataset);
+    });
+
+    /** The default. Nothing that does not ask for a refresher gets a download. */
+    it('does not refresh at all when no refresher was supplied', async () => {
+        await write(true);
+        const { config } = await loadConfig(dir);
+        const runtime = Runtime.fromConfig(config, audit, { configDir: dir });
+
+        expect(runtime.dataset).toBeDefined();
+        await expect(runtime.reload()).resolves.toBeUndefined();
+    });
+});


### PR DESCRIPTION
Reported as *"I tried to get TV show IMDb scores from my library from Seerr, but that wasn't possible."*

It genuinely was not possible, and four separate things had to be wrong for that to be true. For a series, the IMDb dataset is the **only** source of an IMDb rating — Seerr's `/tv/{id}/ratings` is Rotten Tomatoes only (the combined endpoint carrying the IMDb half exists for films alone, upstream), and Sonarr's flat rating can only honestly be recorded as `tvdb`.

## 1. The dataset never ingested unless the container restarted

`startRefresh` was called once, at startup, from `src/index.ts`. `Runtime` opened and closed `imdb.db` to follow the config but never refreshed it — so ticking the box in the config UI opened an empty database that nothing ever filled, and every rating stayed missing until someone restarted. That is indistinguishable from the feature not working: `get_library` reports "0 rated" either way.

`Runtime#syncDataset` now starts the refresh as it opens the database and stops it as it closes. The refresher is injected rather than imported, so `Runtime` keeps the property its own doc comment claimed — constructing one never reaches the network unless the caller asked.

`test/imdbLifecycle.test.ts` covers switch-on-by-reload, switch-off, off-then-on, and the one that would have leaked: an unrelated config save must not stack up a second timer.

## 2. Zero was reported without its reason

`ratingCoverage` said `{ source: 'imdb', rated: 0, unrated: 40 }`. True, and useless — it reads as *your series are unrated* rather than *the only thing that can answer this is switched off*. A model handed that number reasonably concludes the question cannot be answered, which is what it told the user.

Adds `ratingCoverage.note`, separating three cases that all arrived as zero:

| state | note |
| --- | --- |
| dataset off | names `metadata.imdb.enabled`, and says this is a gap in what the server can look up |
| enabled, still ingesting | says to wait — no config change needed |
| ingested, doesn't know these titles | **no note** — that is a real answer about a real library |

Only ever attached to a zero; a partial count speaks for itself.

## 3. The docs buried the one thing it uniquely does

The config card led with "most stacks do not need this" and put the series case halfway through the second paragraph. README, config card, dashboard panel and the `get_library` description now say it plainly.

## 4. Refresh drops from daily to weekly

This holds average ratings for titles that already exist, and an average over millions of votes moves by hundredths across a year — nightly spent 6.5 GB a month to return the same answers. Weekly is under a gigabyte.

**Trade-off, stated rather than hidden:** a title IMDb published in the last week may not be there yet, so a brand-new release can be missing from `discover_media` and a series added the day it premiered goes without an IMDb rating until the next refresh.

## Also: the config page had two save models at once

One button covered Config UI credentials, the IMDb dataset and the MCP endpoint. By sitting last on the page it read as a global save, while every service card above saved itself.

Now three self-contained cards, one route each. Splitting introduces exactly one new hazard — a form that no longer *carries* a field looks identical to a user clearing it — so each builder carries forward the config it does not own. The naive split wiped `allowed_hosts` when saving the IMDb card; there is a test per way of getting that wrong.

Two of those tests initially passed while proving nothing: the fixture pinned a host that Hono's `app.request()` never sends, so every save 403'd and the assertions checked values the failed save had left alone. Caught by asserting the status, and the fixture now documents why.

## Versioning

`feat:` because `ratingCoverage.note` is a new response field, which CONTRIBUTING calls a minor. Nothing is removed from the tool surface — no tool, parameter or response field. `POST /ui/config/access` becomes `/account`, `/imdb` and `/mcp`, which is internal to the config UI.

## Gates

All three green locally:

```
npm run lint       # clean
npm run typecheck  # clean
npm test           # 1223 passed (60 files)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
