### PR TITLE
fix: reclaim leaked staging dirs, and take the IMDb dataset to 81 MB

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,18 +385,30 @@ IMDb's published files and keeps them in a local SQLite database beside the
 audit log. The first ingest takes a few minutes; every tool answers exactly as
 it did before until it lands, and the dashboard says when it has finished.
 
-**It costs real disk.** Measured against the live dumps on 2026-08-08:
+**It costs real disk.** Measured against the live dumps on 2026-08-10:
 
 | | |
 | --- | --- |
 | Download, per refresh | **223 MB** |
 | Refreshed | **weekly** |
-| On disk | **~125 MB** |
+| On disk | **~81 MB** |
 | First ingest | ~3 minutes |
-| Titles stored / rated | 546K / 1.7M |
+| Titles stored / rated | 809K / 809K |
 
-Only rated titles of a kind something can actually query are stored — the other
-12 million rows are episodes, shorts and video games no query can reach.
+Only rated titles of a kind something can actually reach are stored — the other
+12 million rows are episodes and video games no query can touch. The two tables
+now hold the same set of ids: a rating is kept exactly when its title is, which
+is what took `rating` from 1.7M rows to 809K.
+
+The on-disk figure is what a running server actually leaves behind. It used to
+be ~125 MB, and three changes account for the difference — both tables are
+`WITHOUT ROWID` (each keyed on `tconst` alone, so the old layout stored every id
+twice), ratings with no stored title are pruned, and the database is vacuumed
+after each replace so freed pages go back to the OS rather than leaving the file
+at its high-water mark for ever. That last one is also why the number is now
+honest: the old ~125 MB was measured post-`VACUUM` by the script, and no live
+install ever reached it.
+
 Re-measure with `node --experimental-strip-types scripts/measure-imdb.ts`; the
 dumps grow, and a figure in a README is only as good as the day it was taken.
 

--- a/scripts/measure-imdb.ts
+++ b/scripts/measure-imdb.ts
@@ -50,18 +50,24 @@ try {
     const status = dataset.status();
     dataset.close();
 
-    // Checkpointed and vacuumed, so this is what the file settles at rather
-    // than what it peaked at mid-write.
+    // What the running server actually leaves behind, measured before this
+    // script touches anything. `replaceAll` vacuums for itself now, so this is
+    // the honest figure — it used to be measured only after the VACUUM below,
+    // which meant the README quoted a size no live install ever reached.
+    const asLeft = onDisk(dir);
+
+    // Checkpointing folds the WAL back in. Kept because the WAL is real disk
+    // the server occupies between refreshes, and worth reporting separately.
     const db = new Database(join(dir, IMDB_FILENAME));
     db.pragma('wal_checkpoint(TRUNCATE)');
-    db.exec('VACUUM');
     db.close();
 
     console.log('\n--- measured ---');
     console.log('titles              ', status.titles.toLocaleString('en'));
     console.log('rated               ', status.ratings.toLocaleString('en'));
     console.log('ingest wall clock   ', `${seconds}s`);
-    console.log('on disk             ', mb(onDisk(dir)));
+    console.log('on disk, as left    ', mb(asLeft));
+    console.log('on disk, checkpointed', mb(onDisk(dir)));
 } finally {
     // Best effort: Windows can still hold the SQLite file briefly after close,
     // and failing to tidy a temp directory must not lose the measurement that

--- a/src/metadata/imdbDataset.ts
+++ b/src/metadata/imdbDataset.ts
@@ -35,18 +35,35 @@ const KIND_TO_IMDB: Record<'movie' | 'series', readonly string[]> = {
 };
 
 /**
- * The only title types any query can reach, so the only ones worth storing.
+ * Types an *arr can plausibly be managing that `discover` deliberately does
+ * not offer.
  *
- * IMDb's 12.7M rows are mostly `tvEpisode`, plus shorts, video games and adult
- * titles — none of which `discover` can return and none of which carry a rating
- * anyone looks up here. Filtering at ingest rather than at query time is the
- * difference between a 1.3 GB database and a small one.
- *
- * Derived from `KIND_TO_IMDB` rather than written out again: two lists would
- * drift, and the failure would be silent — a kind you can ask for that was
- * never stored just returns nothing.
+ * A direct-to-video film is `video`, a stand-up or holiday special is
+ * `tvSpecial`, and a short film Radarr has is `tvShort` or `short`. Nobody
+ * browsing "films from 1994" wants these mixed in, so they stay out of
+ * `KIND_TO_IMDB` — but somebody who *owns* one still deserves its rating, and
+ * `ratingsFor` reaches titles by id without going through `discover`'s
+ * vocabulary at all.
  */
-const STORED_KINDS: ReadonlySet<string> = new Set(Object.values(KIND_TO_IMDB).flat());
+const ALSO_STORED = ['video', 'tvSpecial', 'tvShort', 'short'] as const;
+
+/**
+ * Every title type worth *storing*, which is deliberately more than every type
+ * `discover` can *return*.
+ *
+ * IMDb's 12.7M rows are mostly `tvEpisode`, plus video games and adult titles
+ * — none of which anything here can reach. Filtering at ingest rather than at
+ * query time is the difference between a 1.3 GB database and a small one.
+ *
+ * This was `KIND_TO_IMDB` flattened, on the reasoning that two lists would
+ * drift. They are two questions, though, and conflating them only looked free
+ * while the `rating` table was unfiltered: ratings for unstored titles were
+ * what kept a direct-to-video film rated. Pruning those orphans — two thirds
+ * of the table — takes that prop away, so what a lookup may hit has to be
+ * stated separately from what a browse may return. The pair is covered by
+ * tests that a stored-but-not-discoverable kind stays out of `discover`.
+ */
+const STORED_KINDS: ReadonlySet<string> = new Set([...Object.values(KIND_TO_IMDB).flat(), ...ALSO_STORED]);
 
 /**
  * SQLite's compiled-in default variable limit, minus room to spare.
@@ -80,6 +97,17 @@ export type DatasetTitle = {
 
 export type DatasetStatus = { ingestedAt?: string; titles: number; ratings: number };
 
+/**
+ * `WITHOUT ROWID` on both big tables.
+ *
+ * Each keys on `tconst` and nothing else, so the default layout stored every
+ * id twice — once in the rowid btree holding the row, and again in the
+ * implicit unique index enforcing the primary key. `WITHOUT ROWID` puts the
+ * row in the key's own btree and drops the second copy. The rows here are
+ * small and the key is most of them, which is exactly the shape it is for.
+ *
+ * `meta` holds two rows and is left alone; the pragma would be noise.
+ */
 const SCHEMA = `
 CREATE TABLE IF NOT EXISTS title (
     tconst  TEXT PRIMARY KEY,
@@ -88,12 +116,12 @@ CREATE TABLE IF NOT EXISTS title (
     year    INTEGER,
     runtime INTEGER,
     genres  TEXT
-);
+) WITHOUT ROWID;
 CREATE TABLE IF NOT EXISTS rating (
     tconst  TEXT PRIMARY KEY,
     average REAL    NOT NULL,
     votes   INTEGER NOT NULL
-);
+) WITHOUT ROWID;
 CREATE TABLE IF NOT EXISTS meta (
     key   TEXT PRIMARY KEY,
     value TEXT NOT NULL
@@ -110,11 +138,44 @@ export class ImdbDataset {
         // tool calls read, and a reader must never block on a twenty-minute
         // rebuild.
         this.#db.pragma('journal_mode = WAL');
+        this.#dropSuperseded();
         this.#db.exec(SCHEMA);
-        // Written through 1.0 and never read by a single query — 52 MB a day and
-        // millions of rows for a table nothing consulted. Dropped on open so an
-        // existing database reclaims the space rather than carrying it forever.
+    }
+
+    /**
+     * Throw away what an older version left that this one cannot use.
+     *
+     * Both cases are **drops, not migrations**, and the module header is the
+     * licence for that: this is a cache that is wholly replaced every week and
+     * can be deleted at any moment without losing anything a user typed.
+     * Losing it costs a download. Writing migration code for it would be
+     * carrying a liability to avoid a cost nobody pays — and `Runtime` starts
+     * a refresh the moment it opens the database, so the refill is immediate.
+     *
+     * - `episode` was written through 1.0 and never read by a single query —
+     *   52 MB a day and millions of rows for a table nothing consulted.
+     * - `title` and `rating` predating `WITHOUT ROWID` cannot be changed in
+     *   place: `CREATE TABLE IF NOT EXISTS` is a no-op against a table that
+     *   already exists, so without this an existing `imdb.db` would keep the
+     *   old layout for ever and quietly never get the saving.
+     */
+    #dropSuperseded(): void {
         this.#db.exec('DROP INDEX IF EXISTS episode_parent; DROP TABLE IF EXISTS episode;');
+
+        const legacy = this.#db
+            .prepare(
+                `SELECT name FROM sqlite_master
+                  WHERE type = 'table' AND name IN ('title', 'rating')
+                    AND sql NOT LIKE '%WITHOUT ROWID%'`
+            )
+            .all() as { name: string }[];
+
+        if (legacy.length === 0) return;
+
+        // `meta` goes too, and it matters: it holds `ingested_at`, and leaving
+        // it would have `status()` report a date for rows that no longer
+        // exist — the dashboard claiming a fresh dataset over an empty one.
+        this.#db.exec('DROP TABLE IF EXISTS title; DROP TABLE IF EXISTS rating; DROP TABLE IF EXISTS meta;');
     }
 
     static open(dir: string): ImdbDataset {
@@ -270,7 +331,27 @@ export class ImdbDataset {
             // the mistake that crashed the first real ingest.
             this.#db.exec('DELETE FROM title WHERE tconst NOT IN (SELECT tconst FROM rating)');
 
+            // And the mirror image, which is the larger half: `rating` arrives
+            // unfiltered, so it carried a row for every episode, video game and
+            // short IMDb has ever rated — 1.7M rows against 546K titles. After
+            // this the two tables hold the same set of ids.
+            //
+            // Safe only because `ALSO_STORED` widened what a title *is*: these
+            // orphans were what kept a direct-to-video film rated back when
+            // `ratingsFor` could reach a rating whose title was never stored.
+            this.#db.exec('DELETE FROM rating WHERE tconst NOT IN (SELECT tconst FROM title)');
+
             setMeta.run('ingested_at', new Date().toISOString());
         })();
+
+        // Outside the transaction, because VACUUM cannot run inside one.
+        //
+        // SQLite does not hand freed pages back to the OS by itself, so a
+        // replace left the file at its high-water mark for ever — and every
+        // replace frees the entire previous dataset. The ~125 MB the README
+        // quoted was a number only `measure-imdb.ts` ever saw, because it
+        // vacuumed afterwards and the running server never did. Costs a full
+        // rewrite once a week, on a file that has just been rewritten anyway.
+        this.#db.exec('VACUUM');
     }
 }

--- a/src/metadata/refresh.ts
+++ b/src/metadata/refresh.ts
@@ -1,4 +1,4 @@
-import { closeSync, createWriteStream, mkdtempSync, openSync, readSync, rmSync } from 'node:fs';
+import { closeSync, createWriteStream, mkdtempSync, openSync, readdirSync, readSync, rmSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Readable } from 'node:stream';
@@ -38,6 +38,76 @@ export const IMDB_BASE_URL = 'https://datasets.imdbws.com';
  * that cannot help can still be set wrong.
  */
 export const REFRESH_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * What every staging directory is named, and nothing else is.
+ *
+ * Exported so the sweep and the thing it sweeps cannot drift apart: two
+ * spellings of this would mean either cleaning up nothing or cleaning up
+ * somebody else's directory, and both fail silently.
+ */
+export const STAGING_PREFIX = 'arr-mcp-imdb-';
+
+/**
+ * How long a staging directory must have gone untouched before it counts as
+ * abandoned rather than in use.
+ *
+ * An ingest takes minutes, so a day is a hundredfold margin. The gate exists
+ * because a *young* staging directory is the only evidence available that
+ * another process — a second container sharing /tmp, or `measure-imdb.ts` —
+ * is still writing to it, and deleting a running ingest's dumps out from
+ * under it would turn a slow disk leak into a broken refresh.
+ */
+const ABANDONED_AFTER_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Remove staging directories that an earlier run never got to remove itself.
+ *
+ * `ingestOnce` cleans up in a `finally`, which covers a failed download and a
+ * failed parse but **not** the process being killed — and that is the failure
+ * this project has actually had. The first real ingest was OOM-killed, and
+ * days later 661 MB of `title.basics.tsv` was still sitting in the OS temp
+ * directory. At a weekly refresh that leaks slowly enough that nobody notices
+ * until a disk is full.
+ *
+ * Returns how many it removed, and **never throws**: this is housekeeping in
+ * front of the download that is the actual point, so a permission error or a
+ * directory that vanished mid-scan must not take the refresh down with it.
+ */
+export function sweepStaging(root: string, opts: { now?: number } = {}): number {
+    const now = opts.now ?? Date.now();
+    let removed = 0;
+
+    let entries: string[];
+    try {
+        entries = readdirSync(root);
+    } catch {
+        // No temp directory, or not readable. Nothing to clean, and nothing
+        // worth failing a refresh over.
+        return 0;
+    }
+
+    for (const name of entries) {
+        if (!name.startsWith(STAGING_PREFIX)) continue;
+
+        const path = join(root, name);
+        try {
+            const stat = statSync(path);
+            // A plain file that happens to match is not ours: staging is
+            // always a directory, and deleting an unrelated file on a name
+            // collision would be a real bug rather than a tidy-up.
+            if (!stat.isDirectory()) continue;
+            if (now - stat.mtimeMs < ABANDONED_AFTER_MS) continue;
+
+            rmSync(path, { recursive: true, force: true });
+            removed += 1;
+        } catch (err) {
+            logger.warn({ path, err }, 'could not remove an abandoned IMDb staging directory');
+        }
+    }
+
+    return removed;
+}
 
 /**
  * Download one dump, decompressed, **to a file** — never into memory.
@@ -108,7 +178,14 @@ export function* linesOf(path: string): Generator<string> {
 export async function ingestOnce(dataset: ImdbDataset, opts: { baseUrl?: string } = {}): Promise<void> {
     const baseUrl = opts.baseUrl ?? IMDB_BASE_URL;
     const started = Date.now();
-    const staging = mkdtempSync(join(tmpdir(), 'arr-mcp-imdb-'));
+
+    // Before staging our own, not after: this is the moment we are about to
+    // ask for another ~700 MB of temp space, so it is the moment worth
+    // reclaiming what a killed predecessor left behind.
+    const swept = sweepStaging(tmpdir());
+    if (swept > 0) logger.info({ swept }, 'removed abandoned IMDb staging directories');
+
+    const staging = mkdtempSync(join(tmpdir(), STAGING_PREFIX));
 
     try {
         const titlesFile = join(staging, 'title.basics.tsv');

--- a/src/web/configPage.ts
+++ b/src/web/configPage.ts
@@ -474,7 +474,7 @@ export function configPage(opts: {
                 ratings to keep working while Seerr is down.
             </p>
             <p class="note">
-                <strong>About 125 MB on disk, and a 223 MB download each week.</strong> Refreshed weekly
+                <strong>About 81 MB on disk, and a 223 MB download each week.</strong> Refreshed weekly
                 rather than daily: an average over millions of votes barely moves, so a nightly re-download
                 spent 6.5 GB a month to change third decimal places. The cost is that a title published in
                 the last week may not be there yet. The first ingest takes a few minutes; everything keeps

--- a/src/web/pages.ts
+++ b/src/web/pages.ts
@@ -245,7 +245,7 @@ const imdbPanel = (status: DatasetStatus): SafeHtml => html`<h2>IMDb dataset</h2
             : html`<p class="note">
                       A fallback for ratings when Seerr is not configured or not answering — and the only
                       source of an <strong>IMDb rating for a series</strong>, which no service in this stack
-                      reports. Refreshed weekly — about 223 MB down, roughly 125 MB on disk. Nothing here is
+                      reports. Refreshed weekly — about 223 MB down, roughly 81 MB on disk. Nothing here is
                       sent anywhere.
                   </p>
                   <table>

--- a/test/imdbDataset.test.ts
+++ b/test/imdbDataset.test.ts
@@ -133,6 +133,78 @@ describe('discovering from the dataset', () => {
     });
 });
 
+/**
+ * Three changes made to get the file down, and the coverage each one must not
+ * cost. `rating` held 1.7M rows against `title`'s 546K, so two thirds of it
+ * was rows for titles that were filtered out at ingest.
+ */
+describe('keeping the file small', () => {
+    /**
+     * The saving. Ratings for titles nothing stores are the bulk of the table
+     * — episodes above all, at roughly ten million rows.
+     */
+    it('drops a rating for a title it did not store', () => {
+        db = ImdbDataset.ephemeral();
+        db.replaceAll({
+            titles: [
+                { tconst: 'tt1', kind: 'tvEpisode', title: 'An Episode' },
+                { tconst: 'tt2', kind: 'movie', title: 'A Film' }
+            ],
+            ratings: [
+                { tconst: 'tt1', average: 9, votes: 10 },
+                { tconst: 'tt2', average: 8, votes: 10 }
+            ]
+        });
+
+        expect(db.status().ratings).toBe(1);
+        expect(db.ratingsFor(['tt1']).size).toBe(0);
+    });
+
+    /**
+     * The coverage that pruning would otherwise have cost, and the reason
+     * `STORED_KINDS` is no longer just `KIND_TO_IMDB` flattened.
+     *
+     * `ratingsFor` looks up by tconst without joining `title`, so before the
+     * prune these were rated purely because the rating table was unfiltered.
+     * Delete the orphans without widening what is stored and a direct-to-video
+     * film in Radarr, or a stand-up special in Sonarr, silently loses its
+     * rating — which reads as "unrated" and is indistinguishable from a title
+     * IMDb has never heard of.
+     */
+    it.each(['video', 'tvSpecial', 'tvShort'])('still rates a %s, which an *arr can manage', kind => {
+        db = ImdbDataset.ephemeral();
+        db.replaceAll({
+            titles: [{ tconst: 'tt9', kind, title: 'Something An Arr Has' }],
+            ratings: [{ tconst: 'tt9', average: 7.7, votes: 900 }]
+        });
+
+        expect(db.ratingsFor(['tt9']).get('tt9')).toBe(7.7);
+    });
+
+    /**
+     * Stored is not the same as discoverable, which is the whole point of
+     * splitting the two lists. `discover` still offers exactly the vocabulary
+     * `get_library` speaks, so widening storage must not start returning
+     * direct-to-video results to someone browsing films.
+     */
+    it('does not offer the extra stored kinds through discover', () => {
+        db = ImdbDataset.ephemeral();
+        db.replaceAll({
+            titles: [
+                { tconst: 'tt9', kind: 'video', title: 'Straight To Video' },
+                { tconst: 'tt8', kind: 'movie', title: 'A Real Film' }
+            ],
+            ratings: [
+                { tconst: 'tt9', average: 7.7, votes: 900 },
+                { tconst: 'tt8', average: 8.1, votes: 900 }
+            ]
+        });
+
+        expect(db.discover({ kind: 'movie', limit: 10 }).map(h => h.tconst)).toEqual(['tt8']);
+    });
+
+});
+
 describe('status', () => {
     it('reports what it holds, for the dashboard', () => {
         const s = seed().status();

--- a/test/imdbDatasetFile.test.ts
+++ b/test/imdbDatasetFile.test.ts
@@ -1,0 +1,131 @@
+import Database from 'better-sqlite3';
+import { mkdtempSync, rmSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { IMDB_FILENAME, ImdbDataset } from '../src/metadata/imdbDataset.ts';
+
+/**
+ * The parts of the store that only a real file can show: the physical schema,
+ * the rebuild that gets an existing database onto it, and whether the file
+ * actually gives space back.
+ *
+ * Everything else about this class is tested in `imdbDataset.test.ts` against
+ * an in-memory database, which is faster and says the same thing about SQL. It
+ * cannot say anything about bytes on disk.
+ */
+
+let dir: string;
+let db: ImdbDataset | undefined;
+
+beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'arr-mcp-dbfile-'));
+});
+
+afterEach(() => {
+    try {
+        db?.close();
+    } catch {
+        // Already closed by the test.
+    }
+    db = undefined;
+    rmSync(dir, { recursive: true, force: true, maxRetries: 3 });
+});
+
+const path = (): string => join(dir, IMDB_FILENAME);
+
+/** The `CREATE TABLE` SQLite actually stored, read without the class. */
+const schemaOf = (table: string): string => {
+    const raw = new Database(path(), { readonly: true });
+    try {
+        const row = raw.prepare('SELECT sql FROM sqlite_master WHERE name = ?').get(table) as
+            | { sql: string }
+            | undefined;
+        return row?.sql ?? '';
+    } finally {
+        raw.close();
+    }
+};
+
+const rows = (count: number) => ({
+    titles: Array.from({ length: count }, (_, i) => ({
+        tconst: `tt${i}`,
+        kind: 'movie',
+        title: `Film number ${i} with a title long enough to occupy real pages`,
+        year: 2000,
+        genres: 'Drama,Crime,Thriller'
+    })),
+    ratings: Array.from({ length: count }, (_, i) => ({ tconst: `tt${i}`, average: 7, votes: 100 }))
+});
+
+describe('the physical schema', () => {
+    /**
+     * Both tables key on `tconst` and nothing else, so the default rowid btree
+     * plus the implicit unique index on the key stored every id twice.
+     */
+    it.each(['title', 'rating'])('stores %s without a redundant rowid index', table => {
+        db = ImdbDataset.open(dir);
+        expect(schemaOf(table)).toContain('WITHOUT ROWID');
+    });
+
+    /**
+     * `CREATE TABLE IF NOT EXISTS` cannot change a table that already exists,
+     * so an `imdb.db` written by an earlier version would keep the old layout
+     * forever and quietly never get the saving.
+     *
+     * Rebuilt rather than migrated, because this is a cache: losing it costs a
+     * download, not data — the module has said so since it was written — and
+     * the refresh that follows startup refills it immediately.
+     */
+    it('rebuilds a database still carrying the old rowid schema', () => {
+        const legacy = new Database(path());
+        legacy.exec(`
+            CREATE TABLE title (tconst TEXT PRIMARY KEY, kind TEXT NOT NULL, title TEXT NOT NULL,
+                                year INTEGER, runtime INTEGER, genres TEXT);
+            CREATE TABLE rating (tconst TEXT PRIMARY KEY, average REAL NOT NULL, votes INTEGER NOT NULL);
+        `);
+        legacy.prepare('INSERT INTO rating VALUES (?, ?, ?)').run('tt0903747', 9.5, 100);
+        legacy.close();
+
+        db = ImdbDataset.open(dir);
+
+        expect(schemaOf('rating')).toContain('WITHOUT ROWID');
+        // The stale row went with the old table. An empty dataset reports
+        // itself as empty, and the next ingest refills it.
+        expect(db.status().ratings).toBe(0);
+        expect(db.status().ingestedAt).toBeUndefined();
+    });
+
+    /** A database already on the new schema keeps its contents. */
+    it('leaves an up-to-date database alone', () => {
+        db = ImdbDataset.open(dir);
+        db.replaceAll(rows(10));
+        db.close();
+
+        db = ImdbDataset.open(dir);
+        expect(db.status().ratings).toBe(10);
+    });
+});
+
+describe('giving space back', () => {
+    /**
+     * SQLite does not return freed pages to the OS on its own, so a replace
+     * that shrinks the dataset used to leave the file at its high-water mark
+     * for good — and the ~125 MB in the README was a figure only
+     * `measure-imdb.ts` ever saw, because it vacuumed and the running server
+     * did not.
+     */
+    it('shrinks the file when a replace holds far less than the last one', () => {
+        db = ImdbDataset.open(dir);
+        db.replaceAll(rows(20_000));
+        db.close();
+        const big = statSync(path()).size;
+
+        db = ImdbDataset.open(dir);
+        db.replaceAll(rows(10));
+        db.close();
+        const small = statSync(path()).size;
+
+        expect(small).toBeLessThan(big / 2);
+    });
+});

--- a/test/imdbLifecycle.test.ts
+++ b/test/imdbLifecycle.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, writeFile } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -27,6 +27,8 @@ const BEARER = 'a'.repeat(64);
 
 let dir: string;
 let audit: WriteAudit;
+/** Held so cleanup can close the dataset's handle on `imdb.db`. */
+let runtime: Runtime | undefined;
 
 /** Every dataset the refresher was handed, and whether it has been stopped. */
 type Started = { dataset: ImdbDataset; stopped: boolean };
@@ -56,16 +58,37 @@ const write = async (imdb: boolean): Promise<void> => {
 
 const runtimeFrom = async (opts: { refresh: (d: ImdbDataset) => () => void }): Promise<Runtime> => {
     const { config } = await loadConfig(dir);
-    return Runtime.fromConfig(config, audit, { configDir: dir, refresh: opts.refresh });
+    runtime = Runtime.fromConfig(config, audit, { configDir: dir, refresh: opts.refresh });
+    return runtime;
 };
 
+/**
+ * **Not** the `arr-mcp-imdb-` prefix, deliberately. That one belongs to
+ * `ingestOnce`'s staging directories, and `sweepStaging` deletes anything
+ * wearing it that has gone a day untouched — so a config directory borrowing
+ * the name would be a test fixture that a production code path is entitled to
+ * delete. The first draft of this file did borrow it, and left 35 of them
+ * behind besides.
+ */
 beforeEach(async () => {
-    dir = await mkdtemp(join(tmpdir(), 'arr-mcp-imdb-life-'));
+    dir = await mkdtemp(join(tmpdir(), 'arr-mcp-lifecycle-'));
     audit = WriteAudit.ephemeral();
 });
 
-afterEach(() => {
+afterEach(async () => {
     audit.close();
+
+    // The open dataset holds a handle on imdb.db, and Windows refuses to
+    // unlink an open file however `force` is set — `rm` fails with EBUSY, and
+    // the directory leaks exactly as it did before this cleanup existed.
+    try {
+        runtime?.dataset?.close();
+    } catch {
+        // Already closed by a test that switched the dataset off.
+    }
+    runtime = undefined;
+
+    await rm(dir, { recursive: true, force: true, maxRetries: 3 });
 });
 
 describe('the IMDb refresh follows the config', () => {
@@ -163,7 +186,7 @@ describe('the IMDb refresh follows the config', () => {
     it('does not refresh at all when no refresher was supplied', async () => {
         await write(true);
         const { config } = await loadConfig(dir);
-        const runtime = Runtime.fromConfig(config, audit, { configDir: dir });
+        runtime = Runtime.fromConfig(config, audit, { configDir: dir });
 
         expect(runtime.dataset).toBeDefined();
         await expect(runtime.reload()).resolves.toBeUndefined();

--- a/test/imdbStaging.test.ts
+++ b/test/imdbStaging.test.ts
@@ -1,0 +1,109 @@
+import { mkdirSync, mkdtempSync, existsSync, utimesSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { rmSync } from 'node:fs';
+import { STAGING_PREFIX, sweepStaging } from '../src/metadata/refresh.ts';
+
+/**
+ * Cleaning up after an ingest that never got to clean up after itself.
+ *
+ * `ingestOnce` removes its staging directory in a `finally`, which covers a
+ * failed download and a failed parse. It does not cover the process being
+ * killed — and that is the failure this project has actually had: the first
+ * real ingest was OOM-killed (f3e4a95), and two days later 661 MB of
+ * `title.basics.tsv` was still sitting in the OS temp directory. A weekly
+ * refresh leaks slowly enough that nobody notices until the disk is full.
+ *
+ * Age-gated rather than "delete every staging dir I find", because a second
+ * process — another container sharing /tmp, or `scripts/measure-imdb.ts` —
+ * may be part-way through an ingest of its own, and its staging directory
+ * looks exactly like abandoned one. An ingest takes minutes; the gate is a
+ * day.
+ */
+
+/** Its own root, never the real temp directory: a test that swept `tmpdir()`
+ *  itself would delete a concurrently-running ingest's staging on a dev box. */
+let root: string;
+
+beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'arr-mcp-sweep-test-'));
+});
+
+afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+});
+
+const HOUR = 60 * 60 * 1000;
+const NOW = 1_700_000_000_000;
+
+/** A directory with a staged dump in it, aged by touching its mtime. */
+const staged = (name: string, ageMs: number): string => {
+    const dir = join(root, name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'title.basics.tsv'), 'tconst\ttitleType\n', 'utf8');
+
+    const seconds = (NOW - ageMs) / 1000;
+    utimesSync(dir, seconds, seconds);
+    return dir;
+};
+
+describe('sweeping abandoned staging directories', () => {
+    it('removes a staging directory left by a killed ingest', () => {
+        const abandoned = staged(`${STAGING_PREFIX}dead01`, 48 * HOUR);
+
+        expect(sweepStaging(root, { now: NOW })).toBe(1);
+        expect(existsSync(abandoned)).toBe(false);
+    });
+
+    /**
+     * The whole reason for the age gate. A staging directory being *young* is
+     * the only evidence available that another process is still using it, and
+     * deleting a running ingest's dumps mid-stream would turn a slow disk leak
+     * into a broken refresh.
+     */
+    it('leaves a recent one alone, which may be an ingest in progress', () => {
+        const running = staged(`${STAGING_PREFIX}live01`, 2 * HOUR);
+
+        expect(sweepStaging(root, { now: NOW })).toBe(0);
+        expect(existsSync(running)).toBe(true);
+    });
+
+    it('does not touch directories belonging to anything else', () => {
+        const other = staged('some-other-tool-cache', 48 * HOUR);
+        const alsoOther = staged('arr-mcp-ui-abc123', 48 * HOUR);
+
+        expect(sweepStaging(root, { now: NOW })).toBe(0);
+        expect(existsSync(other)).toBe(true);
+        expect(existsSync(alsoOther)).toBe(true);
+    });
+
+    it('removes several at once and reports how many', () => {
+        staged(`${STAGING_PREFIX}a`, 30 * HOUR);
+        staged(`${STAGING_PREFIX}b`, 40 * HOUR);
+        const young = staged(`${STAGING_PREFIX}c`, 1 * HOUR);
+
+        expect(sweepStaging(root, { now: NOW })).toBe(2);
+        expect(existsSync(young)).toBe(true);
+    });
+
+    /**
+     * A sweep is housekeeping. It runs immediately before a download that is
+     * the actual point of the exercise, so anything it cannot do — a
+     * permission error, a directory that vanished under it, no temp directory
+     * at all — must not take the refresh down with it.
+     */
+    it('reports nothing rather than throwing when the root does not exist', () => {
+        expect(sweepStaging(join(root, 'nope'), { now: NOW })).toBe(0);
+    });
+
+    it('ignores a plain file that happens to match the prefix', () => {
+        const file = join(root, `${STAGING_PREFIX}notadir`);
+        writeFileSync(file, 'x', 'utf8');
+        const seconds = (NOW - 48 * HOUR) / 1000;
+        utimesSync(file, seconds, seconds);
+
+        expect(sweepStaging(root, { now: NOW })).toBe(0);
+        expect(existsSync(file)).toBe(true);
+    });
+});


### PR DESCRIPTION
Follow-up to #89. Both of these were written while #89 was open and pushed to its branch after it had already been squash-merged, so they never made it into 1.2.0 — cherry-picked onto the merged `main` here, unchanged.

## 1. A killed ingest leaked its staging directory

`ingestOnce` cleans up in a `finally`, which covers a failed download and a failed parse but **not** the process being killed. Not hypothetical: this dev box had **661 MB** of `title.basics.tsv` sitting in the OS temp directory, dated the day of the OOM crash in f3e4a95, two days after the fact. At a weekly refresh, a leak that size goes unnoticed until a disk is full.

`sweepStaging` runs immediately before the next ingest stages its own — the moment we are about to ask for another ~700 MB is the moment worth reclaiming what a dead predecessor still holds.

Age-gated at a day rather than deleting every staging directory it finds: a *young* one is the only available evidence that another process (a second container sharing `/tmp`, or `measure-imdb.ts`) is still writing to it, and deleting a running ingest's dumps would turn a slow leak into a broken refresh. It never throws — housekeeping in front of the real work must not take a refresh down over a permission error.

Also stops the lifecycle tests squatting on the `arr-mcp-imdb-` prefix, which is now a name production code is entitled to delete, and makes them close the dataset before removing their temp directory. Windows refuses to unlink an open `imdb.db` however `force` is set, so those were leaking too — 35 of them.

## 2. 125 MB → 81 MB on disk

Measured against the live dumps on 2026-08-10 with `scripts/measure-imdb.ts`:

| | before | after |
| --- | --- | --- |
| On disk | ~125 MB | **81.2 MB** |
| Titles stored | 546K | 809K |
| Ratings stored | 1.7M | **809K** |
| Download per refresh | 223 MB | 223 MB |
| First ingest | ~3 min | ~3 min (166s) |

Three changes:

**`WITHOUT ROWID` on `title` and `rating`.** Each keys on `tconst` and nothing else, so the default layout stored every id twice — once in the rowid btree holding the row, again in the implicit unique index enforcing the key.

**Ratings with no stored title are pruned.** `rating` arrived unfiltered: 1.7M rows against `title`'s 546K, two thirds of it episodes and video games nothing could reach. The two tables now hold the same set of ids.

**`VACUUM` after each replace.** SQLite does not hand freed pages back to the OS, and every replace frees the entire previous dataset, so the file sat at its high-water mark for ever.

### The prune is only safe because `STORED_KINDS` widened first

These two have to be read together. `ratingsFor` reaches a rating by id **without** going through `discover`'s vocabulary, so the orphan ratings were what kept a direct-to-video film (`video`) or a stand-up special (`tvSpecial`) rated. Pruning them alone would have silently dropped those — which reads as "unrated", indistinguishable from a title IMDb has never heard of.

So `STORED_KINDS` is no longer `KIND_TO_IMDB` flattened. What a *lookup* may hit and what a *browse* may return are two different questions, and there are tests holding the line that the extra kinds stay out of `discover`. Title count going *up* (546K → 809K) is that widening; the prune still nets the saving comfortably.

### The old number was never real

The ~125 MB was measured **post-`VACUUM` by the measuring script**, while the running server never vacuumed at all — so no live install ever reached it. The script now reports the size as the server actually leaves it, which is what stops this drifting again.

## Deployment note

An existing `imdb.db` is **dropped and rebuilt**, not migrated: `CREATE TABLE IF NOT EXISTS` cannot change a table that already exists, so without it an existing database keeps the old layout for ever and never sees the saving. Licensed by the module's own header — a cache that is wholly replaced every week and whose loss costs a download, not data — and `Runtime` starts a refresh as it opens the database, so the refill is immediate.

Practically: the first start after this deploys re-downloads 223 MB and spends ~3 minutes rebuilding, during which series IMDb ratings are unavailable and `ratingCoverage.note` says so.

## Versioning

`fix:` — patch. Nothing is added to or removed from the tool surface.

## Gates

```
npm run lint       # clean
npm run typecheck  # clean
npm test           # 1239 passed (62 files)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
