### PR TITLE
fix: make the config UI usable on a phone, and the write audit readable

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,116 @@
+name: Feature request
+description: A question arr-mcp cannot answer, or a service it does not speak to
+labels: ['enhancement']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Describe the question you could not get answered, not the tool you
+        think should exist.** Knowing which question goes unanswered is most of
+        the work; the code that answers it is the easy half.
+
+        This matters because the answer is often a new parameter or a new field
+        on a tool that already exists. Twenty-one tools is close to the ceiling
+        — model accuracy degrades measurably past roughly forty — so new
+        capability extends an existing tool before it adds one. A request framed
+        as a question can be answered that way. One framed as a tool name
+        usually cannot.
+
+        Requests you never intend to write the code for are welcome. So are
+        ones you do — see
+        [CONTRIBUTING.md](https://github.com/bardesss/arr-mcp/blob/main/CONTRIBUTING.md).
+
+  - type: textarea
+    id: question
+    attributes:
+      label: What did you ask, and what came back?
+      description: >-
+        The actual question you put to your MCP client, and what arr-mcp
+        answered — a refusal, an empty list, the wrong thing, or nothing at all.
+      placeholder: >-
+        "Which of my films are on a drive that is nearly full?" — get_library
+        returned the films but nothing about which disk they are on.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What should the answer have been?
+      description: >-
+        Roughly what you expected back. If you already know which tool is
+        closest and what it is missing, say so here.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: services
+    attributes:
+      label: Which services would this have to read?
+      description: >-
+        Tick what you think it needs. Guessing is fine — tick nothing if you
+        are not sure.
+      options:
+        - label: Radarr
+        - label: Sonarr
+        - label: Prowlarr
+        - label: Bazarr
+        - label: Jellyfin
+        - label: Seerr
+        - label: SABnzbd
+        - label: Transmission
+
+  - type: input
+    id: unsupported-service
+    attributes:
+      label: A service arr-mcp does not support at all?
+      description: >-
+        Name it and its version. Adapters are the most self-contained thing in
+        the codebase and the highest-value contribution — but a service the
+        maintainer does not run cannot be tested in review, so one you are
+        willing to test yourself against a live instance goes much further than
+        one nobody can exercise.
+      placeholder: 'Lidarr 2.14.0'
+
+  - type: dropdown
+    id: writes
+    attributes:
+      label: Would this change anything in your stack?
+      description: >-
+        Reads ship freely. Writes are gated per service and per tier, and a
+        write that loses data — files, history, a blocklist entry — is a
+        different conversation from one the service can undo.
+      options:
+        - 'No — it only reads'
+        - 'Yes, but reversibly (monitor, search, approve)'
+        - 'Yes, destructively (delete files, remove a record)'
+        - 'Not sure'
+    validations:
+      required: true
+
+  - type: input
+    id: arr-mcp-version
+    attributes:
+      label: arr-mcp version
+      description: The image tag you are on, or `git rev-parse --short HEAD` if running from source.
+      placeholder: '1.4.1'
+    validations:
+      required: true
+
+  - type: textarea
+    id: workaround
+    attributes:
+      label: How are you working around it today?
+      description: >-
+        Optional, and more useful than it sounds — a workaround that almost
+        works usually points at the field that is missing.
+
+  - type: checkboxes
+    id: checked
+    attributes:
+      label: Before submitting
+      options:
+        - label: >-
+            I checked the tool list in the README, including each tool's
+            parameters, and none of them answers this.
+          required: true

--- a/README.md
+++ b/README.md
@@ -605,6 +605,18 @@ while a timestamp inside the content cannot be dropped.
 | Logs | Three streams — all activity, problems only, or one service |
 | Write audit | Every write attempt — applied, previewed, refused or failed |
 
+**It works on a phone**, which is where you are when something stops playing.
+The navigation becomes its own full-width row rather than wrapping into the
+title, form fields are large enough that iOS does not zoom the page in when you
+tap one, and no table pushes the page sideways.
+
+**The write audit reads as entries, not as a spreadsheet.** Each attempt gives
+its outcome, tool and time on one line and its recorded arguments underneath,
+each as its own field — the arguments are stored as a single JSON blob, and a
+column holding that blob beside six others was unreadable on a desktop long
+before it was unreadable on a phone. Nothing is summarised away: an argument
+that does not parse is shown exactly as it was recorded.
+
 **Connection tests diagnose rather than pass or fail.** A service that is down
 says what is wrong and what to do about it — the same `kind`, `detail` and
 `remedy` the MCP tools return — instead of showing a red cross you then have to
@@ -721,6 +733,59 @@ the code around them.
 Fixtures are captured from real services rather than hand-written for the same
 reason. A test that passes against an invented shape proves nothing about the
 service it claims to support.
+
+### Missing a tool? Open an issue
+
+**A question arr-mcp cannot answer is worth reporting even if you never intend
+to write the code.** Knowing which question goes unanswered is most of the work;
+the tool that answers it is the easy half.
+
+The [feature request form](.github/ISSUE_TEMPLATE/feature_request.yml) asks
+**what you asked and what you expected back**, rather than for a tool name. The
+answer is often a new parameter or a new field on a tool that already exists —
+twenty-one tools is close to the ceiling, because model accuracy degrades
+measurably past roughly forty, so new capability extends an existing tool before
+it adds one. A request framed as a question can be answered that way; one framed
+as a tool name usually cannot. It is also where to name a service arr-mcp does
+not speak to at all.
+
+Bugs go through the [bug report form](.github/ISSUE_TEMPLATE/bug_report.yml),
+which asks for the two fields a report is unreproducible without: your versions
+and your logs. Redact API keys and the bearer token.
+
+### AI-assisted contributions
+
+**Welcome, and held to the same bar — not a lower one, and not a higher one.**
+arr-mcp is itself built with a coding agent. A patch is judged by whether it
+holds up, so there is no separate review track and nothing to disclose beyond
+being straight about what was actually verified.
+
+Point your agent at [CONTRIBUTING.md](CONTRIBUTING.md) first — it is written to
+be read by one, and it carries the constraints that are not visible from the
+code alone. Four of them matter more than the rest, because breaking them
+produces a pull request that *looks* finished:
+
+- **Never write a fixture by hand.** Asked for one, an agent will produce
+  something plausible — and a plausible fixture is worse than no fixture at all,
+  because the test passes, the adapter ships, and the shape was never the
+  service's. Capture with `npm run capture` against a live instance, or say in
+  the PR that the fixture is missing.
+- **Run the three gates and paste what they printed.** `npm run lint`,
+  `npm run typecheck`, `npm test`. "Should pass" is not a result, and CI runs
+  exactly what you can run locally, so there is nothing to guess about.
+- **Say what a *human* exercised.** An agent cannot run your Lidarr. An adapter
+  that has never touched a live service is still worth opening — one described
+  as tested when nobody tested it is not, because I cannot check that claim for
+  a service I do not run.
+- **A typecheck failure against `src/services/generated/` is the codegen doing
+  its job.** Fix the mapper; do not widen it with a cast. This is the one
+  failure most likely to get papered over, and the cast survives long after the
+  reason for it is forgotten.
+
+Commit messages are [Conventional Commits](https://www.conventionalcommits.org/)
+and are read by release automation, so the prefix decides the next version
+number — `fix:` patch, `feat:` minor, `feat!:` major. Getting it wrong ships the
+wrong version rather than failing loudly.
 
 ## Requirements
 

--- a/src/web/assets.ts
+++ b/src/web/assets.ts
@@ -43,7 +43,12 @@ nav a {
 }
 nav a:hover { background: var(--panel-2); color: var(--text); }
 nav a.on { background: var(--panel-2); color: var(--text); }
-main { max-width: 1100px; margin: 0 auto; padding: 1.5rem 1.25rem 4rem; }
+main { max-width: 1100px; margin: 0 auto; padding: 1.5rem 1.25rem 2rem; }
+footer {
+  max-width: 1100px; margin: 0 auto; padding: 1rem 1.25rem 2.5rem;
+  border-top: 1px solid var(--line); color: var(--dim); font-size: .85rem;
+  display: flex; flex-wrap: wrap; gap: .3rem 1.1rem; align-items: baseline;
+}
 h2 { font-size: 1.05rem; margin: 2rem 0 .75rem; }
 h2:first-child { margin-top: 0; }
 p.note { color: var(--dim); font-size: .9rem; margin: .35rem 0 1rem; }
@@ -64,7 +69,14 @@ p.note { color: var(--dim); font-size: .9rem; margin: .35rem 0 1rem; }
   background: var(--panel-2); border-radius: 0 6px 6px 0; font-size: .85rem; color: var(--text);
 }
 table { width: 100%; border-collapse: collapse; font-size: .87rem; }
-th, td { text-align: left; padding: .45rem .6rem; border-bottom: 1px solid var(--line); vertical-align: top; }
+/* A health message, a mount path, a URL: one long unbroken value in a cell is
+   enough to push the whole page sideways on a phone. overflow-wrap is
+   "anywhere" rather than "break-word" because only that value lets the cell's
+   min-content width shrink, which is the part that stops the overflow. */
+th, td {
+  text-align: left; padding: .45rem .6rem; border-bottom: 1px solid var(--line);
+  vertical-align: top; overflow-wrap: anywhere;
+}
 th { color: var(--dim); font-weight: 500; position: sticky; top: 0; background: var(--panel); }
 td.mono, .mono { font-family: var(--mono); font-size: .85em; }
 tr.lvl-40 td { color: var(--warn); } tr.lvl-50 td, tr.lvl-60 td { color: var(--bad); }
@@ -111,9 +123,68 @@ dialog {
 }
 dialog::backdrop { background: rgba(0, 0, 0, .6); }
 dialog .panel { margin: 0; border: 0; border-radius: 10px; max-height: 82vh; overflow: auto; }
-.token { display: flex; gap: .5rem; align-items: center; margin-bottom: .5rem; }
-.token input { flex: 1; font-family: var(--mono); font-size: .8rem; }
+.token { display: flex; gap: .5rem; align-items: center; margin-bottom: .5rem; flex-wrap: wrap; }
+/* Wraps rather than shrinking: squeezed onto one phone-width line, the field
+   holding the token is narrower than the two buttons beside it, and a token
+   you cannot see any of is worse than one on its own line. */
+.token input { flex: 1 1 14rem; font-family: var(--mono); font-size: .8rem; }
 #mcp-config { width: 100%; margin-top: .6rem; font-size: .78rem; white-space: pre; }
+.dim { color: var(--dim); }
+
+/* --- the write audit ---------------------------------------------------
+   Seven columns, one of them a JSON blob of arguments, was unreadable before
+   it was unresponsive — no width makes that table scannable. An entry per
+   attempt puts the answer on the first line (what happened, which tool, when)
+   and moves the arguments underneath, where their length costs nothing. */
+.trail { display: grid; gap: .6rem; }
+.entry {
+  background: var(--panel); border: 1px solid var(--line);
+  border-radius: 10px; padding: .75rem .9rem;
+}
+.entry-top { display: flex; align-items: baseline; gap: .5rem; flex-wrap: wrap; }
+.entry-top .tool { font-weight: 600; }
+.entry-top time { margin-left: auto; color: var(--dim); font-size: .8rem; }
+.entry dl {
+  margin: .55rem 0 0; display: grid; grid-template-columns: auto 1fr;
+  gap: .15rem .75rem; font-size: .86rem;
+}
+.entry dt { color: var(--dim); }
+.entry dd { margin: 0; overflow-wrap: anywhere; }
+.badge {
+  font-size: .72rem; text-transform: uppercase; letter-spacing: .04em;
+  padding: .1rem .45rem; border-radius: 999px; white-space: nowrap;
+  border: 1px solid var(--line); background: var(--panel-2); color: var(--dim);
+}
+/* Only the outcomes worth stopping on are coloured. A preview and a dry run
+   are the system working, and colouring those too would leave nothing for a
+   refusal or a half-finished write to stand out against. */
+.badge.applied { color: var(--ok); border-color: currentColor; }
+.badge.denied, .badge.attempted { color: var(--warn); border-color: currentColor; }
+.badge.failed { color: var(--bad); border-color: currentColor; }
+
+/* --- small screens -----------------------------------------------------
+   The body is one column at any width already. What breaks on a phone is the
+   header, where a title, four nav links and Sign out share one wrapping flex
+   row and land wherever they happen to fall. */
+@media (max-width: 700px) {
+  header { gap: .6rem .75rem; padding: .75rem .9rem; }
+  header h1 { flex: 1; }
+  /* A row of its own, under the title and Sign out. Moved with "order" rather
+     than in the markup, because on a wide screen the nav genuinely does belong
+     between those two, and the source order is the reading order. */
+  nav { order: 1; flex-basis: 100%; gap: .3rem; }
+  /* Stretched to fill the line: four links of unequal length wrapping across
+     two rows read as debris otherwise. Smaller and tighter so that on most
+     phones they fit on one row at all. */
+  nav a { flex: 1 1 auto; text-align: center; padding: .55rem .55rem; font-size: .85rem; }
+  main { padding: 1.25rem .9rem 1.5rem; }
+  footer { padding: 1rem .9rem 2.5rem; }
+  .panel, .card, .entry { padding: .8rem .85rem; }
+  /* 16px is the threshold under which iOS Safari zooms the page in on focus —
+     and it does not zoom back out, so one tap on a field leaves you scrolled
+     sideways across a form you were only trying to type in. */
+  input, select, textarea, .token input, #mcp-config { font-size: 16px; }
+}
 `;
 
 /**

--- a/src/web/pages.ts
+++ b/src/web/pages.ts
@@ -11,6 +11,11 @@ import { esc, html, humanBytes, raw, shortTime, type SafeHtml } from './html.ts'
 
 export type Nav = 'dashboard' | 'config' | 'logs' | 'audit';
 
+/** Where this came from, and where a missing tool or a bug goes. On every
+ *  page, including the sign-in one — the person who cannot get in is exactly
+ *  the person who needs the issue tracker. */
+const REPO = 'https://github.com/bardesss/arr-mcp';
+
 const NAV: { key: Nav; href: string; label: string }[] = [
     { key: 'dashboard', href: '/ui', label: 'Dashboard' },
     { key: 'config', href: '/ui/config', label: 'Configuration' },
@@ -63,6 +68,14 @@ dialog { display: block; position: static; max-width: none; width: auto; margin:
 <body>
 <header><h1>arr-mcp <span>${esc(opts.version)}</span></h1>${nav}</header>
 <main>${message}${opts.body}</main>
+<!-- rel="noreferrer" because this page is served over plain http on a LAN and
+     the link leaves for github.com: without it the Referer header hands them
+     the hostname and port your instance is reachable on. -->
+<footer>
+  <span>arr-mcp ${esc(opts.version)}</span>
+  <a href="${REPO}" target="_blank" rel="noreferrer">Source on GitHub</a>
+  <a href="${REPO}/issues/new/choose" target="_blank" rel="noreferrer">Report a bug or request a tool</a>
+</footer>
 <script src="/ui/app.js?v=${encodeURIComponent(opts.version)}" defer></script>
 </body>
 </html>`;
@@ -577,38 +590,71 @@ export type AuditRow = {
     detail: string | null;
 };
 
+/**
+ * The recorded arguments, as fields rather than as the blob they are stored as.
+ *
+ * `args` is JSON in one database column, and printing it into a cell put a
+ * whole object on one line beside six other columns — the single thing that
+ * made this page unreadable at any width.
+ *
+ * A row that does not parse is shown verbatim rather than dropped. This is a
+ * log: something unexpected in it is a reason to display it, not to hide it.
+ */
+function argFields(args: string): SafeHtml {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(args);
+    } catch {
+        return html`<dt>Arguments</dt><dd class="mono">${args}</dd>`;
+    }
+
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+        return html`<dt>Arguments</dt><dd class="mono">${args}</dd>`;
+    }
+
+    const entries = Object.entries(parsed as Record<string, unknown>);
+    if (entries.length === 0) return html`<dt>Arguments</dt><dd class="dim">none</dd>`;
+
+    return html`${entries.map(
+        ([key, value]) =>
+            html`<dt class="mono">${key}</dt>
+                <dd class="mono">${typeof value === 'string' ? value : JSON.stringify(value)}</dd>`
+    )}`;
+}
+
+/**
+ * One entry per attempt, rather than one row of seven columns.
+ *
+ * The order is the order the questions get asked: what happened, to what, with
+ * which arguments, and — only when there is one — what the service said back.
+ */
+function auditEntry(r: AuditRow): SafeHtml {
+    return html`<article class="entry">
+        <div class="entry-top">
+            <span class="badge ${r.outcome}">${r.outcome}</span>
+            <span class="tool">${r.tool}</span>
+            <span class="mono dim">${r.service}</span>
+            <time class="mono">${shortTime(r.at)}</time>
+        </div>
+        <dl>
+            <dt>Target</dt>
+            <dd class="mono">${r.target}</dd>
+            ${argFields(r.args)}
+        </dl>
+        ${r.detail === null || r.detail === '' ? raw('') : html`<div class="remedy">${r.detail}</div>`}
+    </article>`;
+}
+
 export function auditPage(opts: { version: string; rows: AuditRow[] }): string {
     const body = html`<h2>Write audit</h2>
         <p class="note">
-            Every write attempt, including previews and refusals. A row still reading
+            Every write attempt, including previews and refusals. An entry still reading
             <span class="mono">attempted</span> means arr-mcp stopped mid-write.
         </p>
 
         ${opts.rows.length === 0
             ? html`<p class="note">Nothing has tried to write yet.</p>`
-            : html`<div class="scroll">
-                  <table>
-                      <thead>
-                          <tr>
-                              <th>Time</th><th>Outcome</th><th>Tool</th><th>Service</th>
-                              <th>Target</th><th>Arguments</th><th>Detail</th>
-                          </tr>
-                      </thead>
-                      <tbody>
-                          ${opts.rows.map(
-                              r => html`<tr>
-                                  <td class="mono">${shortTime(r.at)}</td>
-                                  <td>${r.outcome}</td>
-                                  <td>${r.tool}</td>
-                                  <td>${r.service}</td>
-                                  <td class="mono">${r.target}</td>
-                                  <td class="mono">${r.args}</td>
-                                  <td>${r.detail ?? ''}</td>
-                              </tr>`
-                          )}
-                      </tbody>
-                  </table>
-              </div>`}`;
+            : html`<div class="trail">${opts.rows.map(auditEntry)}</div>`}`;
 
     return layout({ title: 'Write audit', nav: 'audit', version: opts.version, body });
 }

--- a/test/webHtml.test.ts
+++ b/test/webHtml.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { DiskSpace } from '../src/services/types.ts';
 import { JS } from '../src/web/assets.ts';
 import { esc, html, humanBytes, raw, shortTime } from '../src/web/html.ts';
-import { groupDisks } from '../src/web/pages.ts';
+import { auditPage, groupDisks, loginPage, type AuditRow } from '../src/web/pages.ts';
 
 describe('escaping', () => {
     it('neutralises the characters that end a tag or an attribute', () => {
@@ -190,6 +190,83 @@ describe('grouping the disks a stack reports', () => {
             disk('jellyfin', 4_800_000_000_000, 11_878_195_200_000)
         ]);
         expect(groups).toHaveLength(2);
+    });
+});
+
+/**
+ * The audit trail's arguments are stored as JSON in one column, and printing
+ * that column into a cell is what made this page unreadable: an object on one
+ * line, beside six other columns.
+ */
+describe('the write audit', () => {
+    const row = (over: Partial<AuditRow> = {}): AuditRow => ({
+        at: '2026-08-12T14:03:11.000Z',
+        tool: 'delete_media',
+        service: 'radarr/4k',
+        operation: 'delete',
+        tier: 'destructive',
+        target: '1535',
+        args: '{"id":"1535","delete_files":true}',
+        outcome: 'applied',
+        detail: null,
+        ...over
+    });
+
+    it('renders each recorded argument as its own field', () => {
+        const page = auditPage({ version: '1.4.1', rows: [row()] });
+
+        expect(page).toContain('<dt class="mono">delete_files</dt>');
+        expect(page).toContain('<dd class="mono">true</dd>');
+        // The blob it is stored as never reaches the page.
+        expect(page).not.toContain('{&quot;id&quot;');
+    });
+
+    it('shows arguments that do not parse verbatim rather than dropping them', () => {
+        const page = auditPage({ version: '1.4.1', rows: [row({ args: 'not json at all' })] });
+        expect(page).toContain('not json at all');
+    });
+
+    // A log's value is that nothing goes missing from it, so a shape nobody
+    // expected is a reason to print it, not to skip the row.
+    it('survives arguments that are valid JSON but not an object', () => {
+        const page = auditPage({ version: '1.4.1', rows: [row({ args: '[1,2]' })] });
+        expect(page).toContain('[1,2]');
+        expect(page).toContain('delete_media');
+    });
+
+    it('marks the outcomes worth stopping on, and leaves a preview unmarked', () => {
+        const marked = auditPage({ version: '1.4.1', rows: [row({ outcome: 'failed' })] });
+        expect(marked).toContain('<span class="badge failed">failed</span>');
+
+        const plain = auditPage({ version: '1.4.1', rows: [row({ outcome: 'unconfirmed' })] });
+        expect(plain).toContain('<span class="badge unconfirmed">unconfirmed</span>');
+    });
+
+    it('escapes a detail the service handed back', () => {
+        const page = auditPage({
+            version: '1.4.1',
+            rows: [row({ outcome: 'failed', detail: '<img src=x onerror=alert(1)>' })]
+        });
+        expect(page).not.toContain('<img src=x');
+        expect(page).toContain('&lt;img src=x');
+    });
+});
+
+/**
+ * The footer is on every page including sign-in, because the person locked out
+ * is exactly the person who needs the issue tracker.
+ */
+describe('the footer', () => {
+    it('links to the repository and the issue form, without leaking the host', () => {
+        const page = loginPage({ version: '1.4.1' });
+
+        // Both carry noreferrer: a plain-http LAN page linking out would
+        // otherwise hand github.com the hostname and port this instance
+        // answers on.
+        expect(page).toContain('href="https://github.com/bardesss/arr-mcp" target="_blank" rel="noreferrer"');
+        expect(page).toContain(
+            'href="https://github.com/bardesss/arr-mcp/issues/new/choose" target="_blank" rel="noreferrer"'
+        );
     });
 });
 


### PR DESCRIPTION
## The header, which is what you notice first

A title, four nav links and a Sign out button shared one wrapping flex row with
a `1.5rem` gap. On a phone they landed wherever they fell.

Below 700px the nav is now a full-width row of its own under the title, its
links stretched to fill the line. It gets there with `order` rather than by
moving in the markup — on a wide screen it genuinely does belong between the
title and Sign out, and the source order is the reading order.

## Three smaller things that made the page hostile on a phone

- **Form fields are 16px below 700px.** Under that, iOS Safari zooms the page in
  on focus and does not zoom back out, so one tap on the URL field left you
  scrolled sideways across a form you were only trying to type in.
- **Table cells wrap.** A long health message or mount path was enough to push
  the whole page sideways. `overflow-wrap: anywhere` rather than `break-word`,
  because only that value lets a cell's min-content width shrink — which is the
  part that actually stops the overflow.
- **The token row wraps instead of shrinking.** Squeezed onto one phone-width
  line, the field holding the bearer token ended up narrower than the two
  buttons beside it.

## The write audit, which was a different problem

Not a responsive one: seven columns, one of them the arguments as the single
JSON blob they are stored as. No width makes that scannable, and it was
unreadable on a desktop long before it was unreadable on a phone.

It is now an entry per attempt — outcome, tool, service and time on the first
line; target and each argument as its own field underneath; the service's own
words only when there are any. Only the outcomes worth stopping on are coloured,
so a refusal or a half-finished write has something to stand out against.

Nothing is summarised away. Arguments that do not parse are printed exactly as
recorded, because a log's whole value is that nothing goes missing from it.

## A footer

Every page, including sign-in — the person locked out is exactly the person who
needs the issue tracker. Both links carry `rel="noreferrer"`: this page is
served over plain http on a LAN, and without it the `Referer` header hands
github.com the hostname and port the instance answers on.

## Also here

`docs:` commit, no version effect: the README now says contributions are welcome
including AI-assisted ones, with the four constraints an agent specifically
defeats (it will invent a fixture rather than capture one, claim the gates pass
rather than run them, describe an adapter as tested when nobody ran it, and cast
away the generated-type failure that exists to catch the mapper bug it is
hiding). A feature request form joins the bug form, asking what you asked and
what came back rather than for a tool name — at twenty-one tools the answer is
usually a new parameter on an existing one.

## Testing

`npm run lint`, `npm run typecheck` and `npm test` all pass — 62 files, 1338
tests, 6 of them new, covering the audit rendering and the footer's links.

**Not verified on a real phone.** The layout was reasoned about and rendered to
static HTML, not opened in Mobile Safari — the iOS zoom threshold in particular
is applied from the documented 16px rule rather than observed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
