### PR TITLE
fix: refuse a tool argument this server does not have, instead of dropping it

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ yourself.
 
 | | |
 | --- | --- |
-| **[Tools](docs/tools.md)** | All twenty-one, what each answers, and the fields whose meaning is not obvious |
+| **[Tools](docs/tools.md)** | All twenty-two, what each answers, and the fields whose meaning is not obvious |
 | **[Writes](docs/writes.md)** | Turning them on, the two tiers, and the preview-and-confirm handshake |
 | **[Configuration](docs/configuration.md)** | `config.yaml`, several Radarrs, Jellyfin's `default_user` |
 | **[Config UI](docs/config-ui.md)** | The four pages, and what each does that is not obvious |
@@ -103,7 +103,7 @@ arr-mcp is itself built with a coding agent. Point yours at
 
 **Missing a tool?** [Open an issue](../../issues/new/choose) describing the
 question you could not get answered rather than the tool you think should
-exist — at twenty-one tools the answer is usually a new parameter on one that
+exist — at twenty-two tools the answer is usually a new parameter on one that
 already exists.
 
 ## Security

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,6 +1,6 @@
 # Tools
 
-Twenty-one of them. The first thirteen read; the last eight write, and are off
+Twenty-two of them. The first thirteen read; the last nine write, and are off
 until you turn them on — see [writes](writes.md).
 
 | Tool | Answers |
@@ -19,6 +19,7 @@ until you turn them on — see [writes](writes.md).
 | `lookup_media` | Tell me about this, without adding it |
 | `discover_media` | What exists in this genre, year, or rating band |
 | `trigger_search` | Go look for this again |
+| `trigger_scan` | Rescan a library — it downloaded but still will not play |
 | `set_monitoring` | Turn Sonarr monitoring on or off — a whole series, one season, or specific episodes |
 | `remove_queue_item` | Get rid of this stuck or wrong download |
 | `delete_media` | Remove this film or series, optionally from disk |
@@ -41,6 +42,9 @@ Tools spanning several services also report which ones they could not reach, and
 how many results each contributed, so a long answer from one service can never
 silently hide another.
 
+`diagnose` takes a title, or an exact `service` plus `id`, and returns a verdict
+rather than a list.
+
 **An argument a tool does not have is refused, and the refusal lists the ones it
 does have.** Dropping it silently would be worse than it sounds: the call
 succeeds, the invented argument is gone, and the answer is indistinguishable
@@ -49,9 +53,6 @@ from one where it had been honoured. That is [#103] — an agent sent `offset` a
 unpaginable, never having learned that `limit` was the parameter it wanted.
 
 [#103]: https://github.com/bardesss/arr-mcp/issues/103
-
-`diagnose` takes a title, or an exact `service` plus `id`, and returns a verdict
-rather than a list.
 
 ## `diagnose`
 
@@ -179,7 +180,7 @@ how far in you are.
 
 ## Prompts and resources
 
-Twenty-one tools do not tell you which one to reach for, and the questions
+Twenty-two tools do not tell you which one to reach for, and the questions
 people actually ask are rarely one call.
 
 **Five prompts**, which most clients surface as slash commands:

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -41,6 +41,15 @@ Tools spanning several services also report which ones they could not reach, and
 how many results each contributed, so a long answer from one service can never
 silently hide another.
 
+**An argument a tool does not have is refused, and the refusal lists the ones it
+does have.** Dropping it silently would be worse than it sounds: the call
+succeeds, the invented argument is gone, and the answer is indistinguishable
+from one where it had been honoured. That is [#103] — an agent sent `offset` and
+`source` to `get_library`, got a clean `200`, and reported the library as
+unpaginable, never having learned that `limit` was the parameter it wanted.
+
+[#103]: https://github.com/bardesss/arr-mcp/issues/103
+
 `diagnose` takes a title, or an exact `service` plus `id`, and returns a verdict
 rather than a list.
 

--- a/docs/writes.md
+++ b/docs/writes.md
@@ -30,6 +30,7 @@ re-monitor it.
 | Tool | Tier | Needs |
 | --- | --- | --- |
 | `trigger_search` | safe | `safe_write` |
+| `trigger_scan` | safe | `safe_write` |
 | `respond_to_request` | safe | `safe_write` |
 | `add_media` | safe | `safe_write` |
 | `set_monitoring` | safe | `safe_write` |

--- a/src/core/shape.ts
+++ b/src/core/shape.ts
@@ -20,6 +20,46 @@ export const LimitSchema = z
     .describe(`Maximum items to return. Defaults to ${DEFAULT_LIMIT}, hard maximum ${MAX_LIMIT}.`);
 
 /**
+ * Every tool's arguments, refusing the ones it does not have.
+ *
+ * A plain `z.object` **strips** unknown keys, which is the quietest possible
+ * failure: the call succeeds, the invented argument is gone, and the result
+ * looks exactly like one where it had been honoured. #103 is what that costs —
+ * an agent sent `offset` and `source` to `get_library`, got a clean 200, and
+ * concluded from the unchanged results that this server's pagination and
+ * filtering were broken. Neither parameter has ever existed. It never found
+ * `limit`, which was the parameter it actually wanted, because nothing in the
+ * exchange ever suggested it was looking in the wrong place.
+ *
+ * So the error names both halves: what was refused, and what this tool does
+ * accept. The first alone leaves a model exactly as stuck as silence did — the
+ * list is what lets it correct itself in one turn rather than guess again.
+ *
+ * `undocumented` keeps a key working while leaving it out of that list. Two
+ * parameters were frozen at 1.0 under an older spelling and are deliberately
+ * described nowhere (see `preferred`); advertising them in an error would teach
+ * the old name to every caller who made a typo, which is the one thing keeping
+ * them undocumented was for.
+ */
+export function toolInput<T extends z.ZodRawShape>(
+    shape: T,
+    opts: { undocumented?: readonly (keyof T & string)[] } = {}
+) {
+    const hidden = new Set<string>(opts.undocumented ?? []);
+    const accepted = Object.keys(shape)
+        .filter(k => !hidden.has(k))
+        .sort()
+        .join(', ');
+
+    return z.strictObject(shape, {
+        error: issue =>
+            issue.code === 'unrecognized_keys'
+                ? `Unknown argument(s): ${issue.keys.join(', ')}. They were refused rather than ignored, because a dropped argument is indistinguishable from one that worked. This tool accepts: ${accepted}.`
+                : undefined
+    });
+}
+
+/**
  * The truncation contract from Silent truncation is how a
  * model confidently reports that a 900-film library contains 50 films, so
  * every read tool routes its list through here and serialises all four fields.

--- a/src/tools/diagnose/index.ts
+++ b/src/tools/diagnose/index.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/server';
 import * as z from 'zod/v4';
 import { ServiceIdSchema } from '../../config/schema.ts';
+import { toolInput } from '../../core/shape.ts';
 import { buildChain, type Diagnosis } from './chain.ts';
 import { collectEvidence, type DiagnoseDeps, type DiagnoseTarget } from './evidence.ts';
 
@@ -18,7 +19,7 @@ export function registerDiagnose(server: McpServer, deps: DiagnoseDeps): void {
         {
             description:
                 'Why is this not playable? Walks the whole chain — requested, managed, monitored, downloaded, indexed, imported, scanned — and names the first thing that explains the absence, with what to do about it. Give a title as `query` for how a person actually asks; give `service` plus `id` only when you already have an exact item in hand (e.g. from get_media_details) — the explicit id wins if both are given. Works with services down: any step it could not check sets `certain: false` and the summary says what was missed, rather than guessing across the hole.',
-            inputSchema: z.object({
+            inputSchema: toolInput({
                 query: z.string().min(1).optional().describe('A title — how a person actually asks.'),
                 service: ServiceIdSchema.optional().describe('With `id`: an exact item, when one is already in hand.'),
                 id: z.string().min(1).optional(),

--- a/src/tools/discoverMedia.ts
+++ b/src/tools/discoverMedia.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/server';
 import * as z from 'zod/v4';
 import { logger } from '../core/logger.ts';
-import { DetailSchema, LimitSchema, applyLimit, preferred, type DetailLevel } from '../core/shape.ts';
+import { DetailSchema, LimitSchema, applyLimit, preferred, toolInput, type DetailLevel } from '../core/shape.ts';
 import type { SeerrAdapter } from '../services/seerr.ts';
 import { fenceText } from '../core/fence.ts';
 import { enrichWithImdb } from '../metadata/enrich.ts';
@@ -134,7 +134,7 @@ export function registerDiscoverMedia(
         {
             description:
                 'Browse what exists rather than what you have: films or series by genre, year and minimum rating. Nothing is requested or added. Answered by Seerr when it is configured — TMDB-backed, so `genre` is a TMDB genre id and the rating is TMDB’s. With no Seerr it is answered from the local IMDb dataset instead, where `genre` is a name such as `Crime` and the rating is IMDb’s; passing a numeric id there is refused rather than silently matching nothing.',
-            inputSchema: z.object({
+            inputSchema: toolInput({
                 kind: z.enum(['movie', 'series']).optional().describe('Films or series. Defaults to films.'),
                 // Undocumented on purpose: the spelling this tool had when the
                 // surface froze at 1.0. Kept working forever — removing it
@@ -146,7 +146,7 @@ export function registerDiscoverMedia(
                 min_rating: z.number().min(0).max(10).optional().describe('Minimum TMDB rating out of 10.'),
                 detail: DetailSchema,
                 limit: LimitSchema
-            })
+            }, { undocumented: ['media_type'] })
         },
         async ({ kind, media_type, genre, year, min_rating, detail, limit }) => {
             const resolved =

--- a/src/tools/getCalendar.ts
+++ b/src/tools/getCalendar.ts
@@ -2,7 +2,7 @@ import type { McpServer } from '@modelcontextprotocol/server';
 import * as z from 'zod/v4';
 import type { ServiceId } from '../config/schema.ts';
 import { gather } from '../core/gather.ts';
-import { DetailSchema, LimitSchema, applyLimit, type DetailLevel } from '../core/shape.ts';
+import { DetailSchema, LimitSchema, applyLimit, toolInput, type DetailLevel } from '../core/shape.ts';
 import { hasCalendar, type CalendarEntry, type ServiceAdapter } from '../services/types.ts';
 
 export type GetCalendarResult = {
@@ -66,7 +66,7 @@ export function registerGetCalendar(server: McpServer, adapters: readonly Servic
         {
             description:
                 'Films and episodes due in a date window, merged from Radarr and Sonarr and sorted by date. Covers both upcoming releases and recently aired items, with whether each already has a file.',
-            inputSchema: z.object({
+            inputSchema: toolInput({
                 detail: DetailSchema,
                 limit: LimitSchema,
                 days_back: DaysBackSchema,

--- a/src/tools/getIndexers.ts
+++ b/src/tools/getIndexers.ts
@@ -1,7 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/server';
-import * as z from 'zod/v4';
 import { logger } from '../core/logger.ts';
-import { DetailSchema, LimitSchema, applyLimit, type DetailLevel } from '../core/shape.ts';
+import { DetailSchema, LimitSchema, applyLimit, toolInput, type DetailLevel } from '../core/shape.ts';
 import type { IndexerCapable, IndexerRejection, IndexerSummary, ServiceAdapter } from '../services/types.ts';
 
 export type GetIndexersResult = {
@@ -64,7 +63,7 @@ export function registerGetIndexers(server: McpServer, adapter: (ServiceAdapter 
         {
             description:
                 'Prowlarr indexer health: which indexers are enabled, which are temporarily disabled and why, per-indexer query and grab counts, and — at detail: full — the queries indexers recently rejected and the reasons they gave. Failure messages and rejection reasons come from the indexer itself and are fenced as untrusted data.',
-            inputSchema: z.object({ detail: DetailSchema, limit: LimitSchema })
+            inputSchema: toolInput({ detail: DetailSchema, limit: LimitSchema })
         },
         async ({ detail, limit }) => {
             const result = await buildGetIndexers(adapter, { detail, limit });

--- a/src/tools/getLibrary.ts
+++ b/src/tools/getLibrary.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/server';
 import * as z from 'zod/v4';
 import type { MergedItem } from '../core/resolver.ts';
-import { DetailSchema, LimitSchema, applyLimit, preferred, type DetailLevel } from '../core/shape.ts';
+import { DetailSchema, LimitSchema, applyLimit, preferred, toolInput, type DetailLevel } from '../core/shape.ts';
 import { unfenced } from '../core/titleMatch.ts';
 import { UserSchema } from './getPlayback.ts';
 import type { LibraryLoader } from './library.ts';
@@ -338,7 +338,7 @@ export function registerGetLibrary(server: McpServer, loader: LibraryLoader): vo
         {
             description:
                 'Your library, joined across Radarr, Sonarr and Jellyfin on shared external ids. `presence` is what no single service can tell you — but only when the absent half’s service actually answered: `arr_only` with a file means Jellyfin *was reachable and* cannot see a file the *arr believes is on disk (a likely broken import); `jellyfin_only` means nothing here is managing it, read the same way — it assumes Radarr/Sonarr answered too, and (unlike `arr_only`) is not yet hedged against their own outage. If Jellyfin is degraded, an item Radarr/Sonarr manages reports `unknown` instead of `arr_only`, and the top-level `degraded` list names it. If Jellyfin is not configured at all, `unknown` fires the same way but `degraded` stays empty — there is nothing to name as degraded — so check whether `jellyfin` even appears in your config instead. `has_file: false` with `monitored: true` is "what am I still waiting for". Two limits: `quality` applies to films only (a series’ quality is per-episode), and a series carries Sonarr’s one flat TVDB rating plus an IMDb rating **only when the IMDb dataset is enabled** — nothing else in this stack has a series’ IMDb number, so with the dataset off `rating_source: "imdb"` on a series matches nothing. `rating_source` still defaults to `tvdb` for a series, so ask for `imdb` explicitly. A rating filter also reports how much of the library that source actually covers; if that count is zero because the dataset is off or still ingesting, `ratingCoverage.note` says so — report that reason rather than telling the user their library is unrated or that the question cannot be answered. A series at `detail: "full"` also carries `seasons`: per season, how many episodes you have watched (`watched`), how many are on disk (`onDisk`), how many have aired (`aired`), and how many exist in total (`total`, which is TVDB\'s count via Sonarr). `complete` is true only when every episode of the season has been watched — and is **absent, not false**, when either half is unknown: a series no *arr manages has no `total`, and one Jellyfin has never seen has no `watched`. Season 0 is specials and is reported like any other season. `seasons` is omitted below `detail: "full"`. Each season row also carries `monitored`, Sonarr’s own per-season flag — the same field `get_media_details` reports — absent rather than false when no Sonarr manages the series.',
-            inputSchema: z.object({
+            inputSchema: toolInput({
                 kind: z.enum(['movie', 'series']).optional().describe('Films or series. Omit for both.'),
                 year: z.number().int().optional(),
                 genre: z.string().min(1).optional().describe('Matched case-insensitively against the *arr genres.'),
@@ -384,7 +384,7 @@ export function registerGetLibrary(server: McpServer, loader: LibraryLoader): vo
                     ),
                 detail: DetailSchema,
                 limit: LimitSchema
-            })
+            }, { undocumented: ['watched_by'] })
         },
         async input => {
             const { user, watched_by, ...rest } = input as LibraryQuery & { user?: string };

--- a/src/tools/getMediaDetails.ts
+++ b/src/tools/getMediaDetails.ts
@@ -5,7 +5,7 @@ import { ServiceIdSchema, type ServiceId } from '../config/schema.ts';
 import { ServiceError } from '../core/errors.ts';
 import { servicesOnly } from '../core/gather.ts';
 import type { MergedItem } from '../core/resolver.ts';
-import { DetailSchema, LimitSchema, type DetailLevel } from '../core/shape.ts';
+import { DetailSchema, LimitSchema, toolInput, type DetailLevel } from '../core/shape.ts';
 import { enrichWithImdb } from '../metadata/enrich.ts';
 import { SeerrAdapter } from '../services/seerr.ts';
 import type { ImdbDataset } from '../metadata/imdbDataset.ts';
@@ -159,7 +159,7 @@ export function registerGetMediaDetails(
         {
             description:
                 'Everything known about one item. Give a title as `query` for the merged record — acquisition, watch state, ratings and presence joined across services — or `service` plus `id` for one service’s raw view, which is how you inspect a join that looks wrong — the explicit id wins if both are given. A series at detail: full also returns its episodes. Asked by title, a series also carries `seasons`: per-season `watched` and `lastPlayed` from Jellyfin, `onDisk`, `aired` and `total` from Sonarr, and `complete`, which is absent rather than false whenever it cannot be known. Both forms — by title and by `service` plus `id` — carry `seasons[].monitored`, Sonarr’s own per-season monitoring flag, absent rather than false when no Sonarr manages the series. Check it before delete_episode_files: deleting the files of a season that is still monitored makes Sonarr search for them again and re-download exactly what was removed.',
-            inputSchema: z.object({
+            inputSchema: toolInput({
                 query: z.string().min(1).optional().describe('A title. Resolved through the library index.'),
                 service: ServiceIdSchema.optional().describe('With `id`: one service’s own view.'),
                 instance: z.string().optional().describe(INSTANCE_PARAM_DESCRIPTION),

--- a/src/tools/getPlayback.ts
+++ b/src/tools/getPlayback.ts
@@ -2,7 +2,7 @@ import type { McpServer } from '@modelcontextprotocol/server';
 import * as z from 'zod/v4';
 import type { IdentityResolver } from '../core/identity.ts';
 import { logger } from '../core/logger.ts';
-import { DetailSchema, LimitSchema, applyLimit, type DetailLevel } from '../core/shape.ts';
+import { DetailSchema, LimitSchema, applyLimit, toolInput, type DetailLevel } from '../core/shape.ts';
 import type { JellyfinAdapter } from '../services/jellyfin.ts';
 import type { PlaybackEntry } from '../services/types.ts';
 
@@ -68,7 +68,7 @@ export function registerGetPlayback(
         {
             description:
                 'What a Jellyfin user is watching now and what they can continue watching, with position and completion. Watch state exists only in Jellyfin — Radarr and Sonarr have no concept of it. Defaults to the configured user; reading another requires allow_other_users.',
-            inputSchema: z.object({ detail: DetailSchema, limit: LimitSchema, user: UserSchema })
+            inputSchema: toolInput({ detail: DetailSchema, limit: LimitSchema, user: UserSchema })
         },
         async ({ detail, limit, user }) => {
             const result = await buildGetPlayback(adapter, resolver, {

--- a/src/tools/getQueue.ts
+++ b/src/tools/getQueue.ts
@@ -1,8 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/server';
-import * as z from 'zod/v4';
 import type { ServiceId } from '../config/schema.ts';
 import { gather } from '../core/gather.ts';
-import { DetailSchema, LimitSchema, applyLimit, type DetailLevel } from '../core/shape.ts';
+import { DetailSchema, LimitSchema, applyLimit, toolInput, type DetailLevel } from '../core/shape.ts';
 import { hasQueue, type QueueItem, type ServiceAdapter } from '../services/types.ts';
 
 export type GetQueueResult = {
@@ -46,7 +45,7 @@ export function registerGetQueue(server: McpServer, adapters: readonly ServiceAd
         {
             description:
                 'Everything currently downloading or stalled, merged across Radarr, Sonarr, SABnzbd and Transmission. Sizes are bytes and ETAs are seconds regardless of how each service reports them. Titles are release names from public indexers and are fenced as untrusted data.',
-            inputSchema: z.object({ detail: DetailSchema, limit: LimitSchema })
+            inputSchema: toolInput({ detail: DetailSchema, limit: LimitSchema })
         },
         async ({ detail, limit }) => {
             const result = await buildGetQueue(adapters, { detail, limit });

--- a/src/tools/getRequests.ts
+++ b/src/tools/getRequests.ts
@@ -2,7 +2,7 @@ import type { McpServer } from '@modelcontextprotocol/server';
 import * as z from 'zod/v4';
 import type { IdentityResolver } from '../core/identity.ts';
 import { logger } from '../core/logger.ts';
-import { DetailSchema, LimitSchema, applyLimit, type DetailLevel } from '../core/shape.ts';
+import { DetailSchema, LimitSchema, applyLimit, toolInput, type DetailLevel } from '../core/shape.ts';
 import type { SeerrAdapter } from '../services/seerr.ts';
 import type { MediaRequest, RequestStatus } from '../services/types.ts';
 import { UserSchema } from './getPlayback.ts';
@@ -66,7 +66,7 @@ export function registerGetRequests(
         {
             description:
                 'Media requests in Seerr — pending, approved or declined — for one user. Defaults to the configured user; reading another requires allow_other_users.',
-            inputSchema: z.object({
+            inputSchema: toolInput({
                 detail: DetailSchema,
                 limit: LimitSchema,
                 user: UserSchema,

--- a/src/tools/getSubtitles.ts
+++ b/src/tools/getSubtitles.ts
@@ -1,7 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/server';
-import * as z from 'zod/v4';
 import { logger } from '../core/logger.ts';
-import { DetailSchema, LimitSchema, applyLimit, type DetailLevel } from '../core/shape.ts';
+import { DetailSchema, LimitSchema, applyLimit, toolInput, type DetailLevel } from '../core/shape.ts';
 import type { ServiceAdapter, SubtitleCapable, SubtitleGap, SubtitleProvider } from '../services/types.ts';
 
 export type GetSubtitlesResult = {
@@ -96,7 +95,7 @@ export function registerGetSubtitles(server: McpServer, adapters: readonly (Serv
         {
             description:
                 'Subtitles Bazarr knows are missing, for both films and episodes, with the languages wanted for each — and which subtitle providers are currently working, throttled, or blocked, which is usually why something is missing. Release names come from public indexers and are fenced as untrusted data.',
-            inputSchema: z.object({ detail: DetailSchema, limit: LimitSchema })
+            inputSchema: toolInput({ detail: DetailSchema, limit: LimitSchema })
         },
         async ({ detail, limit }) => {
             const result = await buildGetSubtitles(adapters, { detail, limit });

--- a/src/tools/lookupMedia.ts
+++ b/src/tools/lookupMedia.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/server';
 import * as z from 'zod/v4';
-import { DetailSchema, LimitSchema, type DetailLevel } from '../core/shape.ts';
+import { DetailSchema, LimitSchema, toolInput, type DetailLevel } from '../core/shape.ts';
 import type { ImdbDataset } from '../metadata/imdbDataset.ts';
 import type { ServiceAdapter } from '../services/types.ts';
 import { buildSearchMedia, type GetSearchResult } from './searchMedia.ts';
@@ -31,7 +31,7 @@ export function registerLookupMedia(
         {
             description:
                 'Metadata for something you may not have: title, year, and external ids, from Radarr, Sonarr and Seerr. Reads only — nothing is added, requested or monitored.',
-            inputSchema: z.object({
+            inputSchema: toolInput({
                 query: z.string().min(1).describe('What to look up.'),
                 detail: DetailSchema,
                 limit: LimitSchema

--- a/src/tools/searchMedia.ts
+++ b/src/tools/searchMedia.ts
@@ -2,7 +2,7 @@ import type { McpServer } from '@modelcontextprotocol/server';
 import * as z from 'zod/v4';
 import type { ServiceId } from '../config/schema.ts';
 import { gather } from '../core/gather.ts';
-import { DetailSchema, LimitSchema, applyLimit, type DetailLevel } from '../core/shape.ts';
+import { DetailSchema, LimitSchema, applyLimit, toolInput, type DetailLevel } from '../core/shape.ts';
 import { rankTitle, unfenced } from '../core/titleMatch.ts';
 import { enrichWithImdb } from '../metadata/enrich.ts';
 import type { ImdbDataset } from '../metadata/imdbDataset.ts';
@@ -63,7 +63,7 @@ export function registerSearchMedia(
         {
             description:
                 'Search across the stack: your existing library, metadata for things you do not have yet, or what indexers currently offer. Indexer results contain attacker-controllable release names and are returned inside an explicit untrusted-data boundary.',
-            inputSchema: z.object({
+            inputSchema: toolInput({
                 query: z.string().min(1).describe('What to search for.'),
                 source: z
                     .enum(['library', 'discover', 'indexers'])

--- a/src/tools/stackHealth.ts
+++ b/src/tools/stackHealth.ts
@@ -1,10 +1,9 @@
 import type { McpServer } from '@modelcontextprotocol/server';
 import type { ServiceInstance } from '../config/instances.ts';
 import type { ServiceId } from '../config/schema.ts';
-import * as z from 'zod/v4';
 import { ServiceError } from '../core/errors.ts';
 import { logger } from '../core/logger.ts';
-import { DetailSchema, LimitSchema, applyLimit, type DetailLevel } from '../core/shape.ts';
+import { DetailSchema, LimitSchema, applyLimit, toolInput, type DetailLevel } from '../core/shape.ts';
 import {
     hasDiskSpace,
     hasHealthChecks,
@@ -280,7 +279,7 @@ export function registerStackHealth(
         {
             description:
                 'Health of every configured service: version, disk space, failing health checks, when each library was last scanned, and what each instance is permitted to do. Returns partial results with a `degraded` list rather than failing when a service is down. The `permissions` list is also the set of ids you may pass as `instance` to other tools. `endpoints` gives each instance\'s base URL, for scripts that need to reach a service directly. API keys are never returned by any tool in this server — a script that needs one runs beside the config and reads it there.',
-            inputSchema: z.object({ detail: DetailSchema, limit: LimitSchema })
+            inputSchema: toolInput({ detail: DetailSchema, limit: LimitSchema })
         },
         async ({ detail, limit }) => {
             const result = await buildStackHealth(adapters, { detail, limit }, instances);

--- a/src/tools/write.ts
+++ b/src/tools/write.ts
@@ -4,6 +4,7 @@ import type { WriteAudit } from '../core/audit.ts';
 import type { ConfirmTokens, WriteIntent } from '../core/confirm.ts';
 import { ServiceError } from '../core/errors.ts';
 import { checkPermission, type PermissionSource, type WriteTier } from '../core/permissions.ts';
+import { toolInput } from '../core/shape.ts';
 import type { LibraryLoader } from './library.ts';
 
 /**
@@ -127,7 +128,13 @@ export function registerWriteTool<Schema extends z.ZodObject>(
         spec.name,
         {
             description: spec.description,
-            inputSchema: spec.inputSchema.extend({ dry_run: DryRunSchema, confirm: ConfirmSchema })
+            // Rebuilt through `toolInput` rather than extended, and the
+            // difference is the error text: strictness carried over from the
+            // spec's own schema would list only the tool's half, so a caller
+            // that mistyped one argument would be told `dry_run` and `confirm`
+            // — the two parameters the write protocol itself runs on — are not
+            // parameters of this tool.
+            inputSchema: toolInput({ ...spec.inputSchema.shape, dry_run: DryRunSchema, confirm: ConfirmSchema })
         },
         async (raw: Record<string, unknown>) => {
             const { dry_run: dryRun, confirm: presented, ...rest } = raw as {

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -284,6 +284,103 @@ describe('a thrown ServiceError reaches the client with its remedy', () => {
 });
 
 /**
+ * Reported from a live agent session (#103): a caller sent `offset`, `source`
+ * and `totally_made_up` to `get_library` and got a clean 200 back. Nothing
+ * objected, so the model concluded the parameters existed and that its
+ * pagination was simply broken — it then reported a 243-item library as
+ * unpaginable, having never learned that `limit` was the parameter it wanted.
+ *
+ * A dropped argument is indistinguishable from an honoured one, which makes
+ * silence the worst possible answer: the caller's next move is to trust the
+ * result. These run through the real HTTP path because the SDK validates
+ * against the schema *before* the handler — a test that calls the handler
+ * directly, as `toolSurface.test.ts` does, never sees this at all.
+ */
+describe('an argument this server does not have is refused, not ignored', () => {
+    const callTool = async (name: string, args: Record<string, unknown>) => {
+        const res = await app().request(
+            'http://localhost:6060/mcp',
+            rpc(
+                { jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name, arguments: args } },
+                { Authorization: `Bearer ${TOKEN}` }
+            )
+        );
+        const payload = await rpcPayload(res);
+        return (payload.result ?? {}) as { isError?: boolean; content?: { type: string; text: string }[] };
+    };
+
+    it('refuses the exact call from #103, naming every invented parameter', async () => {
+        const result = await callTool('get_library', { offset: 100, source: 'media', totally_made_up: true });
+
+        expect(result.isError).toBe(true);
+        const text = result.content?.[0]?.text ?? '';
+        expect(text).toContain('offset');
+        expect(text).toContain('source');
+        expect(text).toContain('totally_made_up');
+    });
+
+    /**
+     * The half that turns a refusal into a recovery. "offset is not a
+     * parameter" leaves the model exactly as stuck as silence did; naming the
+     * parameters it *can* send is what lets it find `limit` on its own, which
+     * is the answer it was looking for in #103.
+     */
+    it('names the parameters the tool does accept, so the caller can correct itself', async () => {
+        const text = (await callTool('get_library', { offset: 100 })).content?.[0]?.text ?? '';
+
+        expect(text).toContain('limit');
+        expect(text).toContain('min_rating');
+    });
+
+    /**
+     * The undocumented 1.0 spellings are accepted and stay unadvertised — an
+     * error message that listed them would teach the old name to every caller
+     * that made a typo, which is the one thing keeping them undocumented was
+     * for.
+     */
+    it('still accepts the undocumented aliases, and does not advertise them', async () => {
+        expect((await callTool('get_library', { watched_by: 'Someone' })).isError).toBeFalsy();
+        expect((await callTool('discover_media', { media_type: 'tv' })).isError).toBeFalsy();
+
+        const text = (await callTool('get_library', { offset: 1 })).content?.[0]?.text ?? '';
+        expect(text).not.toContain('watched_by');
+    });
+
+    /**
+     * `dry_run` and `confirm` are added to every write tool by
+     * `registerWriteTool`, after the tool declared its own arguments — so a
+     * strictness applied only to the tool's half would refuse the two
+     * parameters the write protocol itself depends on.
+     */
+    it('keeps the write protocol’s own parameters valid on a write tool', async () => {
+        const text = (await callTool('set_monitoring', { nonsense: 1 })).content?.[0]?.text ?? '';
+
+        expect(text).toContain('nonsense');
+        expect(text).toContain('dry_run');
+        expect(text).toContain('confirm');
+    });
+
+    /**
+     * The guard for tool number twenty. Strictness that has to be remembered
+     * per tool is strictness that will be forgotten, and the failure mode is
+     * silent — so this asserts the property across the whole surface rather
+     * than sampling it.
+     */
+    it('advertises no tool that would accept an unknown argument', async () => {
+        const res = await app().request(
+            'http://localhost:6060/mcp',
+            rpc(toolsList, { Authorization: `Bearer ${TOKEN}` })
+        );
+        const { result } = (await rpcPayload(res)) as {
+            result: { tools: { name: string; inputSchema: { additionalProperties?: boolean } }[] };
+        };
+
+        const permissive = result.tools.filter(t => t.inputSchema.additionalProperties !== false);
+        expect(permissive.map(t => t.name)).toEqual([]);
+    });
+});
+
+/**
  * The bet this whole phase rests on: client support for prompts and resources
  * is uneven, and arr-mcp has to work on all of them. So a client that surfaces
  * neither must be exactly as capable as before. Too central to leave resting on


### PR DESCRIPTION
Closes #103.

## What happened

An agent sent `{"offset":100,"source":"media","totally_made_up":true}` to `get_library` and got a clean `200`. All three were invented — `get_library` has never had `offset` or `source` — and `z.object` strips unknown keys, so the call succeeded with them silently removed.

That is the worst answer available, because a dropped argument and an honoured one produce the identical response. The agent concluded pagination and filtering were broken here and reported a 243-item library as unpaginable. It never found `limit`, which was the parameter it wanted, because nothing in the exchange suggested it was looking in the wrong place.

## The fix

Every tool's arguments now go through `toolInput` in `core/shape.ts` — a strict object whose unrecognized-keys error names both halves:

> Invalid arguments for tool get_library: Unknown argument(s): offset, source, totally_made_up. They were refused rather than ignored, because a dropped argument is indistinguishable from one that worked. This tool accepts: detail, genre, has_file, kind, limit, min_rating, monitored, presence, quality, rating_source, sort, user, watched, year.

The second half is the point. "`offset` is not a parameter" leaves a model exactly as stuck as silence did; the list is what lets it correct itself in one turn.

Two details worth the names they cost:

- **`undocumented`** keeps the frozen-at-1.0 spellings (`watched_by`, `media_type`) working while leaving them out of that list. Advertising them in an error would teach the old name to every caller who made a typo, which is the one thing keeping them undocumented was for.
- **Write tools are wrapped, not extended.** `registerWriteTool` rebuilds the schema through `toolInput` after merging `dry_run` and `confirm`, so a caller who mistypes one argument is not told that the two parameters the write protocol runs on are parameters the tool does not have.

## Second commit: `trigger_scan` was documented nowhere

Found while writing the first. The server advertises 22 tools; `docs/tools.md` listed 21, `docs/writes.md` gave tiers for eight of the nine writes, and `trigger_scan` appeared in neither, nor in the README. It has been reachable and invisible since it was added, and it is the remedy `diagnose` reports most often.

Same failure one layer up: someone reading the docs to learn the surface would conclude the tool did not exist, exactly as an agent reading a silent `200` concluded `offset` did.

## Compatibility

Nothing accepted before is refused now — only arguments that were already being thrown away. No parameter is renamed or removed, so this is a `fix:` rather than a break. A client that has been sending junk alongside valid arguments will now see an error where it saw a silent success; that is the intended change.

## Verification

- New tests in `test/app.test.ts` drive the real HTTP path, because the SDK validates before the handler — a test calling the handler directly (as `toolSurface.test.ts` does) never sees this. They cover the exact #103 call, the accepted-parameter list, the undocumented aliases staying accepted and unadvertised, the write-tool path, and a guard asserting no advertised tool would accept an unknown argument.
- 1343 tests pass; lint and typecheck clean.
- Verified live against a running instance, not only through the suite: the #103 call, a valid call, an alias call and a write tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
