### PR TITLE
feat: pagination, output schemas, and a plain-JSON transport path

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ Your MCP client goes to `http://<host>:6060/mcp` with the bearer token shown on
 the dashboard. Everything the UI does is still just `config.yaml`, and editing
 that by hand remains supported.
 
+A client that asks for `Accept: application/json` — or sends no `Accept` at
+all — gets a single JSON object back with a `Content-Length`, rather than being
+refused for not also naming `text/event-stream`. One that does accept a stream
+still gets one. So a plain `curl` or `requests.post` works as-is, and so does a
+full MCP client.
+
 Image tags are `X.Y.Z`, `X.Y`, `X` and `latest`, plus `main` for bleeding edge.
 Pin a minor — `:1.4` — if you would rather approve each new tool surface
 yourself.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -35,8 +35,20 @@ not obvious, and the places where a value is deliberately absent rather than
 ## Every tool answers the same way
 
 Every tool but `diagnose` takes `detail` (`minimal`/`standard`/`full`) and
-`limit`, and reports `{ total, returned, truncated }` — a truncated answer
-always says so.
+`limit`, and reports `{ total, returned, offset, truncated }` — a truncated
+answer always says so.
+
+**Paging.** Every list tool also takes `offset`: page two of fifty is
+`offset: 50`. `total` always counts the whole list rather than the window, so
+`offset + returned < total` is how you know another page exists. `truncated`
+answers a different question — *this is not the whole list* — and so stays
+`true` on the last page of a walk, where everything you already read is behind
+you. Pair `offset` with `sort` when the order matters: without one the order is
+whatever the services returned, and an item can move between pages.
+
+`stack_health` is the exception and takes no `offset`. One `limit` budget spans
+its two lists, spent on failures before disks, so a single number could not say
+which list it meant to skip into — and neither is one you page through.
 
 Tools spanning several services also report which ones they could not reach, and
 how many results each contributed, so a long answer from one service can never

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -57,6 +57,12 @@ silently hide another.
 `diagnose` takes a title, or an exact `service` plus `id`, and returns a verdict
 rather than a list.
 
+**Every answer comes twice: a sentence and a structure.** The summary line is
+for a reader; `structuredContent` is the contract, and every tool declares its
+shape as an `outputSchema` so a client knows what it will get before it calls.
+Read `total` from there rather than parsing it out of "50 of 243 item(s)" —
+that sentence is prose and may be reworded.
+
 **An argument a tool does not have is refused, and the refusal lists the ones it
 does have.** Dropping it silently would be worse than it sounds: the call
 succeeds, the invented argument is gone, and the answer is indistinguishable

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,6 +6,7 @@ import type { WriteAudit } from './core/audit.ts';
 import { logger } from './core/logger.ts';
 import type { LogStore } from './core/logs.ts';
 import type { Runtime } from './core/runtime.ts';
+import { acceptingBoth, acceptsStream, asPlainJson } from './mcp/plainJson.ts';
 import { registerAllPrompts } from './mcp/prompts.ts';
 import { registerAllResources } from './mcp/resources.ts';
 import { registerAllTools } from './tools/register.ts';
@@ -105,7 +106,18 @@ export function buildApp(opts: { runtime: Runtime; audit: WriteAudit; logs: LogS
             return c.json({ error: 'unauthorized' }, 401, { 'WWW-Authenticate': 'Bearer realm="arr-mcp"' });
         }
 
-        return handler.fetch(c.req.raw, { parsedBody: c.get('parsedBody') });
+        // A client that never asked for a stream gets one JSON object with a
+        // Content-Length rather than an SSE frame in a chunked body — and, more
+        // to the point, is not refused with a 406 for saying so. See
+        // `plainJson.ts`: both halves of that were how #103 started.
+        // Both media types, always — the transport demands both and refuses a
+        // request naming only one, which caught a client asking for JSON *and*
+        // a client asking for a stream. What the caller actually wanted is
+        // decided on the way out, not by whether it guessed the header.
+        const streaming = acceptsStream(c.req.raw);
+        const response = await handler.fetch(acceptingBoth(c.req.raw), { parsedBody: c.get('parsedBody') });
+
+        return streaming ? response : asPlainJson(response);
     });
 
     return app;

--- a/src/core/shape.ts
+++ b/src/core/shape.ts
@@ -20,6 +20,25 @@ export const LimitSchema = z
     .describe(`Maximum items to return. Defaults to ${DEFAULT_LIMIT}, hard maximum ${MAX_LIMIT}.`);
 
 /**
+ * How many to skip — the other half of `limit`, and the parameter #103 guessed
+ * at because a library past `MAX_LIMIT` could not be read in full without it.
+ *
+ * Unbounded above, unlike `limit`: `limit` caps how much context one answer can
+ * spend, which is a real cost, while a large `offset` only means a caller is
+ * deep into a list and costs nothing to serve. Capping it would put items past
+ * the cap permanently out of reach, which is the bug this parameter exists to
+ * fix.
+ */
+export const OffsetSchema = z
+    .number()
+    .int()
+    .min(0)
+    .default(0)
+    .describe(
+        'How many items to skip before the window `limit` returns — page two of 50 is `offset: 50`. `total` always counts the whole list, so `offset + returned < total` is how you know there is another page. Pair it with `sort` for a stable walk: without one the order is whatever the services returned, and an item can move between pages.'
+    );
+
+/**
  * Every tool's arguments, refusing the ones it does not have.
  *
  * A plain `z.object` **strips** unknown keys, which is the quietest possible
@@ -62,23 +81,39 @@ export function toolInput<T extends z.ZodRawShape>(
 /**
  * The truncation contract from Silent truncation is how a
  * model confidently reports that a 900-film library contains 50 films, so
- * every read tool routes its list through here and serialises all four fields.
+ * every read tool routes its list through here and serialises all five fields.
  *
  * `limit` is clamped defensively even though LimitSchema also caps it — a
  * future internal caller that bypasses the schema must not be able to request
  * 5000 items, and must not be able to request zero and get a silently empty
  * list back.
+ *
+ * `offset` is clamped only at zero, and not at the top: a window past the end
+ * is an empty page, which is the honest answer to "give me items 900–950 of
+ * 243". A negative one starts at the beginning rather than reaching `slice`,
+ * where it would count backwards from the end and hand back the last few items
+ * as though they were the first.
+ *
+ * `truncated` keeps the meaning it had before an offset existed — *this is not
+ * the whole list* — rather than becoming "there is more after this window".
+ * Under the second reading the last page of a paged walk reports `false` with
+ * everything the caller never saw sitting in front of it, which is the same
+ * false completeness the field was added to prevent. "Is there another page" is
+ * `offset + returned < total`, and every term is in the response.
  */
 export function applyLimit<T>(
     items: readonly T[],
-    limit: number
-): { items: T[]; total: number; returned: number; truncated: boolean } {
+    limit: number,
+    offset = 0
+): { items: T[]; total: number; returned: number; offset: number; truncated: boolean } {
     const effective = Math.min(Math.max(Math.trunc(limit), 1), MAX_LIMIT);
-    const sliced = items.slice(0, effective);
+    const start = Math.max(Math.trunc(offset), 0);
+    const sliced = items.slice(start, start + effective);
     return {
         items: sliced,
         total: items.length,
         returned: sliced.length,
+        offset: start,
         truncated: sliced.length < items.length
     };
 }

--- a/src/core/shape.ts
+++ b/src/core/shape.ts
@@ -79,6 +79,56 @@ export function toolInput<T extends z.ZodRawShape>(
 }
 
 /**
+ * The truncation envelope, declared so a client can read it *before* it calls.
+ *
+ * #103 reported `total` as missing from `structuredContent`. It was never
+ * missing — but no tool declared an `outputSchema`, and a client that gates
+ * `structuredContent` on a declared schema surfaces nothing without one, which
+ * from the far side is indistinguishable from the field not existing. The
+ * reporter fell back to parsing "50 of 243 item(s)" out of the summary
+ * sentence, which is prose written for a reader and not a contract.
+ *
+ * **Loose, and deliberately.** The SDK validates `structuredContent` against
+ * this and fails the whole call on a mismatch, so a schema that tried to
+ * enumerate every tool's fields would turn a documentation gap into an outage
+ * the first time one of them returned something unforeseen. Everything shared
+ * is named; `items` and per-tool extras (`ratingCoverage`, `providers`,
+ * `recentRejections`) ride through unconstrained. `projectCallToolResult` does
+ * not strip to the schema, so nothing is lost by leaving them undeclared.
+ *
+ * `items` stays `unknown` for the same reason: what an item *is* differs per
+ * tool and is described in that tool's own description, where a model reads it.
+ */
+export const TruncationSchema = z.looseObject({
+    items: z.array(z.unknown()).describe('The window of results. What an item carries depends on the tool and on `detail`.'),
+    total: z
+        .number()
+        .int()
+        .describe('How many matched in total — the whole list, never the window. Compare against `returned` before reporting a count to anyone.'),
+    returned: z.number().int().describe('How many are in `items`.'),
+    offset: z.number().int().describe('How many were skipped. `offset + returned < total` means there is another page.'),
+    truncated: z
+        .boolean()
+        .describe('True when this is not the whole list — including on the last page of a paged walk, where the rest is behind you rather than ahead.')
+});
+
+/**
+ * A whole tool's answer: the truncation envelope plus who failed to answer.
+ *
+ * Separate from `TruncationSchema` because `stack_health` nests two truncated
+ * lists inside one answer and reports `degraded` once, at the top, for both.
+ * Requiring it on the inner lists asserted something no tool produces — and,
+ * being an output schema, that did not read as a wrong description: it failed
+ * the call outright. Which is how the split came to exist.
+ */
+export const PagedOutputSchema = TruncationSchema.extend({
+    degraded: z
+        .array(z.string())
+        .describe('Services that could not be reached. Their contribution is missing from `items`, so a short list may be an outage rather than an answer.'),
+    counts: z.record(z.string(), z.number()).optional().describe('How many results each service contributed.')
+});
+
+/**
  * The truncation contract from Silent truncation is how a
  * model confidently reports that a 900-film library contains 50 films, so
  * every read tool routes its list through here and serialises all five fields.

--- a/src/mcp/plainJson.ts
+++ b/src/mcp/plainJson.ts
@@ -1,0 +1,122 @@
+/**
+ * Answering a plain HTTP client in plain JSON.
+ *
+ * The streamable HTTP transport requires a POST to accept **both**
+ * `application/json` and `text/event-stream`, and the SDK enforces it with a
+ * `406 Not Acceptable` before the request reaches any tool. That is
+ * spec-conformant and, for a stateless server that never pushes anything, it
+ * buys nothing: a client that says `Accept: application/json` is refused
+ * outright, and the reason it gives is a header, which reads as "this server is
+ * broken" from the other end.
+ *
+ * That is one half of #103. The agent could not load tools, hand-rolled its own
+ * HTTP calls, and its first attempt failed on the header. The second half is
+ * what it got when it corrected that: an SSE frame inside a chunked body, which
+ * it tried to parse as JSON and which produced `Extra data: line 1 column 4` —
+ * the hex chunk-size line `2e6` parsing as the number 2×10⁶. Both halves are a
+ * client that wanted one JSON object and could not get one.
+ *
+ * So: the request is upgraded to accept both — the tools do not care, and this
+ * is the only thing standing between a working call and a 406 — and if the
+ * client never asked for a stream, the SSE frame is unwrapped again on the way
+ * out. The result is `application/json` with a `Content-Length`: no framing, no
+ * chunk headers, nothing to misparse. The spec allows exactly this ("the server
+ * MAY return `application/json`"), and a client that *does* accept
+ * `text/event-stream` is left completely alone.
+ *
+ * What this deliberately does not do is make the server less strict about
+ * anything that matters. It relaxes a transport header, not an argument, a
+ * permission or a token — #103's actual lesson being that this server had those
+ * exactly backwards.
+ */
+
+const STREAM = 'text/event-stream';
+const JSON_TYPE = 'application/json';
+
+/** Whether the caller is prepared to read an SSE stream. */
+export const acceptsStream = (request: Request): boolean =>
+    (request.headers.get('accept') ?? '').toLowerCase().includes(STREAM);
+
+/**
+ * The same request, accepting both media types.
+ *
+ * Headers only — the body is not touched and not read. `/mcp` always hands the
+ * handler a `parsedBody` (the Hono adapter parses one from a clone), so the
+ * request stream itself is never consumed here or afterwards.
+ */
+export function acceptingBoth(request: Request): Request {
+    const headers = new Headers(request.headers);
+    headers.set('accept', `${JSON_TYPE}, ${STREAM}`);
+    return new Request(request, { headers });
+}
+
+/**
+ * The JSON-RPC messages carried by an SSE body.
+ *
+ * One event may spread its payload over several `data:` lines, which the
+ * protocol says to rejoin with newlines — the SDK never does, writing one line
+ * per message, but a parser that only handles the shape it has seen is how the
+ * next version breaks quietly.
+ */
+function eventPayloads(body: string): string[] {
+    return body
+        .split(/\r?\n\r?\n/)
+        .map(event =>
+            event
+                .split(/\r?\n/)
+                .filter(line => line.startsWith('data:'))
+                .map(line => line.slice('data:'.length).trimStart())
+                .join('\n')
+        )
+        .filter(payload => payload.length > 0);
+}
+
+/** A response, never a notification: what a caller is waiting on. */
+const isResponse = (message: unknown): boolean =>
+    typeof message === 'object' && message !== null && 'id' in message && !('method' in message);
+
+/**
+ * An SSE response rendered as a single JSON body.
+ *
+ * Anything that is not an SSE frame — a 401, the 405 on GET, an already-JSON
+ * error — is returned untouched, so this can sit in front of every response
+ * without knowing which ones it will need to change.
+ *
+ * Mid-call notifications are dropped rather than concatenated, which is what
+ * the SDK's own `responseMode: 'json'` does: a caller that cannot read a stream
+ * cannot be sent progress either, and appending a second JSON object to the
+ * body would hand it precisely the "extra data" that made #103 unparseable.
+ * If nothing in the frame is a response, the original is passed through rather
+ * than being replaced by an invented one.
+ */
+export async function asPlainJson(response: Response): Promise<Response> {
+    if (!(response.headers.get('content-type') ?? '').includes(STREAM)) return response;
+
+    const body = await response.text();
+    const messages = eventPayloads(body).flatMap(payload => {
+        try {
+            return [JSON.parse(payload) as unknown];
+        } catch {
+            return [];
+        }
+    });
+
+    const responses = messages.filter(isResponse);
+    if (responses.length === 0) return new Response(body, { status: response.status, headers: response.headers });
+
+    const headers = new Headers(response.headers);
+    headers.set('content-type', JSON_TYPE);
+    // Set by the SSE path for proxies that would otherwise buffer a stream.
+    // There is no stream now, and leaving them would describe a response this
+    // no longer is.
+    headers.delete('x-accel-buffering');
+    headers.delete('transfer-encoding');
+
+    // A batch in, a batch out: a caller that sent one request must not have to
+    // handle an array, and one that sent several must not be handed only the
+    // first.
+    return new Response(JSON.stringify(responses.length === 1 ? responses[0] : responses), {
+        status: response.status,
+        headers
+    });
+}

--- a/src/tools/diagnose/index.ts
+++ b/src/tools/diagnose/index.ts
@@ -19,6 +19,25 @@ export function registerDiagnose(server: McpServer, deps: DiagnoseDeps): void {
         {
             description:
                 'Why is this not playable? Walks the whole chain — requested, managed, monitored, downloaded, indexed, imported, scanned — and names the first thing that explains the absence, with what to do about it. Give a title as `query` for how a person actually asks; give `service` plus `id` only when you already have an exact item in hand (e.g. from get_media_details) — the explicit id wins if both are given. Works with services down: any step it could not check sets `certain: false` and the summary says what was missed, rather than guessing across the hole.',
+            // A verdict, not a list — so no paged envelope. `certain` is the
+            // field that matters most and the one a client must not have to
+            // read prose to find: a diagnosis reached across a service that
+            // could not be checked is a guess, and reporting it as an answer is
+            // how someone gets told their file is fine when nothing looked.
+            outputSchema: z.looseObject({
+                query: z.string(),
+                resolved: z.looseObject({}).optional().describe('What the title resolved to. Absent when nothing matched.'),
+                steps: z.array(z.unknown()).describe('The chain, in the order it runs: requested, managed, monitored, downloaded, indexed, imported, scanned.'),
+                verdict: z.looseObject({
+                    stage: z.string().describe('The first stage that explains the absence, or `playable`.'),
+                    summary: z.string(),
+                    remedy: z.string().optional(),
+                    certain: z
+                        .boolean()
+                        .describe('False when a step could not be checked. Report the verdict as provisional and say what was missed rather than guessing across the hole.')
+                }),
+                degraded: z.array(z.string())
+            }),
             inputSchema: toolInput({
                 query: z.string().min(1).optional().describe('A title — how a person actually asks.'),
                 service: ServiceIdSchema.optional().describe('With `id`: an exact item, when one is already in hand.'),

--- a/src/tools/discoverMedia.ts
+++ b/src/tools/discoverMedia.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/server';
 import * as z from 'zod/v4';
 import { logger } from '../core/logger.ts';
-import { DetailSchema, LimitSchema, applyLimit, preferred, toolInput, type DetailLevel } from '../core/shape.ts';
+import { DetailSchema, LimitSchema, OffsetSchema, applyLimit, preferred, toolInput, type DetailLevel } from '../core/shape.ts';
 import type { SeerrAdapter } from '../services/seerr.ts';
 import { fenceText } from '../core/fence.ts';
 import { enrichWithImdb } from '../metadata/enrich.ts';
@@ -25,6 +25,7 @@ export async function buildDiscoverMedia(
         minRating?: number;
         detail: DetailLevel;
         limit: number;
+        offset?: number;
     },
     dataset?: ImdbDataset | undefined
 ): Promise<GetSearchResult> {
@@ -56,7 +57,7 @@ export async function buildDiscoverMedia(
     // TMDB-backed, so a hit carrying an imdb id gains an IMDb rating beside
     // the TMDB one it already had — source selection and enrichment are
     // independent decisions.
-    const shaped = applyLimit(hits, opts.limit);
+    const shaped = applyLimit(hits, opts.limit, opts.offset);
     const rated = enrichWithImdb(shaped.items, dataset);
 
     return {
@@ -81,7 +82,7 @@ export async function buildDiscoverMedia(
  * rejected rather than silently returning nothing.
  */
 function fromDataset(
-    opts: { kind: 'movie' | 'series'; genre?: string; year?: number; minRating?: number; detail: DetailLevel; limit: number },
+    opts: { kind: 'movie' | 'series'; genre?: string; year?: number; minRating?: number; detail: DetailLevel; limit: number; offset?: number },
     dataset: ImdbDataset | undefined
 ): GetSearchResult {
     const empty = { items: [], total: 0, returned: 0, truncated: false, degraded: [], counts: {} };
@@ -120,7 +121,7 @@ function fromDataset(
     // back rather than what exists — the dataset holds ~10^7 titles and
     // counting the full match set would cost a second query to tell the caller
     // a number they cannot page through anyway.
-    const shaped = applyLimit(hits, opts.limit);
+    const shaped = applyLimit(hits, opts.limit, opts.offset);
     return { ...shaped, items: shaped.items.map(h => project(h, opts.detail)), degraded: [], counts: {} };
 }
 
@@ -145,10 +146,11 @@ export function registerDiscoverMedia(
                 year: z.number().int().min(1900).max(2100).optional().describe('Restrict to one release year.'),
                 min_rating: z.number().min(0).max(10).optional().describe('Minimum TMDB rating out of 10.'),
                 detail: DetailSchema,
-                limit: LimitSchema
+                limit: LimitSchema,
+                offset: OffsetSchema
             }, { undocumented: ['media_type'] })
         },
-        async ({ kind, media_type, genre, year, min_rating, detail, limit }) => {
+        async ({ kind, media_type, genre, year, min_rating, detail, limit, offset }) => {
             const resolved =
                 preferred({
                     name: 'kind',
@@ -164,7 +166,8 @@ export function registerDiscoverMedia(
                 ...(year === undefined ? {} : { year }),
                 ...(min_rating === undefined ? {} : { minRating: min_rating }),
                 detail,
-                limit
+                limit,
+                offset
             }, dataset);
             const summary =
                 result.degraded.length > 0

--- a/src/tools/discoverMedia.ts
+++ b/src/tools/discoverMedia.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/server';
 import * as z from 'zod/v4';
 import { logger } from '../core/logger.ts';
-import { DetailSchema, LimitSchema, OffsetSchema, applyLimit, preferred, toolInput, type DetailLevel } from '../core/shape.ts';
+import { DetailSchema, LimitSchema, OffsetSchema, PagedOutputSchema, applyLimit, preferred, toolInput, type DetailLevel } from '../core/shape.ts';
 import type { SeerrAdapter } from '../services/seerr.ts';
 import { fenceText } from '../core/fence.ts';
 import { enrichWithImdb } from '../metadata/enrich.ts';
@@ -50,7 +50,7 @@ export async function buildDiscoverMedia(
         });
     } catch (err) {
         logger.warn({ service: adapter.id, err }, 'discover failed; degrading');
-        return { items: [], total: 0, returned: 0, truncated: false, degraded: [adapter.id], counts: {} };
+        return { items: [], total: 0, returned: 0, offset: 0, truncated: false, degraded: [adapter.id], counts: {} };
     }
 
     // Enrichment applies whatever the source. Seerr's discover is
@@ -85,7 +85,7 @@ function fromDataset(
     opts: { kind: 'movie' | 'series'; genre?: string; year?: number; minRating?: number; detail: DetailLevel; limit: number; offset?: number },
     dataset: ImdbDataset | undefined
 ): GetSearchResult {
-    const empty = { items: [], total: 0, returned: 0, truncated: false, degraded: [], counts: {} };
+    const empty = { items: [], total: 0, returned: 0, offset: 0, truncated: false, degraded: [], counts: {} };
     if (dataset === undefined) return empty;
 
     if (opts.genre !== undefined && /^\d+$/.test(opts.genre)) {
@@ -135,6 +135,7 @@ export function registerDiscoverMedia(
         {
             description:
                 'Browse what exists rather than what you have: films or series by genre, year and minimum rating. Nothing is requested or added. Answered by Seerr when it is configured — TMDB-backed, so `genre` is a TMDB genre id and the rating is TMDB’s. With no Seerr it is answered from the local IMDb dataset instead, where `genre` is a name such as `Crime` and the rating is IMDb’s; passing a numeric id there is refused rather than silently matching nothing.',
+            outputSchema: PagedOutputSchema,
             inputSchema: toolInput({
                 kind: z.enum(['movie', 'series']).optional().describe('Films or series. Defaults to films.'),
                 // Undocumented on purpose: the spelling this tool had when the

--- a/src/tools/getCalendar.ts
+++ b/src/tools/getCalendar.ts
@@ -2,13 +2,14 @@ import type { McpServer } from '@modelcontextprotocol/server';
 import * as z from 'zod/v4';
 import type { ServiceId } from '../config/schema.ts';
 import { gather } from '../core/gather.ts';
-import { DetailSchema, LimitSchema, OffsetSchema, applyLimit, toolInput, type DetailLevel } from '../core/shape.ts';
+import { DetailSchema, LimitSchema, OffsetSchema, PagedOutputSchema, applyLimit, toolInput, type DetailLevel } from '../core/shape.ts';
 import { hasCalendar, type CalendarEntry, type ServiceAdapter } from '../services/types.ts';
 
 export type GetCalendarResult = {
     items: CalendarEntry[];
     total: number;
     returned: number;
+    offset: number;
     truncated: boolean;
     degraded: string[];
     counts: Partial<Record<ServiceId, number>>;
@@ -66,6 +67,7 @@ export function registerGetCalendar(server: McpServer, adapters: readonly Servic
         {
             description:
                 'Films and episodes due in a date window, merged from Radarr and Sonarr and sorted by date. Covers both upcoming releases and recently aired items, with whether each already has a file.',
+            outputSchema: PagedOutputSchema,
             inputSchema: toolInput({
                 detail: DetailSchema,
                 limit: LimitSchema,

--- a/src/tools/getCalendar.ts
+++ b/src/tools/getCalendar.ts
@@ -2,7 +2,7 @@ import type { McpServer } from '@modelcontextprotocol/server';
 import * as z from 'zod/v4';
 import type { ServiceId } from '../config/schema.ts';
 import { gather } from '../core/gather.ts';
-import { DetailSchema, LimitSchema, applyLimit, toolInput, type DetailLevel } from '../core/shape.ts';
+import { DetailSchema, LimitSchema, OffsetSchema, applyLimit, toolInput, type DetailLevel } from '../core/shape.ts';
 import { hasCalendar, type CalendarEntry, type ServiceAdapter } from '../services/types.ts';
 
 export type GetCalendarResult = {
@@ -39,7 +39,7 @@ const project = (c: CalendarEntry, detail: DetailLevel): CalendarEntry => {
 
 export async function buildGetCalendar(
     adapters: readonly ServiceAdapter[],
-    opts: { detail: DetailLevel; limit: number; daysBack: number; daysAhead: number; now?: () => Date }
+    opts: { detail: DetailLevel; limit: number; offset?: number; daysBack: number; daysAhead: number; now?: () => Date }
 ): Promise<GetCalendarResult> {
     // The clock is injected so tests are not time-dependent.
     const at = (opts.now ?? (() => new Date()))();
@@ -56,7 +56,7 @@ export async function buildGetCalendar(
     // items, not whichever service happened to answer second.
     items.sort((a, b) => a.date.localeCompare(b.date));
 
-    const shaped = applyLimit(items, opts.limit);
+    const shaped = applyLimit(items, opts.limit, opts.offset);
     return { ...shaped, items: shaped.items.map(i => project(i, opts.detail)), degraded, counts };
 }
 
@@ -69,14 +69,16 @@ export function registerGetCalendar(server: McpServer, adapters: readonly Servic
             inputSchema: toolInput({
                 detail: DetailSchema,
                 limit: LimitSchema,
+                offset: OffsetSchema,
                 days_back: DaysBackSchema,
                 days_ahead: DaysAheadSchema
             })
         },
-        async ({ detail, limit, days_back, days_ahead }) => {
+        async ({ detail, limit, offset, days_back, days_ahead }) => {
             const result = await buildGetCalendar(adapters, {
                 detail,
                 limit,
+                offset,
                 daysBack: days_back,
                 daysAhead: days_ahead
             });

--- a/src/tools/getIndexers.ts
+++ b/src/tools/getIndexers.ts
@@ -1,12 +1,13 @@
 import type { McpServer } from '@modelcontextprotocol/server';
 import { logger } from '../core/logger.ts';
-import { DetailSchema, LimitSchema, OffsetSchema, applyLimit, toolInput, type DetailLevel } from '../core/shape.ts';
+import { DetailSchema, LimitSchema, OffsetSchema, PagedOutputSchema, applyLimit, toolInput, type DetailLevel } from '../core/shape.ts';
 import type { IndexerCapable, IndexerRejection, IndexerSummary, ServiceAdapter } from '../services/types.ts';
 
 export type GetIndexersResult = {
     items: IndexerSummary[];
     total: number;
     returned: number;
+    offset: number;
     truncated: boolean;
     degraded: string[];
     /** the "recent rejections". Present only at detail: full. */
@@ -26,7 +27,7 @@ export async function buildGetIndexers(
     opts: { detail: DetailLevel; limit: number; offset?: number }
 ): Promise<GetIndexersResult> {
     if (adapter === undefined) {
-        return { items: [], total: 0, returned: 0, truncated: false, degraded: [] };
+        return { items: [], total: 0, returned: 0, offset: 0, truncated: false, degraded: [] };
     }
 
     let indexers: IndexerSummary[];
@@ -34,7 +35,7 @@ export async function buildGetIndexers(
         indexers = await adapter.getIndexers();
     } catch (err) {
         logger.warn({ service: adapter.id, err }, 'indexer read failed; degrading');
-        return { items: [], total: 0, returned: 0, truncated: false, degraded: [adapter.id] };
+        return { items: [], total: 0, returned: 0, offset: 0, truncated: false, degraded: [adapter.id] };
     }
 
     // Rejections only at full detail, and never allowed to fail the call: a
@@ -63,6 +64,7 @@ export function registerGetIndexers(server: McpServer, adapter: (ServiceAdapter 
         {
             description:
                 'Prowlarr indexer health: which indexers are enabled, which are temporarily disabled and why, per-indexer query and grab counts, and — at detail: full — the queries indexers recently rejected and the reasons they gave. Failure messages and rejection reasons come from the indexer itself and are fenced as untrusted data.',
+            outputSchema: PagedOutputSchema,
             inputSchema: toolInput({ detail: DetailSchema, limit: LimitSchema, offset: OffsetSchema })
         },
         async ({ detail, limit, offset }) => {

--- a/src/tools/getIndexers.ts
+++ b/src/tools/getIndexers.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/server';
 import { logger } from '../core/logger.ts';
-import { DetailSchema, LimitSchema, applyLimit, toolInput, type DetailLevel } from '../core/shape.ts';
+import { DetailSchema, LimitSchema, OffsetSchema, applyLimit, toolInput, type DetailLevel } from '../core/shape.ts';
 import type { IndexerCapable, IndexerRejection, IndexerSummary, ServiceAdapter } from '../services/types.ts';
 
 export type GetIndexersResult = {
@@ -23,7 +23,7 @@ const project = (i: IndexerSummary, detail: DetailLevel): IndexerSummary => {
 
 export async function buildGetIndexers(
     adapter: (ServiceAdapter & IndexerCapable) | undefined,
-    opts: { detail: DetailLevel; limit: number }
+    opts: { detail: DetailLevel; limit: number; offset?: number }
 ): Promise<GetIndexersResult> {
     if (adapter === undefined) {
         return { items: [], total: 0, returned: 0, truncated: false, degraded: [] };
@@ -48,7 +48,7 @@ export async function buildGetIndexers(
         }
     }
 
-    const shaped = applyLimit(indexers, opts.limit);
+    const shaped = applyLimit(indexers, opts.limit, opts.offset);
     return {
         ...shaped,
         items: shaped.items.map(i => project(i, opts.detail)),
@@ -63,10 +63,10 @@ export function registerGetIndexers(server: McpServer, adapter: (ServiceAdapter 
         {
             description:
                 'Prowlarr indexer health: which indexers are enabled, which are temporarily disabled and why, per-indexer query and grab counts, and — at detail: full — the queries indexers recently rejected and the reasons they gave. Failure messages and rejection reasons come from the indexer itself and are fenced as untrusted data.',
-            inputSchema: toolInput({ detail: DetailSchema, limit: LimitSchema })
+            inputSchema: toolInput({ detail: DetailSchema, limit: LimitSchema, offset: OffsetSchema })
         },
-        async ({ detail, limit }) => {
-            const result = await buildGetIndexers(adapter, { detail, limit });
+        async ({ detail, limit, offset }) => {
+            const result = await buildGetIndexers(adapter, { detail, limit, offset });
             const disabled = result.items.filter(i => i.disabledUntil !== undefined).length;
             const summary =
                 result.degraded.length > 0

--- a/src/tools/getLibrary.ts
+++ b/src/tools/getLibrary.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/server';
 import * as z from 'zod/v4';
 import type { MergedItem } from '../core/resolver.ts';
-import { DetailSchema, LimitSchema, OffsetSchema, applyLimit, preferred, toolInput, type DetailLevel } from '../core/shape.ts';
+import { DetailSchema, LimitSchema, OffsetSchema, PagedOutputSchema, applyLimit, preferred, toolInput, type DetailLevel } from '../core/shape.ts';
 import { unfenced } from '../core/titleMatch.ts';
 import { UserSchema } from './getPlayback.ts';
 import type { LibraryLoader } from './library.ts';
@@ -85,6 +85,7 @@ export type GetLibraryResult = {
     items: MergedItem[];
     total: number;
     returned: number;
+    offset: number;
     truncated: boolean;
     degraded: string[];
     /** Keyed by source — see `LibrarySnapshot.counts`. */
@@ -339,6 +340,7 @@ export function registerGetLibrary(server: McpServer, loader: LibraryLoader): vo
         {
             description:
                 'Your library, joined across Radarr, Sonarr and Jellyfin on shared external ids. `presence` is what no single service can tell you — but only when the absent half’s service actually answered: `arr_only` with a file means Jellyfin *was reachable and* cannot see a file the *arr believes is on disk (a likely broken import); `jellyfin_only` means nothing here is managing it, read the same way — it assumes Radarr/Sonarr answered too, and (unlike `arr_only`) is not yet hedged against their own outage. If Jellyfin is degraded, an item Radarr/Sonarr manages reports `unknown` instead of `arr_only`, and the top-level `degraded` list names it. If Jellyfin is not configured at all, `unknown` fires the same way but `degraded` stays empty — there is nothing to name as degraded — so check whether `jellyfin` even appears in your config instead. `has_file: false` with `monitored: true` is "what am I still waiting for". Two limits: `quality` applies to films only (a series’ quality is per-episode), and a series carries Sonarr’s one flat TVDB rating plus an IMDb rating **only when the IMDb dataset is enabled** — nothing else in this stack has a series’ IMDb number, so with the dataset off `rating_source: "imdb"` on a series matches nothing. `rating_source` still defaults to `tvdb` for a series, so ask for `imdb` explicitly. A rating filter also reports how much of the library that source actually covers; if that count is zero because the dataset is off or still ingesting, `ratingCoverage.note` says so — report that reason rather than telling the user their library is unrated or that the question cannot be answered. A series at `detail: "full"` also carries `seasons`: per season, how many episodes you have watched (`watched`), how many are on disk (`onDisk`), how many have aired (`aired`), and how many exist in total (`total`, which is TVDB\'s count via Sonarr). `complete` is true only when every episode of the season has been watched — and is **absent, not false**, when either half is unknown: a series no *arr manages has no `total`, and one Jellyfin has never seen has no `watched`. Season 0 is specials and is reported like any other season. `seasons` is omitted below `detail: "full"`. Each season row also carries `monitored`, Sonarr’s own per-season flag — the same field `get_media_details` reports — absent rather than false when no Sonarr manages the series.',
+            outputSchema: PagedOutputSchema,
             inputSchema: toolInput({
                 kind: z.enum(['movie', 'series']).optional().describe('Films or series. Omit for both.'),
                 year: z.number().int().optional(),

--- a/src/tools/getLibrary.ts
+++ b/src/tools/getLibrary.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/server';
 import * as z from 'zod/v4';
 import type { MergedItem } from '../core/resolver.ts';
-import { DetailSchema, LimitSchema, applyLimit, preferred, toolInput, type DetailLevel } from '../core/shape.ts';
+import { DetailSchema, LimitSchema, OffsetSchema, applyLimit, preferred, toolInput, type DetailLevel } from '../core/shape.ts';
 import { unfenced } from '../core/titleMatch.ts';
 import { UserSchema } from './getPlayback.ts';
 import type { LibraryLoader } from './library.ts';
@@ -66,6 +66,7 @@ export type SortField = (typeof SORT_FIELDS)[number];
 export type LibraryQuery = {
     detail: DetailLevel;
     limit: number;
+    offset?: number;
     sort?: SortField;
     kind?: 'movie' | 'series';
     year?: number;
@@ -292,7 +293,7 @@ export async function buildGetLibrary(loader: LibraryLoader, opts: LibraryQuery)
         // `bestCoveredSource` is never consulted here: no rating is read, so
         // computing one would be work whose result is discarded.
         const ordered = opts.sort === undefined ? filtered : applySort(filtered, opts.sort, 'imdb');
-        const shaped = applyLimit(ordered, opts.limit);
+        const shaped = applyLimit(ordered, opts.limit, opts.offset);
         return { ...shaped, items: shaped.items.map(i => project(i, opts.detail)), degraded, counts };
     }
 
@@ -311,7 +312,7 @@ export async function buildGetLibrary(loader: LibraryLoader, opts: LibraryQuery)
             : rated.filter(i => toTenPointScale(source, ratingOf(i, source) as number) >= floor);
 
     const ordered = opts.sort === undefined ? matching : applySort(matching, opts.sort, source);
-    const shaped = applyLimit(ordered, opts.limit);
+    const shaped = applyLimit(ordered, opts.limit, opts.offset);
 
     // Only for `imdb`, and only for a zero: every other source is supplied by a
     // service that either answered or is already named in `degraded`.
@@ -383,7 +384,8 @@ export function registerGetLibrary(server: McpServer, loader: LibraryLoader): vo
                         'Order the results *before* `limit` is applied — which is what makes "the best rated" or "most recently added" answerable at all, since a filter alone would leave the top item outside the returned window. `rating` is descending and uses `rating_source`, excluding items that source has no rating for and reporting them in `ratingCoverage`; `added` is newest first and excludes media no *arr manages, which has no added date; `year` is descending; `title` ascending. Omit to keep the library\'s own order.'
                     ),
                 detail: DetailSchema,
-                limit: LimitSchema
+                limit: LimitSchema,
+                offset: OffsetSchema
             }, { undocumented: ['watched_by'] })
         },
         async input => {

--- a/src/tools/getMediaDetails.ts
+++ b/src/tools/getMediaDetails.ts
@@ -159,6 +159,17 @@ export function registerGetMediaDetails(
         {
             description:
                 'Everything known about one item. Give a title as `query` for the merged record — acquisition, watch state, ratings and presence joined across services — or `service` plus `id` for one service’s raw view, which is how you inspect a join that looks wrong — the explicit id wins if both are given. A series at detail: full also returns its episodes. Asked by title, a series also carries `seasons`: per-season `watched` and `lastPlayed` from Jellyfin, `onDisk`, `aired` and `total` from Sonarr, and `complete`, which is absent rather than false whenever it cannot be known. Both forms — by title and by `service` plus `id` — carry `seasons[].monitored`, Sonarr’s own per-season monitoring flag, absent rather than false when no Sonarr manages the series. Check it before delete_episode_files: deleting the files of a season that is still monitored makes Sonarr search for them again and re-download exactly what was removed.',
+            /**
+             * One item, and the only tool answering in two different shapes:
+             * asked by title it returns the merged record, asked by `service`
+             * plus `id` it returns that one service's own view. Only what both
+             * carry is declared — enumerating either branch would make the
+             * schema reject the other, and a mismatch fails the whole call.
+             */
+            outputSchema: z.looseObject({
+                kind: z.enum(['movie', 'series', 'item']),
+                title: z.string()
+            }),
             inputSchema: toolInput({
                 query: z.string().min(1).optional().describe('A title. Resolved through the library index.'),
                 service: ServiceIdSchema.optional().describe('With `id`: one service’s own view.'),

--- a/src/tools/getPlayback.ts
+++ b/src/tools/getPlayback.ts
@@ -2,7 +2,7 @@ import type { McpServer } from '@modelcontextprotocol/server';
 import * as z from 'zod/v4';
 import type { IdentityResolver } from '../core/identity.ts';
 import { logger } from '../core/logger.ts';
-import { DetailSchema, LimitSchema, OffsetSchema, applyLimit, toolInput, type DetailLevel } from '../core/shape.ts';
+import { DetailSchema, LimitSchema, OffsetSchema, PagedOutputSchema, applyLimit, toolInput, type DetailLevel } from '../core/shape.ts';
 import type { JellyfinAdapter } from '../services/jellyfin.ts';
 import type { PlaybackEntry } from '../services/types.ts';
 
@@ -10,6 +10,7 @@ export type GetPlaybackResult = {
     items: PlaybackEntry[];
     total: number;
     returned: number;
+    offset: number;
     truncated: boolean;
     degraded: string[];
 };
@@ -37,7 +38,7 @@ export async function buildGetPlayback(
     opts: { detail: DetailLevel; limit: number; offset?: number; user?: string }
 ): Promise<GetPlaybackResult> {
     if (adapter === undefined || resolver === undefined) {
-        return { items: [], total: 0, returned: 0, truncated: false, degraded: [] };
+        return { items: [], total: 0, returned: 0, offset: 0, truncated: false, degraded: [] };
     }
 
     // Deliberately outside the try: an authorization or configuration failure
@@ -51,7 +52,7 @@ export async function buildGetPlayback(
         entries = await adapter.getPlayback(user);
     } catch (err) {
         logger.warn({ service: adapter.id, err }, 'playback read failed; degrading');
-        return { items: [], total: 0, returned: 0, truncated: false, degraded: [adapter.id] };
+        return { items: [], total: 0, returned: 0, offset: 0, truncated: false, degraded: [adapter.id] };
     }
 
     const shaped = applyLimit(entries, opts.limit, opts.offset);
@@ -68,6 +69,7 @@ export function registerGetPlayback(
         {
             description:
                 'What a Jellyfin user is watching now and what they can continue watching, with position and completion. Watch state exists only in Jellyfin — Radarr and Sonarr have no concept of it. Defaults to the configured user; reading another requires allow_other_users.',
+            outputSchema: PagedOutputSchema,
             inputSchema: toolInput({ detail: DetailSchema, limit: LimitSchema, offset: OffsetSchema, user: UserSchema })
         },
         async ({ detail, limit, offset, user }) => {

--- a/src/tools/getPlayback.ts
+++ b/src/tools/getPlayback.ts
@@ -2,7 +2,7 @@ import type { McpServer } from '@modelcontextprotocol/server';
 import * as z from 'zod/v4';
 import type { IdentityResolver } from '../core/identity.ts';
 import { logger } from '../core/logger.ts';
-import { DetailSchema, LimitSchema, applyLimit, toolInput, type DetailLevel } from '../core/shape.ts';
+import { DetailSchema, LimitSchema, OffsetSchema, applyLimit, toolInput, type DetailLevel } from '../core/shape.ts';
 import type { JellyfinAdapter } from '../services/jellyfin.ts';
 import type { PlaybackEntry } from '../services/types.ts';
 
@@ -34,7 +34,7 @@ const project = (e: PlaybackEntry, detail: DetailLevel): PlaybackEntry => {
 export async function buildGetPlayback(
     adapter: JellyfinAdapter | undefined,
     resolver: IdentityResolver | undefined,
-    opts: { detail: DetailLevel; limit: number; user?: string }
+    opts: { detail: DetailLevel; limit: number; offset?: number; user?: string }
 ): Promise<GetPlaybackResult> {
     if (adapter === undefined || resolver === undefined) {
         return { items: [], total: 0, returned: 0, truncated: false, degraded: [] };
@@ -54,7 +54,7 @@ export async function buildGetPlayback(
         return { items: [], total: 0, returned: 0, truncated: false, degraded: [adapter.id] };
     }
 
-    const shaped = applyLimit(entries, opts.limit);
+    const shaped = applyLimit(entries, opts.limit, opts.offset);
     return { ...shaped, items: shaped.items.map(e => project(e, opts.detail)), degraded: [] };
 }
 
@@ -68,12 +68,13 @@ export function registerGetPlayback(
         {
             description:
                 'What a Jellyfin user is watching now and what they can continue watching, with position and completion. Watch state exists only in Jellyfin — Radarr and Sonarr have no concept of it. Defaults to the configured user; reading another requires allow_other_users.',
-            inputSchema: toolInput({ detail: DetailSchema, limit: LimitSchema, user: UserSchema })
+            inputSchema: toolInput({ detail: DetailSchema, limit: LimitSchema, offset: OffsetSchema, user: UserSchema })
         },
-        async ({ detail, limit, user }) => {
+        async ({ detail, limit, offset, user }) => {
             const result = await buildGetPlayback(adapter, resolver, {
                 detail,
                 limit,
+                offset,
                 ...(user === undefined ? {} : { user })
             });
             const playing = result.items.filter(i => i.kind === 'now_playing').length;

--- a/src/tools/getQueue.ts
+++ b/src/tools/getQueue.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/server';
 import type { ServiceId } from '../config/schema.ts';
 import { gather } from '../core/gather.ts';
-import { DetailSchema, LimitSchema, applyLimit, toolInput, type DetailLevel } from '../core/shape.ts';
+import { DetailSchema, LimitSchema, OffsetSchema, applyLimit, toolInput, type DetailLevel } from '../core/shape.ts';
 import { hasQueue, type QueueItem, type ServiceAdapter } from '../services/types.ts';
 
 export type GetQueueResult = {
@@ -22,7 +22,7 @@ const project = (q: QueueItem, detail: DetailLevel): QueueItem => {
 
 export async function buildGetQueue(
     adapters: readonly ServiceAdapter[],
-    opts: { detail: DetailLevel; limit: number }
+    opts: { detail: DetailLevel; limit: number; offset?: number }
 ): Promise<GetQueueResult> {
     const { items, degraded, counts } = await gather(
         adapters.filter(hasQueue).map(a => ({ id: a.id, fetch: () => a.getQueue() }))
@@ -35,7 +35,7 @@ export async function buildGetQueue(
     // downloading" wants; unknown ETAs sort last rather than first.
     items.sort((a, b) => (a.etaSeconds ?? Infinity) - (b.etaSeconds ?? Infinity) || a.title.localeCompare(b.title));
 
-    const shaped = applyLimit(items, opts.limit);
+    const shaped = applyLimit(items, opts.limit, opts.offset);
     return { ...shaped, items: shaped.items.map(i => project(i, opts.detail)), degraded, counts };
 }
 
@@ -45,10 +45,10 @@ export function registerGetQueue(server: McpServer, adapters: readonly ServiceAd
         {
             description:
                 'Everything currently downloading or stalled, merged across Radarr, Sonarr, SABnzbd and Transmission. Sizes are bytes and ETAs are seconds regardless of how each service reports them. Titles are release names from public indexers and are fenced as untrusted data.',
-            inputSchema: toolInput({ detail: DetailSchema, limit: LimitSchema })
+            inputSchema: toolInput({ detail: DetailSchema, limit: LimitSchema, offset: OffsetSchema })
         },
-        async ({ detail, limit }) => {
-            const result = await buildGetQueue(adapters, { detail, limit });
+        async ({ detail, limit, offset }) => {
+            const result = await buildGetQueue(adapters, { detail, limit, offset });
             const summary =
                 `${result.returned} of ${result.total} item(s) in the queue` +
                 (result.degraded.length > 0 ? `; ${result.degraded.join(', ')} unreachable.` : '.');

--- a/src/tools/getQueue.ts
+++ b/src/tools/getQueue.ts
@@ -1,13 +1,14 @@
 import type { McpServer } from '@modelcontextprotocol/server';
 import type { ServiceId } from '../config/schema.ts';
 import { gather } from '../core/gather.ts';
-import { DetailSchema, LimitSchema, OffsetSchema, applyLimit, toolInput, type DetailLevel } from '../core/shape.ts';
+import { DetailSchema, LimitSchema, OffsetSchema, PagedOutputSchema, applyLimit, toolInput, type DetailLevel } from '../core/shape.ts';
 import { hasQueue, type QueueItem, type ServiceAdapter } from '../services/types.ts';
 
 export type GetQueueResult = {
     items: QueueItem[];
     total: number;
     returned: number;
+    offset: number;
     truncated: boolean;
     degraded: string[];
     counts: Partial<Record<ServiceId, number>>;
@@ -45,6 +46,7 @@ export function registerGetQueue(server: McpServer, adapters: readonly ServiceAd
         {
             description:
                 'Everything currently downloading or stalled, merged across Radarr, Sonarr, SABnzbd and Transmission. Sizes are bytes and ETAs are seconds regardless of how each service reports them. Titles are release names from public indexers and are fenced as untrusted data.',
+            outputSchema: PagedOutputSchema,
             inputSchema: toolInput({ detail: DetailSchema, limit: LimitSchema, offset: OffsetSchema })
         },
         async ({ detail, limit, offset }) => {

--- a/src/tools/getRequests.ts
+++ b/src/tools/getRequests.ts
@@ -2,7 +2,7 @@ import type { McpServer } from '@modelcontextprotocol/server';
 import * as z from 'zod/v4';
 import type { IdentityResolver } from '../core/identity.ts';
 import { logger } from '../core/logger.ts';
-import { DetailSchema, LimitSchema, OffsetSchema, applyLimit, toolInput, type DetailLevel } from '../core/shape.ts';
+import { DetailSchema, LimitSchema, OffsetSchema, PagedOutputSchema, applyLimit, toolInput, type DetailLevel } from '../core/shape.ts';
 import type { SeerrAdapter } from '../services/seerr.ts';
 import type { MediaRequest, RequestStatus } from '../services/types.ts';
 import { UserSchema } from './getPlayback.ts';
@@ -11,6 +11,7 @@ export type GetRequestsResult = {
     items: MediaRequest[];
     total: number;
     returned: number;
+    offset: number;
     truncated: boolean;
     degraded: string[];
 };
@@ -34,7 +35,7 @@ export async function buildGetRequests(
     opts: { detail: DetailLevel; limit: number; offset?: number; user?: string; status?: RequestStatus }
 ): Promise<GetRequestsResult> {
     if (adapter === undefined || resolver === undefined) {
-        return { items: [], total: 0, returned: 0, truncated: false, degraded: [] };
+        return { items: [], total: 0, returned: 0, offset: 0, truncated: false, degraded: [] };
     }
 
     // Outside the try, for the same reason as get_playback: a refusal must
@@ -49,7 +50,7 @@ export async function buildGetRequests(
         });
     } catch (err) {
         logger.warn({ service: adapter.id, err }, 'request read failed; degrading');
-        return { items: [], total: 0, returned: 0, truncated: false, degraded: [adapter.id] };
+        return { items: [], total: 0, returned: 0, offset: 0, truncated: false, degraded: [adapter.id] };
     }
 
     const shaped = applyLimit(requests, opts.limit, opts.offset);
@@ -66,6 +67,7 @@ export function registerGetRequests(
         {
             description:
                 'Media requests in Seerr — pending, approved or declined — for one user. Defaults to the configured user; reading another requires allow_other_users.',
+            outputSchema: PagedOutputSchema,
             inputSchema: toolInput({
                 detail: DetailSchema,
                 limit: LimitSchema,

--- a/src/tools/getRequests.ts
+++ b/src/tools/getRequests.ts
@@ -2,7 +2,7 @@ import type { McpServer } from '@modelcontextprotocol/server';
 import * as z from 'zod/v4';
 import type { IdentityResolver } from '../core/identity.ts';
 import { logger } from '../core/logger.ts';
-import { DetailSchema, LimitSchema, applyLimit, toolInput, type DetailLevel } from '../core/shape.ts';
+import { DetailSchema, LimitSchema, OffsetSchema, applyLimit, toolInput, type DetailLevel } from '../core/shape.ts';
 import type { SeerrAdapter } from '../services/seerr.ts';
 import type { MediaRequest, RequestStatus } from '../services/types.ts';
 import { UserSchema } from './getPlayback.ts';
@@ -31,7 +31,7 @@ const project = (r: MediaRequest, detail: DetailLevel): MediaRequest => {
 export async function buildGetRequests(
     adapter: SeerrAdapter | undefined,
     resolver: IdentityResolver | undefined,
-    opts: { detail: DetailLevel; limit: number; user?: string; status?: RequestStatus }
+    opts: { detail: DetailLevel; limit: number; offset?: number; user?: string; status?: RequestStatus }
 ): Promise<GetRequestsResult> {
     if (adapter === undefined || resolver === undefined) {
         return { items: [], total: 0, returned: 0, truncated: false, degraded: [] };
@@ -52,7 +52,7 @@ export async function buildGetRequests(
         return { items: [], total: 0, returned: 0, truncated: false, degraded: [adapter.id] };
     }
 
-    const shaped = applyLimit(requests, opts.limit);
+    const shaped = applyLimit(requests, opts.limit, opts.offset);
     return { ...shaped, items: shaped.items.map(r => project(r, opts.detail)), degraded: [] };
 }
 
@@ -69,14 +69,16 @@ export function registerGetRequests(
             inputSchema: toolInput({
                 detail: DetailSchema,
                 limit: LimitSchema,
+                offset: OffsetSchema,
                 user: UserSchema,
                 status: StatusSchema
             })
         },
-        async ({ detail, limit, user, status }) => {
+        async ({ detail, limit, offset, user, status }) => {
             const result = await buildGetRequests(adapter, resolver, {
                 detail,
                 limit,
+                offset,
                 ...(user === undefined ? {} : { user }),
                 ...(status === undefined ? {} : { status })
             });

--- a/src/tools/getSubtitles.ts
+++ b/src/tools/getSubtitles.ts
@@ -1,12 +1,13 @@
 import type { McpServer } from '@modelcontextprotocol/server';
 import { logger } from '../core/logger.ts';
-import { DetailSchema, LimitSchema, OffsetSchema, applyLimit, toolInput, type DetailLevel } from '../core/shape.ts';
+import { DetailSchema, LimitSchema, OffsetSchema, PagedOutputSchema, applyLimit, toolInput, type DetailLevel } from '../core/shape.ts';
 import type { ServiceAdapter, SubtitleCapable, SubtitleGap, SubtitleProvider } from '../services/types.ts';
 
 export type GetSubtitlesResult = {
     items: SubtitleGap[];
     total: number;
     returned: number;
+    offset: number;
     truncated: boolean;
     degraded: string[];
     /**
@@ -45,7 +46,7 @@ export async function buildGetSubtitles(
     opts: { detail: DetailLevel; limit: number; offset?: number }
 ): Promise<GetSubtitlesResult> {
     if (adapters.length === 0) {
-        return { items: [], total: 0, returned: 0, truncated: false, degraded: [] };
+        return { items: [], total: 0, returned: 0, offset: 0, truncated: false, degraded: [] };
     }
 
     const gaps: SubtitleGap[] = [];
@@ -96,6 +97,7 @@ export function registerGetSubtitles(server: McpServer, adapters: readonly (Serv
         {
             description:
                 'Subtitles Bazarr knows are missing, for both films and episodes, with the languages wanted for each — and which subtitle providers are currently working, throttled, or blocked, which is usually why something is missing. Release names come from public indexers and are fenced as untrusted data.',
+            outputSchema: PagedOutputSchema,
             inputSchema: toolInput({ detail: DetailSchema, limit: LimitSchema, offset: OffsetSchema })
         },
         async ({ detail, limit, offset }) => {

--- a/src/tools/getSubtitles.ts
+++ b/src/tools/getSubtitles.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/server';
 import { logger } from '../core/logger.ts';
-import { DetailSchema, LimitSchema, applyLimit, toolInput, type DetailLevel } from '../core/shape.ts';
+import { DetailSchema, LimitSchema, OffsetSchema, applyLimit, toolInput, type DetailLevel } from '../core/shape.ts';
 import type { ServiceAdapter, SubtitleCapable, SubtitleGap, SubtitleProvider } from '../services/types.ts';
 
 export type GetSubtitlesResult = {
@@ -42,7 +42,7 @@ const project = (g: SubtitleGap, detail: DetailLevel): SubtitleGap => {
  */
 export async function buildGetSubtitles(
     adapters: readonly (ServiceAdapter & SubtitleCapable)[],
-    opts: { detail: DetailLevel; limit: number }
+    opts: { detail: DetailLevel; limit: number; offset?: number }
 ): Promise<GetSubtitlesResult> {
     if (adapters.length === 0) {
         return { items: [], total: 0, returned: 0, truncated: false, degraded: [] };
@@ -79,7 +79,8 @@ export async function buildGetSubtitles(
     // answered first, which would make the output differ run to run.
     const shaped = applyLimit(
         gaps.sort((a, b) => a.service.localeCompare(b.service) || a.title.localeCompare(b.title)),
-        opts.limit
+        opts.limit,
+        opts.offset
     );
     return {
         ...shaped,
@@ -95,10 +96,10 @@ export function registerGetSubtitles(server: McpServer, adapters: readonly (Serv
         {
             description:
                 'Subtitles Bazarr knows are missing, for both films and episodes, with the languages wanted for each — and which subtitle providers are currently working, throttled, or blocked, which is usually why something is missing. Release names come from public indexers and are fenced as untrusted data.',
-            inputSchema: toolInput({ detail: DetailSchema, limit: LimitSchema })
+            inputSchema: toolInput({ detail: DetailSchema, limit: LimitSchema, offset: OffsetSchema })
         },
-        async ({ detail, limit }) => {
-            const result = await buildGetSubtitles(adapters, { detail, limit });
+        async ({ detail, limit, offset }) => {
+            const result = await buildGetSubtitles(adapters, { detail, limit, offset });
             const unhealthy = (result.providers ?? []).filter(p => !p.healthy).length;
             const summary =
                 result.degraded.length > 0

--- a/src/tools/lookupMedia.ts
+++ b/src/tools/lookupMedia.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/server';
 import * as z from 'zod/v4';
-import { DetailSchema, LimitSchema, toolInput, type DetailLevel } from '../core/shape.ts';
+import { DetailSchema, LimitSchema, OffsetSchema, toolInput, type DetailLevel } from '../core/shape.ts';
 import type { ImdbDataset } from '../metadata/imdbDataset.ts';
 import type { ServiceAdapter } from '../services/types.ts';
 import { buildSearchMedia, type GetSearchResult } from './searchMedia.ts';
@@ -15,7 +15,7 @@ import { buildSearchMedia, type GetSearchResult } from './searchMedia.ts';
  */
 export async function buildLookupMedia(
     adapters: readonly ServiceAdapter[],
-    opts: { query: string; detail: DetailLevel; limit: number },
+    opts: { query: string; detail: DetailLevel; limit: number; offset?: number },
     dataset?: ImdbDataset | undefined
 ): Promise<GetSearchResult> {
     return buildSearchMedia(adapters, { ...opts, source: 'discover' }, dataset);
@@ -34,11 +34,12 @@ export function registerLookupMedia(
             inputSchema: toolInput({
                 query: z.string().min(1).describe('What to look up.'),
                 detail: DetailSchema,
-                limit: LimitSchema
+                limit: LimitSchema,
+                offset: OffsetSchema
             })
         },
-        async ({ query, detail, limit }) => {
-            const result = await buildLookupMedia(adapters, { query, detail, limit }, dataset);
+        async ({ query, detail, limit, offset }) => {
+            const result = await buildLookupMedia(adapters, { query, detail, limit, offset }, dataset);
             const summary =
                 result.total === 0
                     ? `Nothing found for "${query}".`

--- a/src/tools/lookupMedia.ts
+++ b/src/tools/lookupMedia.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/server';
 import * as z from 'zod/v4';
-import { DetailSchema, LimitSchema, OffsetSchema, toolInput, type DetailLevel } from '../core/shape.ts';
+import { DetailSchema, LimitSchema, OffsetSchema, PagedOutputSchema, toolInput, type DetailLevel } from '../core/shape.ts';
 import type { ImdbDataset } from '../metadata/imdbDataset.ts';
 import type { ServiceAdapter } from '../services/types.ts';
 import { buildSearchMedia, type GetSearchResult } from './searchMedia.ts';
@@ -31,6 +31,7 @@ export function registerLookupMedia(
         {
             description:
                 'Metadata for something you may not have: title, year, and external ids, from Radarr, Sonarr and Seerr. Reads only — nothing is added, requested or monitored.',
+            outputSchema: PagedOutputSchema,
             inputSchema: toolInput({
                 query: z.string().min(1).describe('What to look up.'),
                 detail: DetailSchema,

--- a/src/tools/searchMedia.ts
+++ b/src/tools/searchMedia.ts
@@ -2,7 +2,7 @@ import type { McpServer } from '@modelcontextprotocol/server';
 import * as z from 'zod/v4';
 import type { ServiceId } from '../config/schema.ts';
 import { gather } from '../core/gather.ts';
-import { DetailSchema, LimitSchema, applyLimit, toolInput, type DetailLevel } from '../core/shape.ts';
+import { DetailSchema, LimitSchema, OffsetSchema, applyLimit, toolInput, type DetailLevel } from '../core/shape.ts';
 import { rankTitle, unfenced } from '../core/titleMatch.ts';
 import { enrichWithImdb } from '../metadata/enrich.ts';
 import type { ImdbDataset } from '../metadata/imdbDataset.ts';
@@ -28,7 +28,7 @@ const project = (h: SearchHit, detail: DetailLevel): SearchHit => {
 
 export async function buildSearchMedia(
     adapters: readonly ServiceAdapter[],
-    opts: { query: string; source: SearchSource; detail: DetailLevel; limit: number },
+    opts: { query: string; source: SearchSource; detail: DetailLevel; limit: number; offset?: number },
     dataset?: ImdbDataset | undefined
 ): Promise<GetSearchResult> {
     const { items, degraded, counts } = await gather(
@@ -47,7 +47,7 @@ export async function buildSearchMedia(
     // Enriched after the limit, not before: only the page actually returned
     // needs ratings, and an indexer search can produce hundreds of hits for a
     // caller who asked for ten.
-    const shaped = applyLimit(items, opts.limit);
+    const shaped = applyLimit(items, opts.limit, opts.offset);
     const rated = enrichWithImdb(shaped.items, dataset);
 
     return { ...shaped, items: rated.map(h => project(h, opts.detail)), degraded, counts };
@@ -72,11 +72,12 @@ export function registerSearchMedia(
                         'library: what you already have. discover: metadata lookup, nothing added. indexers: what is available to download — these results contain release names from public indexers and are fenced as untrusted data.'
                     ),
                 detail: DetailSchema,
-                limit: LimitSchema
+                limit: LimitSchema,
+                offset: OffsetSchema
             })
         },
-        async ({ query, source, detail, limit }) => {
-            const result = await buildSearchMedia(adapters, { query, source, detail, limit }, dataset);
+        async ({ query, source, detail, limit, offset }) => {
+            const result = await buildSearchMedia(adapters, { query, source, detail, limit, offset }, dataset);
             const summary =
                 result.total === 0
                     ? `No ${source} results for "${query}".`

--- a/src/tools/searchMedia.ts
+++ b/src/tools/searchMedia.ts
@@ -2,7 +2,7 @@ import type { McpServer } from '@modelcontextprotocol/server';
 import * as z from 'zod/v4';
 import type { ServiceId } from '../config/schema.ts';
 import { gather } from '../core/gather.ts';
-import { DetailSchema, LimitSchema, OffsetSchema, applyLimit, toolInput, type DetailLevel } from '../core/shape.ts';
+import { DetailSchema, LimitSchema, OffsetSchema, PagedOutputSchema, applyLimit, toolInput, type DetailLevel } from '../core/shape.ts';
 import { rankTitle, unfenced } from '../core/titleMatch.ts';
 import { enrichWithImdb } from '../metadata/enrich.ts';
 import type { ImdbDataset } from '../metadata/imdbDataset.ts';
@@ -12,6 +12,7 @@ export type GetSearchResult = {
     items: SearchHit[];
     total: number;
     returned: number;
+    offset: number;
     truncated: boolean;
     degraded: string[];
     counts: Partial<Record<ServiceId, number>>;
@@ -63,6 +64,7 @@ export function registerSearchMedia(
         {
             description:
                 'Search across the stack: your existing library, metadata for things you do not have yet, or what indexers currently offer. Indexer results contain attacker-controllable release names and are returned inside an explicit untrusted-data boundary.',
+            outputSchema: PagedOutputSchema,
             inputSchema: toolInput({
                 query: z.string().min(1).describe('What to search for.'),
                 source: z

--- a/src/tools/stackHealth.ts
+++ b/src/tools/stackHealth.ts
@@ -1,9 +1,10 @@
 import type { McpServer } from '@modelcontextprotocol/server';
+import * as z from 'zod/v4';
 import type { ServiceInstance } from '../config/instances.ts';
 import type { ServiceId } from '../config/schema.ts';
 import { ServiceError } from '../core/errors.ts';
 import { logger } from '../core/logger.ts';
-import { DetailSchema, LimitSchema, applyLimit, toolInput, type DetailLevel } from '../core/shape.ts';
+import { DetailSchema, LimitSchema, TruncationSchema, applyLimit, toolInput, type DetailLevel } from '../core/shape.ts';
 import {
     hasDiskSpace,
     hasHealthChecks,
@@ -15,7 +16,7 @@ import {
     type ServiceAdapter
 } from '../services/types.ts';
 
-type Shaped<T> = { items: T[]; total: number; returned: number; truncated: boolean };
+type Shaped<T> = { items: T[]; total: number; returned: number; offset: number; truncated: boolean };
 
 export type StackHealthResult = {
     services: ConnectionDiagnosis[];
@@ -284,7 +285,20 @@ export function registerStackHealth(
         {
             description:
                 'Health of every configured service: version, disk space, failing health checks, when each library was last scanned, and what each instance is permitted to do. Returns partial results with a `degraded` list rather than failing when a service is down. The `permissions` list is also the set of ids you may pass as `instance` to other tools. `endpoints` gives each instance\'s base URL, for scripts that need to reach a service directly. API keys are never returned by any tool in this server — a script that needs one runs beside the config and reads it there.',
-            inputSchema: toolInput({ detail: DetailSchema, limit: LimitSchema })
+            inputSchema: toolInput({ detail: DetailSchema, limit: LimitSchema }),
+            // The one read tool whose answer is not a list, so it declares its
+            // own shape rather than the paged envelope. `disks` and `failures`
+            // are envelopes of their own — one `limit` budget spans both, spent
+            // on failures first, which is why neither is the top-level list.
+            outputSchema: z.looseObject({
+                services: z.array(z.unknown()).describe('One row per configured instance: reachable, version, latency.'),
+                failures: TruncationSchema.describe('Health checks the services themselves are reporting.'),
+                disks: TruncationSchema.describe('Free space per root folder.'),
+                scans: z.array(z.unknown()).describe('When each library was last scanned. Never truncated — bounded by the number of services.'),
+                permissions: z.array(z.unknown()).optional().describe('What each instance may do. Absent at `minimal` — a permission is not a fault.'),
+                endpoints: z.array(z.unknown()).optional().describe('Where each instance lives. Never a credential.'),
+                degraded: z.array(z.string())
+            })
         },
         async ({ detail, limit }) => {
             const result = await buildStackHealth(adapters, { detail, limit }, instances);

--- a/src/tools/stackHealth.ts
+++ b/src/tools/stackHealth.ts
@@ -225,9 +225,14 @@ export async function buildStackHealth(
     // must not be able to ask for zero items and get a silently empty list.
     // A spent budget is the one case where zero is the honest answer, so it is
     // handled here rather than by weakening that guard for every other caller.
+    // `offset: 0` rather than omitted, so a hand-built envelope reports the
+    // same five fields `applyLimit` does. This tool takes no `offset`
+    // parameter: one budget spans two lists, so a single number could not say
+    // which of them it meant to skip into — and neither list is one you page
+    // through. `limit` here bounds context, it does not paginate.
     const shapedDisks =
         remaining === 0
-            ? { items: [], total: disks.length, returned: 0, truncated: disks.length > 0 }
+            ? { items: [], total: disks.length, returned: 0, offset: 0, truncated: disks.length > 0 }
             : applyLimit(disks, remaining);
 
     // Counts stay honest at every detail level: a model must never see

--- a/src/tools/write.ts
+++ b/src/tools/write.ts
@@ -91,6 +91,44 @@ const ConfirmSchema = z
         'The confirmation token from this same tool\'s preview of this same operation. Omit it to get a preview and a token; pass the token back verbatim to apply the change. Tokens are single-use, expire, and are bound to the exact operation and arguments previewed.'
     );
 
+/**
+ * What every write answers with, declared for the same reason the read
+ * envelope is (#103): a client that gates `structuredContent` on a declared
+ * schema shows the caller nothing without one.
+ *
+ * It matters more here than on a read. `applied` is the difference between "I
+ * deleted it" and "I would delete it, confirm first", and a model that cannot
+ * see the structured half has to infer which happened from a sentence. Getting
+ * that wrong in the reassuring direction — reporting a preview as done — is the
+ * failure the whole confirm handshake exists to prevent.
+ *
+ * Loose, like the read envelope: a validation failure here would fail the call
+ * *after* the write had already landed, reporting a completed deletion as an
+ * error. The optional fields are genuinely conditional — a token is issued only
+ * when there is something to confirm.
+ */
+const WriteOutputSchema = z.looseObject({
+    applied: z.boolean().describe('Whether the change actually happened. False on every preview, refusal and no-op.'),
+    dry_run: z.boolean().describe('Whether this was an explicit preview.'),
+    tool: z.string(),
+    service: z.string(),
+    operation: z.string(),
+    tier: z.enum(['safe', 'destructive']),
+    target: z.string().describe('The resolved id the write acts on — what the confirmation token is bound to.'),
+    summary: z.string().describe('One sentence, safe to show a human.'),
+    effects: z.array(z.string()).describe('Itemised consequences, most severe first. Empty is legitimate for a no-op.'),
+    noop: z.boolean().describe('True when the request resolved but there was nothing to do — already monitored, already approved.'),
+    permission: z.looseObject({
+        allowed: z.boolean(),
+        reason: z.string().optional(),
+        remedy: z.string().optional()
+    }),
+    confirm_token: z.string().optional().describe('Present when a preview is awaiting confirmation. Single-use, expiring, bound to this exact operation and arguments.'),
+    confirm_error: z.string().optional().describe('Why a presented token was rejected. Present only when one was presented.'),
+    result: z.unknown().optional().describe('Whatever the service returned, on a write that landed.'),
+    audit_id: z.number().optional().describe('The audit row this call wrote. Every branch writes one, including previews and refusals.')
+});
+
 export type WriteToolResult = {
     applied: boolean;
     dry_run: boolean;
@@ -134,7 +172,8 @@ export function registerWriteTool<Schema extends z.ZodObject>(
             // that mistyped one argument would be told `dry_run` and `confirm`
             // — the two parameters the write protocol itself runs on — are not
             // parameters of this tool.
-            inputSchema: toolInput({ ...spec.inputSchema.shape, dry_run: DryRunSchema, confirm: ConfirmSchema })
+            inputSchema: toolInput({ ...spec.inputSchema.shape, dry_run: DryRunSchema, confirm: ConfirmSchema }),
+            outputSchema: WriteOutputSchema
         },
         async (raw: Record<string, unknown>) => {
             const { dry_run: dryRun, confirm: presented, ...rest } = raw as {

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -390,6 +390,116 @@ describe('an argument this server does not have is refused, not ignored', () => 
 });
 
 /**
+ * #103 reported `total` as missing from `structuredContent`. It was never
+ * missing — but no tool declared an `outputSchema`, and a client that gates
+ * `structuredContent` on a declared schema surfaces nothing without one, which
+ * from the far side is the same thing. The reporter parsed the count out of the
+ * summary sentence instead.
+ *
+ * Declaring one is not free: the SDK validates `structuredContent` against it
+ * and fails the *whole call* on a mismatch. On a write that means a change that
+ * already landed would be reported as an error. So these drive real payloads
+ * through the validating path — an empty result validates against almost
+ * anything, and would prove nothing.
+ */
+describe('every tool declares the shape it answers in', () => {
+    const film = {
+        id: 1,
+        title: 'Some Film',
+        year: 2026,
+        monitored: true,
+        hasFile: true,
+        tmdbId: 550,
+        movieFile: { size: 4_000_000_000, quality: { quality: { name: 'Bluray-1080p' } } }
+    };
+
+    /** Reachable, with one film and a scan capability — enough for a read, a
+     *  health answer and a write preview to all produce a real payload. */
+    const radarr = (): ServiceAdapter =>
+        ({
+            id: 'radarr',
+            type: 'radarr',
+            testConnection: async () => ({ ok: true, service: 'radarr', latency_ms: 3 }),
+            getVersion: async () => '5.0.0',
+            listLibrary: async () => [
+                {
+                    kind: 'movie',
+                    title: film.title,
+                    year: film.year,
+                    ids: { tmdb: film.tmdbId },
+                    acquisition: { service: 'radarr', monitored: true, hasFile: true, quality: 'Bluray-1080p' }
+                }
+            ],
+            startLibraryScan: async () => ({ commandId: 42 })
+        }) as unknown as ServiceAdapter;
+
+    /**
+     * Permissions are read from the config, never from the adapter, so a write
+     * preview needs a `services.radarr` block even though the adapter above is
+     * a stub. Without it `trigger_scan` is refused before it can produce the
+     * shape this is here to validate.
+     */
+    const writable = ConfigSchema.parse({
+        auth: { bearer_token: TOKEN, password_hash: hashPassword('unused-here') },
+        services: { radarr: { url: 'http://192.0.2.10:7878', api_key: 'k', permissions: { safe_write: true } } }
+    });
+
+    const call = async (name: string, args: Record<string, unknown> = {}) => {
+        const res = await appWith(writable, [radarr()]).request(
+            'http://localhost:6060/mcp',
+            rpc(
+                { jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name, arguments: args } },
+                { Authorization: `Bearer ${TOKEN}` }
+            )
+        );
+        return ((await rpcPayload(res)).result ?? {}) as {
+            isError?: boolean;
+            content?: { text: string }[];
+            structuredContent?: Record<string, unknown>;
+        };
+    };
+
+    it('declares an output schema on every tool, not only the ones that were easy', async () => {
+        const res = await app().request(
+            'http://localhost:6060/mcp',
+            rpc(toolsList, { Authorization: `Bearer ${TOKEN}` })
+        );
+        const { result } = (await rpcPayload(res)) as { result: { tools: { name: string; outputSchema?: unknown }[] } };
+
+        expect(result.tools.filter(t => t.outputSchema === undefined).map(t => t.name)).toEqual([]);
+    });
+
+    /** The field #103 could not reach, now declared and still populated. */
+    it('returns a validated envelope carrying `total` for a real library read', async () => {
+        const result = await call('get_library');
+
+        expect(result.isError).toBeFalsy();
+        expect(result.structuredContent).toMatchObject({ total: 1, returned: 1, offset: 0, truncated: false });
+    });
+
+    it('validates the answer of the one read tool that is not a list', async () => {
+        const result = await call('stack_health');
+
+        expect(result.isError).toBeFalsy();
+        expect(result.structuredContent).toHaveProperty('services');
+    });
+
+    /**
+     * A write preview, which is where a wrong schema would cost the most: the
+     * call fails *after* `apply` has run, so a completed change gets reported
+     * as an error. This one stops before `apply` — no token was presented —
+     * but it exercises the same validation on the same shape.
+     */
+    it('validates a write preview, token and all', async () => {
+        const result = await call('trigger_scan', { service: 'radarr' });
+
+        expect(result.isError).toBeFalsy();
+        expect(result.structuredContent).toMatchObject({ applied: false, tool: 'trigger_scan', tier: 'safe' });
+        expect(result.structuredContent?.['confirm_token']).toEqual(expect.any(String));
+    });
+});
+
+/**
  * The bet this whole phase rests on: client support for prompts and resources
  * is uneven, and arr-mcp has to work on all of them. So a client that surfaces
  * neither must be exactly as capable as before. Too central to leave resting on

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -309,14 +309,22 @@ describe('an argument this server does not have is refused, not ignored', () => 
         return (payload.result ?? {}) as { isError?: boolean; content?: { type: string; text: string }[] };
     };
 
-    it('refuses the exact call from #103, naming every invented parameter', async () => {
-        const result = await callTool('get_library', { offset: 100, source: 'media', totally_made_up: true });
+    /**
+     * The call from #103, minus `offset` — which that issue asked for and this
+     * tool now has, so it is no longer an invented parameter. The other two
+     * never existed and still do not.
+     */
+    it('refuses the invented parameters from #103, naming each one', async () => {
+        const result = await callTool('get_library', { source: 'media', totally_made_up: true });
 
         expect(result.isError).toBe(true);
         const text = result.content?.[0]?.text ?? '';
-        expect(text).toContain('offset');
         expect(text).toContain('source');
         expect(text).toContain('totally_made_up');
+    });
+
+    it('honours `offset`, which #103 asked for, rather than refusing it', async () => {
+        expect((await callTool('get_library', { offset: 100, limit: 5 })).isError).toBeFalsy();
     });
 
     /**
@@ -326,9 +334,10 @@ describe('an argument this server does not have is refused, not ignored', () => 
      * is the answer it was looking for in #103.
      */
     it('names the parameters the tool does accept, so the caller can correct itself', async () => {
-        const text = (await callTool('get_library', { offset: 100 })).content?.[0]?.text ?? '';
+        const text = (await callTool('get_library', { source: 'media' })).content?.[0]?.text ?? '';
 
         expect(text).toContain('limit');
+        expect(text).toContain('offset');
         expect(text).toContain('min_rating');
     });
 
@@ -342,7 +351,7 @@ describe('an argument this server does not have is refused, not ignored', () => 
         expect((await callTool('get_library', { watched_by: 'Someone' })).isError).toBeFalsy();
         expect((await callTool('discover_media', { media_type: 'tv' })).isError).toBeFalsy();
 
-        const text = (await callTool('get_library', { offset: 1 })).content?.[0]?.text ?? '';
+        const text = (await callTool('get_library', { source: 'media' })).content?.[0]?.text ?? '';
         expect(text).not.toContain('watched_by');
     });
 

--- a/test/getLibrary.test.ts
+++ b/test/getLibrary.test.ts
@@ -707,3 +707,74 @@ describe('seasons projection', () => {
         expect(result.items[0]).not.toHaveProperty('seasons');
     });
 });
+
+/**
+ * The other half of #103. `limit` bounds one answer; without an offset a
+ * library past `MAX_LIMIT` could not be read in full at all, which is what the
+ * reporter's agent was reaching for when it invented the parameter.
+ *
+ * Driven through `buildGetLibrary` rather than the schema, because what matters
+ * is that the window lands after sorting and filtering — an offset applied to
+ * the wrong list is a paging bug that no amount of schema testing would find.
+ */
+describe('paging a library larger than one answer', () => {
+    const shelf = () =>
+        loaderOf(
+            Array.from({ length: 12 }, (_, i) =>
+                film({ title: `Film ${String(i).padStart(2, '0')}`, ids: { tmdb: i + 1 } })
+            )
+        );
+
+    const titles = (items: { title: string }[]) => items.map(i => i.title);
+
+    it('returns the second page, and counts the whole library in `total`', async () => {
+        const result = await buildGetLibrary(shelf(), { ...base, sort: 'title', limit: 5, offset: 5 });
+
+        expect(titles(result.items)).toEqual(['Film 05', 'Film 06', 'Film 07', 'Film 08', 'Film 09']);
+        expect(result.total).toBe(12);
+        expect(result.returned).toBe(5);
+        expect(result.offset).toBe(5);
+    });
+
+    /**
+     * The bug this test exists for: an offset applied before the sort would
+     * page through the services' own order and return a different five films
+     * for the same request, while still looking perfectly well-formed.
+     */
+    it('pages the sorted order, not the order the services happened to return', async () => {
+        const pages = await Promise.all(
+            [0, 4, 8].map(offset => buildGetLibrary(shelf(), { ...base, sort: 'title', limit: 4, offset }))
+        );
+
+        expect(pages.flatMap(p => titles(p.items))).toEqual(
+            Array.from({ length: 12 }, (_, i) => `Film ${String(i).padStart(2, '0')}`)
+        );
+    });
+
+    /** A filter narrows the list the offset walks, so the two compose. */
+    it('offsets within the filtered list rather than the whole library', async () => {
+        const loader = loaderOf([
+            ...Array.from({ length: 3 }, (_, i) => film({ title: `Film ${i}`, ids: { tmdb: i + 1 } })),
+            ...Array.from({ length: 3 }, (_, i) =>
+                film({ kind: 'series', title: `Show ${i}`, ids: { tvdb: i + 100 } })
+            )
+        ]);
+        const result = await buildGetLibrary(loader, { ...base, kind: 'series', sort: 'title', limit: 2, offset: 1 });
+
+        expect(titles(result.items)).toEqual(['Show 1', 'Show 2']);
+        expect(result.total).toBe(3);
+    });
+
+    /**
+     * Past the end is an empty page whose `total` still names the library. A
+     * bare `[]` here would read as "you have no films", which is the same
+     * false conclusion #103 ended in.
+     */
+    it('reports an empty page past the end without disowning the library', async () => {
+        const result = await buildGetLibrary(shelf(), { ...base, limit: 5, offset: 50 });
+
+        expect(result.items).toEqual([]);
+        expect(result.total).toBe(12);
+        expect(result.truncated).toBe(true);
+    });
+});

--- a/test/plainJson.test.ts
+++ b/test/plainJson.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from 'vitest';
+import { buildApp } from '../src/app.ts';
+import { ConfigSchema, type Config } from '../src/config/schema.ts';
+import { WriteAudit } from '../src/core/audit.ts';
+import { LogStore } from '../src/core/logs.ts';
+import { Runtime } from '../src/core/runtime.ts';
+import { hashPassword } from '../src/core/session.ts';
+import { acceptingBoth, acceptsStream, asPlainJson } from '../src/mcp/plainJson.ts';
+
+/**
+ * The transport half of #103, which cost the reporter two failures before they
+ * reached a tool at all.
+ *
+ * A POST saying `Accept: application/json` was refused with `406 Not
+ * Acceptable` — spec-conformant, and worth nothing on a stateless server that
+ * never pushes. Correcting the header then produced an SSE frame inside a
+ * chunked body, whose hex chunk-size line (`2e6`) parses as the number 2×10⁶
+ * and yields `Extra data: line 1 column 4 (char 3)` — the exact error in the
+ * issue, reported there as "duplicate JSON".
+ *
+ * Neither is a protocol violation on this server's part. Both are a client
+ * asking for one JSON object and not being able to get one.
+ */
+
+const TOKEN = 'a'.repeat(64);
+
+const config: Config = ConfigSchema.parse({
+    auth: { bearer_token: TOKEN, password_hash: hashPassword('unused-here') },
+    services: {}
+});
+
+const app = () =>
+    buildApp({
+        runtime: Runtime.fromConfig(config, WriteAudit.ephemeral(), { adapters: [] }),
+        audit: WriteAudit.ephemeral(),
+        logs: LogStore.ephemeral()
+    });
+
+const post = (accept: string | undefined, body: unknown) =>
+    app().request('http://localhost:6060/mcp', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${TOKEN}`,
+            ...(accept === undefined ? {} : { Accept: accept })
+        },
+        body: JSON.stringify(body)
+    });
+
+const toolsList = { jsonrpc: '2.0', id: 1, method: 'tools/list' };
+
+describe('a client that asks for JSON gets JSON', () => {
+    it('answers `Accept: application/json` instead of refusing it with a 406', async () => {
+        const res = await post('application/json', toolsList);
+
+        expect(res.status).toBe(200);
+        expect(res.headers.get('content-type')).toContain('application/json');
+    });
+
+    /**
+     * The whole point: `JSON.parse` on the raw body, with nothing stripped
+     * first. This is the call that produced "Extra data: line 1 column 4".
+     */
+    it('returns a body that parses as one JSON object, with no framing to strip', async () => {
+        const body = await (await post('application/json', toolsList)).text();
+
+        expect(body.startsWith('event:')).toBe(false);
+        expect(body).not.toContain('data:');
+        const payload = JSON.parse(body) as { result: { tools: unknown[] } };
+        expect(payload.result.tools.length).toBeGreaterThan(0);
+    });
+
+    it('answers a request with no Accept header at all', async () => {
+        const res = await post(undefined, toolsList);
+        expect(res.status).toBe(200);
+        expect(JSON.parse(await res.text())).toHaveProperty('result');
+    });
+
+    it('answers `Accept: */*`, which the transport counts as neither type', async () => {
+        expect((await post('*/*', toolsList)).status).toBe(200);
+    });
+
+    /**
+     * The transport requires *both* media types, so a client asking only for a
+     * stream was refused as well. It gets its stream.
+     */
+    it('answers `Accept: text/event-stream` alone, and still frames it as a stream', async () => {
+        const res = await post('text/event-stream', toolsList);
+
+        expect(res.status).toBe(200);
+        expect(res.headers.get('content-type')).toContain('text/event-stream');
+        expect(await res.text()).toContain('event: message');
+    });
+
+    it('leaves a client that accepts both exactly as it was', async () => {
+        const res = await post('application/json, text/event-stream', toolsList);
+
+        expect(res.headers.get('content-type')).toContain('text/event-stream');
+        expect(await res.text()).toContain('data:');
+    });
+
+    it('carries a tool call through, structured content and all', async () => {
+        const res = await post('application/json', {
+            jsonrpc: '2.0',
+            id: 2,
+            method: 'tools/call',
+            params: { name: 'get_library', arguments: { limit: 5 } }
+        });
+
+        const payload = JSON.parse(await res.text()) as {
+            result: { structuredContent: { total: number; offset: number } };
+        };
+        expect(payload.result.structuredContent).toMatchObject({ total: 0, offset: 0 });
+    });
+
+    /** Authentication runs first and answers in JSON already; unwrapping must
+     *  not touch it, or a 401 would arrive as a 200. */
+    it('does not disturb a 401', async () => {
+        const res = await app().request('http://localhost:6060/mcp', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+            body: JSON.stringify(toolsList)
+        });
+
+        expect(res.status).toBe(401);
+        expect(JSON.parse(await res.text())).toEqual({ error: 'unauthorized' });
+    });
+
+    /** A notification has no response to unwrap. It must stay a bare 202. */
+    it('leaves a notification acknowledged with 202 and an empty body', async () => {
+        const res = await post('application/json', { jsonrpc: '2.0', method: 'notifications/initialized' });
+
+        expect(res.status).toBe(202);
+        expect(await res.text()).toBe('');
+    });
+});
+
+describe('unwrapping an SSE frame', () => {
+    const sse = (body: string) =>
+        new Response(body, { status: 200, headers: { 'content-type': 'text/event-stream', 'x-accel-buffering': 'no' } });
+
+    it('leaves a response that is not a stream completely alone', async () => {
+        const json = new Response('{"a":1}', { status: 418, headers: { 'content-type': 'application/json' } });
+        const out = await asPlainJson(json);
+
+        expect(out.status).toBe(418);
+        expect(await out.text()).toBe('{"a":1}');
+    });
+
+    it('drops the headers that described a stream this no longer is', async () => {
+        const out = await asPlainJson(sse('event: message\ndata: {"jsonrpc":"2.0","id":1,"result":{}}\n\n'));
+
+        expect(out.headers.get('content-type')).toContain('application/json');
+        expect(out.headers.get('x-accel-buffering')).toBeNull();
+    });
+
+    /**
+     * A payload may span several `data:` lines, rejoined with newlines. The SDK
+     * writes one line per message today; a parser that only handles the shape
+     * it has seen is how the next version breaks quietly.
+     */
+    it('rejoins a payload split across several data lines', async () => {
+        const out = await asPlainJson(sse('event: message\ndata: {"jsonrpc":"2.0","id":1,\ndata: "result":{"ok":true}}\n\n'));
+
+        expect(JSON.parse(await out.text())).toEqual({ jsonrpc: '2.0', id: 1, result: { ok: true } });
+    });
+
+    /**
+     * Mid-call notifications are dropped rather than concatenated — appending a
+     * second object to the body is precisely the "extra data" that made #103
+     * unparseable, and a caller that cannot read a stream cannot read progress
+     * either.
+     */
+    it('keeps the response and drops a notification that arrived before it', async () => {
+        const frame =
+            'event: message\ndata: {"jsonrpc":"2.0","method":"notifications/progress","params":{}}\n\n' +
+            'event: message\ndata: {"jsonrpc":"2.0","id":1,"result":{"tools":[]}}\n\n';
+        const out = await asPlainJson(sse(frame));
+
+        expect(JSON.parse(await out.text())).toEqual({ jsonrpc: '2.0', id: 1, result: { tools: [] } });
+    });
+
+    /** A batch in, a batch out. */
+    it('returns an array when the frame carried several responses', async () => {
+        const frame =
+            'event: message\ndata: {"jsonrpc":"2.0","id":1,"result":{}}\n\n' +
+            'event: message\ndata: {"jsonrpc":"2.0","id":2,"result":{}}\n\n';
+        const out = await asPlainJson(sse(frame));
+
+        expect(JSON.parse(await out.text())).toHaveLength(2);
+    });
+
+    /** Nothing to unwrap: pass the original through rather than invent one. */
+    it('passes a frame carrying no response through unchanged', async () => {
+        const frame = 'event: message\ndata: {"jsonrpc":"2.0","method":"notifications/message","params":{}}\n\n';
+        const out = await asPlainJson(sse(frame));
+
+        expect(await out.text()).toBe(frame);
+    });
+});
+
+describe('reading and rewriting the Accept header', () => {
+    const request = (accept?: string) =>
+        new Request('http://localhost:6060/mcp', {
+            method: 'POST',
+            headers: accept === undefined ? {} : { Accept: accept }
+        });
+
+    it('recognises a stream client however the header is cased or ordered', () => {
+        expect(acceptsStream(request('TEXT/EVENT-STREAM'))).toBe(true);
+        expect(acceptsStream(request('application/json, text/event-stream;q=0.9'))).toBe(true);
+        expect(acceptsStream(request('application/json'))).toBe(false);
+        expect(acceptsStream(request())).toBe(false);
+        expect(acceptsStream(request('*/*'))).toBe(false);
+    });
+
+    it('rewrites only the header, leaving method and url alone', () => {
+        const upgraded = acceptingBoth(request('application/json'));
+
+        expect(upgraded.headers.get('accept')).toBe('application/json, text/event-stream');
+        expect(upgraded.method).toBe('POST');
+        expect(upgraded.url).toBe('http://localhost:6060/mcp');
+    });
+});

--- a/test/shape.test.ts
+++ b/test/shape.test.ts
@@ -14,7 +14,7 @@ describe('applyLimit', () => {
 
     it('reports truncated: false when everything fits', () => {
         const out = applyLimit([1, 2, 3], 50);
-        expect(out).toEqual({ items: [1, 2, 3], total: 3, returned: 3, truncated: false });
+        expect(out).toEqual({ items: [1, 2, 3], total: 3, returned: 3, offset: 0, truncated: false });
     });
 
     it('caps at MAX_LIMIT regardless of what was requested', () => {
@@ -27,7 +27,7 @@ describe('applyLimit', () => {
     });
 
     it('handles an empty list without claiming truncation', () => {
-        expect(applyLimit([], 50)).toEqual({ items: [], total: 0, returned: 0, truncated: false });
+        expect(applyLimit([], 50)).toEqual({ items: [], total: 0, returned: 0, offset: 0, truncated: false });
     });
 
     it('clamps a nonsensical limit to at least one item rather than returning nothing', () => {
@@ -47,6 +47,80 @@ describe('applyLimit', () => {
         const input = [1, 2, 3, 4];
         applyLimit(input, 2);
         expect(input).toEqual([1, 2, 3, 4]);
+    });
+});
+
+/**
+ * The second half of the truncation contract, added in response to #103.
+ *
+ * `limit` alone answers "give me fewer"; it cannot answer "give me the next
+ * ones", and a library past `MAX_LIMIT` was therefore unreadable in full. The
+ * agent in #103 guessed at `offset` for exactly this reason — the parameter it
+ * reached for was the right idea against a tool that did not have it.
+ */
+describe('applyLimit with an offset', () => {
+    const hundred = Array.from({ length: 100 }, (_, i) => i);
+
+    it('returns the window starting at the offset', () => {
+        const out = applyLimit(hundred, 10, 20);
+        expect(out.items).toEqual([20, 21, 22, 23, 24, 25, 26, 27, 28, 29]);
+        expect(out.offset).toBe(20);
+        expect(out.returned).toBe(10);
+        expect(out.total).toBe(100);
+    });
+
+    /**
+     * `total` counts the whole list, never the window. It is the number that
+     * stops a model reporting a 100-item library as a 10-item one, so an offset
+     * must not be able to shrink it.
+     */
+    it('counts the whole list in `total`, not the window', () => {
+        expect(applyLimit(hundred, 10, 90).total).toBe(100);
+    });
+
+    /**
+     * `truncated` keeps the meaning it had before an offset existed: *this is
+     * not the whole list*. Reading it as "there is more after this window"
+     * would make the last page report `false` while 90 items the caller never
+     * saw sat in front of it.
+     */
+    it('still reports truncation on the last page, where most of the list is behind you', () => {
+        const out = applyLimit(hundred, 10, 90);
+        expect(out.returned).toBe(10);
+        expect(out.truncated).toBe(true);
+    });
+
+    it('is not truncated when one window covers everything', () => {
+        expect(applyLimit([1, 2, 3], 50, 0)).toEqual({
+            items: [1, 2, 3],
+            total: 3,
+            returned: 3,
+            offset: 0,
+            truncated: false
+        });
+    });
+
+    /**
+     * Past the end is an empty page, not an error and not a wrapped-around
+     * first page. `total` still says how far past the end the caller went.
+     */
+    it('returns nothing for an offset beyond the end, without pretending it is the start', () => {
+        const out = applyLimit(hundred, 10, 500);
+        expect(out.items).toEqual([]);
+        expect(out.returned).toBe(0);
+        expect(out.total).toBe(100);
+    });
+
+    it('treats a negative or fractional offset as the start rather than slicing from the end', () => {
+        expect(applyLimit(hundred, 3, -5).items).toEqual([0, 1, 2]);
+        expect(applyLimit(hundred, 3, 2.7).items).toEqual([2, 3, 4]);
+    });
+
+    /** Paging the whole list yields every item exactly once, in order. */
+    it('covers the list exactly once when walked page by page', () => {
+        const seen: number[] = [];
+        for (let offset = 0; offset < 100; offset += 30) seen.push(...applyLimit(hundred, 30, offset).items);
+        expect(seen).toEqual(hundred);
     });
 });
 

--- a/test/stackHealth.test.ts
+++ b/test/stackHealth.test.ts
@@ -204,7 +204,7 @@ describe('stack_health', () => {
 
         expect(result.services).toEqual([]);
         expect(result.degraded).toEqual([]);
-        expect(result.disks).toEqual({ items: [], total: 0, returned: 0, truncated: false });
+        expect(result.disks).toEqual({ items: [], total: 0, returned: 0, offset: 0, truncated: false });
     });
 
     it('includes a capability-less service in the diagnosis list without degrading it', async () => {


### PR DESCRIPTION
The three follow-ups from #103 that #104 left open, one commit each.

#104 fixed the root cause — arguments this server does not have are refused rather than silently dropped. These fix the three things the reporter was reaching for when it started guessing.

## 1. `offset` on every list tool

`limit` answers "give me fewer". Nothing answered "give me the next ones", so a library past `MAX_LIMIT` (500) could not be read in full at all. That is why the agent invented `offset`: right idea, tool did not have it.

The envelope is now `{ items, total, returned, offset, truncated }` on all ten list tools. Three decisions worth stating:

- **`total` counts the whole list, never the window.** It is the number that stops a model reporting a 900-film library as a 50-film one, so an offset must not be able to shrink it.
- **`truncated` keeps its old meaning** — *this is not the whole list* — rather than becoming "there is more after this window". Under the second reading the last page of a walk reports `false` with everything the caller never saw sitting in front of it, which is the same false completeness the field exists to prevent. "Is there another page" is `offset + returned < total`, and every term is in the response.
- **`offset` is uncapped** where `limit` stops at 500. A large limit spends context, a real cost; a large offset just means a caller is deep in a list. Capping it would put items past the cap permanently out of reach.

`stack_health` takes no `offset` on purpose: one budget spans its two lists, so a single number could not say which it meant to skip into.

The window lands after filtering and sorting. An offset applied before the sort would page through the services' own order and return different items for the same request while still looking well-formed — there is a test for exactly that.

## 2. `outputSchema` on every tool

Reported as "`total` is not in `structuredContent`". It always was. But nothing declared an output schema, and a client that gates `structuredContent` on one surfaces nothing without it — indistinguishable, from the far side, from the field not existing. The reporter parsed the count out of `"50 of 243 item(s)"`, which is prose and may be reworded.

All 22 tools now declare one: a shared paged envelope, a shared write envelope, and one apiece for `stack_health`, `diagnose` and `get_media_details`.

**Every schema is loose, and that is the design.** The SDK validates `structuredContent` and fails the whole call on a mismatch — so an over-specified schema turns a documentation gap into an outage. On a write it is worse: validation runs *after* `apply`, so a change that already landed would be reported to the model as an error. Everything shared is named and required; `items` and per-tool extras ride through unconstrained. `projectCallToolResult` does not strip to the schema, so nothing is lost by leaving them undeclared.

The tests drive real payloads rather than empty ones and earned it immediately: requiring `degraded` on `stack_health`'s two inner lists — it reports that once, at the top — failed every call to that tool.

## 3. A plain-JSON transport path

The half that cost the reporter two failures before reaching a tool.

`Accept: application/json` was refused with `406 Not Acceptable`. Spec-conformant, worth nothing on a stateless server that never pushes, and it reads as a broken server from the far end. Correcting the header produced the second failure: an SSE frame in a chunked body, which parsed as JSON gives `Extra data: line 1 column 4 (char 3)` — the hex chunk-size line `2e6` read as the number 2×10⁶, reported in the issue as "duplicate JSON". Nothing was duplicated; only some payload sizes produce a hex length that looks like scientific notation, which is why it was intermittent.

Now every request reaches the transport accepting both media types (which also unblocks a client asking *only* for `text/event-stream`, equally refused before), and a caller that never asked for a stream gets the frame unwrapped on the way out: `application/json` with a `Content-Length`, nothing to misparse. A caller that does accept a stream is untouched. The spec allows exactly this.

This gives way on a transport header — not on an argument, a permission or a confirmation token. #103's real lesson was that this server had those backwards: strict where strictness only cost compatibility, silent where a caller needed to be told no.

## Compatibility

Additive throughout. `offset` defaults to 0, every existing call behaves as it did, and no parameter or field was renamed or removed.

## Verification

- 1376 tests, lint and typecheck clean.
- Live-verified against a running instance: `Accept: application/json` returns 200 with `Content-Length`, and `json.loads` on the raw body parses all 22 tools — the same call that used to produce `Extra data: line 1 column 4`.
- Confirmed on the wire: 22 tools advertising `outputSchema`, 10 advertising `offset`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
