### PR TITLE
fix: build on trixie so the arm64 image can load better-sqlite3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+      - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - name: Build image (no push)
         uses: docker/build-push-action@v6
         with:
           context: .
           push: false
+
+      # release.yml publishes linux/arm64, but this job only built for the
+      # runner's own platform, so the arm64 image was first executed by the user
+      # who reported 1.6.0 dying on a Raspberry Pi. Building it is not enough —
+      # a native addon with an unresolvable symbol only fails when loaded.
+      #
+      # Single platform with load:true; a multi-platform build cannot be loaded
+      # into the local image store.
+      - name: Build arm64 image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          load: true
+          platforms: linux/arm64
+          tags: arr-mcp:arm64-smoke
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke-test the arm64 native addon
+        run: |
+          docker run --rm --platform linux/arm64 arr-mcp:arm64-smoke \
+            node -e "const D=require('better-sqlite3');const db=new D(':memory:');db.exec('create table t(x)');db.prepare('insert into t values (?)').run(1);console.log('better-sqlite3 ok:', db.prepare('select count(*) c from t').get().c)"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM node:24-bookworm-slim AS build
+FROM node:24-trixie-slim AS build
 WORKDIR /app
 # better-sqlite3 compiles a native addon; unused in Phase 1 but proven here so
 # Phase 4 does not discover a broken build stage.
@@ -12,7 +12,11 @@ COPY tsconfig.json tsconfig.build.json ./
 COPY src ./src
 RUN npm run build && npm prune --omit=dev
 
-FROM node:24-bookworm-slim AS runtime
+# Trixie (glibc 2.41), not bookworm (2.36): better-sqlite3's prebuilt aarch64
+# addon imports fmod@GLIBC_2.38, so on bookworm the arm64 image died at startup
+# while amd64 — needing only 2.34 — ran fine. test/dockerGlibc.test.ts fails if
+# a future prebuild outgrows this base.
+FROM node:24-trixie-slim AS runtime
 WORKDIR /app
 
 ARG ARR_MCP_VERSION=0.0.0-dev

--- a/test/dockerGlibc.test.ts
+++ b/test/dockerGlibc.test.ts
@@ -1,0 +1,92 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = join(import.meta.dirname, '..');
+
+// better-sqlite3 13 compiles nothing at install time — it bundles a prebuilt
+// .node per platform, and the aarch64 one imports fmod@GLIBC_2.38 while amd64
+// tops out at GLIBC_2.34. On bookworm (glibc 2.36) that killed the arm64 image
+// at startup and left amd64 working, which is how it reached a Raspberry Pi.
+// This compares what the shipped binaries demand against the base image the
+// Dockerfile names, so the next prebuild to outgrow it fails here instead.
+
+// The platforms release.yml publishes; the linuxmusl-* prebuilds that also ship
+// in the tarball are irrelevant to a Debian base image.
+const PLATFORMS = ['linux-x64', 'linux-arm64'];
+
+// glibc is frozen for the life of a Debian suite, so a table is enough. An
+// unknown suite fails rather than defaulting — assuming a modern glibc is the
+// assumption that produced the bug.
+const SUITE_GLIBC: Record<string, [number, number]> = {
+    bookworm: [2, 36],
+    trixie: [2, 41]
+};
+
+type Version = [number, number];
+
+const compare = (a: Version, b: Version): number => a[0] - b[0] || a[1] - b[1];
+const show = (v: Version): string => `${v[0]}.${v[1]}`;
+
+// "GLIBC_2.2.5" and "GLIBC_2.34" both appear; two parts is enough to order them.
+const parseSymbolVersion = (tag: string): Version => {
+    const [major, minor] = tag.slice('GLIBC_'.length).split('.');
+    return [Number(major), Number(minor ?? 0)];
+};
+
+const PREBUILD_DIR = join(ROOT, 'node_modules', 'better-sqlite3', 'prebuilds');
+
+// Scanning raw bytes reads the ELF's version-needed strings without an ELF
+// parser. Over-matching only makes the assertion stricter, never falsely green.
+const requiredGlibc = (platform: string): Version => {
+    const bytes = readFileSync(join(PREBUILD_DIR, `${platform}.node`)).toString('latin1');
+    const tags = bytes.match(/GLIBC_\d+\.\d+(\.\d+)?/g) ?? [];
+    const highest = tags.map(parseSymbolVersion).sort(compare).at(-1);
+    if (!highest) throw new Error(`${platform}.node imports no glibc symbols at all`);
+    return highest;
+};
+
+const DOCKERFILE = readFileSync(join(ROOT, 'Dockerfile'), 'utf8');
+
+const baseImages = (): string[] =>
+    [...DOCKERFILE.matchAll(/^FROM\s+node:\S+/gm)].map((m) => m[0].replace(/^FROM\s+/, ''));
+
+const glibcFor = (image: string): Version | undefined => {
+    const suite = Object.keys(SUITE_GLIBC).find((s) => image.includes(s));
+    return suite ? SUITE_GLIBC[suite] : undefined;
+};
+
+describe('the Docker base image against better-sqlite3 prebuilds', () => {
+    it('still gets its native addon from bundled prebuilds', () => {
+        // If better-sqlite3 goes back to compiling at install time, the base
+        // image no longer decides this and the tests below measure nothing.
+        const shipped = readdirSync(PREBUILD_DIR);
+        for (const platform of PLATFORMS) {
+            expect(shipped, `better-sqlite3 no longer ships a ${platform} prebuild`).toContain(`${platform}.node`);
+        }
+    });
+
+    it('names at least one base image', () => {
+        expect(baseImages().length).toBeGreaterThan(0);
+    });
+
+    it('pins every stage to a suite whose glibc is known', () => {
+        for (const image of baseImages()) {
+            expect(glibcFor(image), `${image} uses a suite missing from SUITE_GLIBC — add its glibc version`).toBeDefined();
+        }
+    });
+
+    for (const platform of PLATFORMS) {
+        it(`ships a glibc new enough for ${platform}`, () => {
+            const required = requiredGlibc(platform);
+            for (const image of baseImages()) {
+                const provided = glibcFor(image);
+                if (!provided) continue; // reported by the test above
+                expect(
+                    compare(provided, required),
+                    `${image} provides glibc ${show(provided)} but ${platform}.node needs ${show(required)}`
+                ).toBeGreaterThanOrEqual(0);
+            }
+        });
+    }
+});


### PR DESCRIPTION
A Raspberry Pi 4 user reported 1.6.0 crashing at startup with `GLIBC_2.38 not found` from better-sqlite3. ARM64 support was not missing — the base image was one glibc symbol too old.

## Root cause

better-sqlite3 13 has no install script and no compile step (`gypfile: false`); it bundles one prebuilt `.node` per platform in its tarball, each built on a different host. Parsing the version-needed table of the binaries our lockfile resolves:

| prebuild | highest glibc symbol | |
|---|---|---|
| `linux-x64.node` | `GLIBC_2.34` | fine on bookworm |
| `linux-arm64.node` | **`GLIBC_2.38`** | `fmod@GLIBC_2.38` |

The runtime base was `node:24-bookworm-slim` — Debian 12, glibc 2.36. amd64 ran, arm64 could not resolve the symbol.

Two reasons this shipped: the addon only fails when *loaded*, not when built, and the `docker` CI job built for the runner's own platform only. `release.yml` publishes `linux/arm64` that had never been executed anywhere before it reached a user's Pi.

## Changes

- **`Dockerfile`** — both stages to `node:24-trixie-slim` (Debian 13, glibc 2.41). `gosu` and `wget` are both in trixie, so the entrypoint is unaffected.
- **`test/dockerGlibc.test.ts`** — reads the glibc floor out of the shipped prebuilds and compares it against the suite the Dockerfile names. An unrecognised suite fails rather than defaulting to "probably new enough".
- **`.github/workflows/ci.yml`** — builds `linux/arm64` and loads better-sqlite3 inside it under QEMU. Costs a few emulated minutes per PR; it is the only check here that runs ARM code at all.

## Verification

- The new test fails on the old Dockerfile with `node:24-bookworm-slim provides glibc 2.36 but linux-arm64.node needs 2.38`, and passes on trixie — re-confirmed after refactoring so it is not passing vacuously.
- 1392 tests across 64 files pass; lint and typecheck clean.
- The arm64 container itself was not run locally (no Docker daemon available on the authoring machine). The new CI step is the end-to-end proof and runs on this PR.

## Not included

The build stage still installs `python3 make g++` under a comment claiming better-sqlite3 compiles a native addon. It no longer does — dead weight, and a misleading comment that helped hide this. Left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
