### PR TITLE
feat: list arr-mcp in the MCP Registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,3 +110,39 @@ jobs:
           subject-name: ghcr.io/bardesss/arr-mcp
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
+
+  # Lists the release at registry.modelcontextprotocol.io, which is how MCP
+  # clients discover servers. Needs `image`, not just the tag: the registry
+  # pulls the image `server.json` names and refuses to publish unless it carries
+  # the `io.modelcontextprotocol.server.name` label the Dockerfile sets.
+  registry:
+    needs: [release-please, image]
+    if: needs.release-please.outputs.released == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v5
+
+      # release-please already bumped `.version`, but the image tag lives inside
+      # a string it cannot rewrite — so derive both from the release version
+      # rather than trusting the file to name the tag this run just pushed.
+      - name: Pin server.json to this release
+        run: |
+          v='${{ needs.release-please.outputs.version }}'
+          jq --arg v "$v" '.version = $v | .packages[0].identifier = "ghcr.io/bardesss/arr-mcp:" + $v' \
+            server.json > server.tmp && mv server.tmp server.json
+          cat server.json
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      # OIDC, so there is no token to store or rotate: the registry trusts the
+      # workflow's own identity, and `io.github.bardesss/*` is ours because the
+      # repository is.
+      - name: Publish to the MCP Registry
+        run: |
+          ./mcp-publisher login github-oidc
+          ./mcp-publisher publish

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,10 @@ WORKDIR /app
 
 ARG ARR_MCP_VERSION=0.0.0-dev
 
+# How the MCP Registry proves we own this image: it pulls the tag `server.json`
+# names and refuses to publish unless this label matches the server name.
+LABEL io.modelcontextprotocol.server.name="io.github.bardesss/arr-mcp"
+
 # The node image already ships a non-root `node` user at 1000:1000, which is
 # also our default PUID/PGID — reuse it rather than creating a second account
 # at the same ids (groupadd -g 1000 fails outright).

--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ It applies immediately; there is no restart. Configure only what you run.
 
 Your MCP client goes to `http://<host>:6060/mcp` with the bearer token shown on
 the dashboard. Everything the UI does is still just `config.yaml`, and editing
-that by hand remains supported.
+that by hand remains supported. Clients that read the
+[MCP Registry](https://registry.modelcontextprotocol.io) find it there as
+`io.github.bardesss/arr-mcp`.
 
 **Works with whatever you point at it.** A client asking for
 `Accept: application/json` — or sending no `Accept` at all — gets one JSON object

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,12 +11,40 @@ PR merged to main  →  release-please updates its release PR
 merge release PR   →  tag vX.Y.Z + GitHub Release
 tag                →  buildx multi-arch → ghcr.io/bardesss/arr-mcp
                    →  SBOM + provenance attestation
+                   →  server.json → registry.modelcontextprotocol.io
 ```
 
 Image tags are `X.Y.Z`, `X.Y`, `X` and `latest` for releases, plus `main` for
 bleeding edge. Nothing else. The release workflow fails the job when a release
 computes no version tag — a release that publishes only `latest` is a silent
 policy violation, and it has happened once.
+
+## The MCP Registry entry
+
+`server.json` is the listing at `registry.modelcontextprotocol.io`, which is how
+MCP clients discover this server. The `registry` job publishes it after the
+image, on releases only, using the workflow's own OIDC identity — there is no
+token to store or rotate.
+
+Two things it depends on, both of which fail late:
+
+- **The published image must carry `LABEL io.modelcontextprotocol.server.name`
+  matching the `name` in `server.json`.** That label is the registry's only
+  proof we own `ghcr.io/bardesss/arr-mcp`, and it is read from the image at
+  publish time — so the tag must already be pushed, which is why `registry`
+  needs `image`.
+- **The tag in `packages[0].identifier` must be the one the release pushed.**
+  release-please bumps `version`, but cannot rewrite a tag embedded in a string,
+  so the job derives both from the release version with `jq`.
+
+Check a `server.json` change without publishing anything:
+
+```bash
+mcp-publisher validate server.json
+```
+
+It checks the schema and the registry's rules. It does **not** check the image
+label — that only fails during a real publish.
 
 ## Forcing a version, and the three ways it has gone wrong
 
@@ -232,7 +260,9 @@ reported a 23-hour-stale library as scanned a minute ago.
 Do this at **0.3 and later**, not for 0.1 or 0.2 — those are foundations, and
 an announcement lands once.
 
-- [ ] [MCP registry](https://github.com/modelcontextprotocol/registry) listing
+- [x] [MCP registry](https://github.com/modelcontextprotocol/registry) listing —
+      `io.github.bardesss/arr-mcp`, published from `server.json` by the release
+      workflow
 - [ ] Unraid Community Applications template
 - [ ] Umbrel app store submission
 - [ ] CasaOS app store submission

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,7 +10,14 @@
       "draft": false,
       "prerelease": false,
       "initial-version": "0.1.0",
-      "include-component-in-tag": false
+      "include-component-in-tag": false,
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "server.json",
+          "jsonpath": "$.version"
+        }
+      ]
     }
   }
 }

--- a/server.json
+++ b/server.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.bardesss/arr-mcp",
+  "title": "arr-mcp",
+  "description": "One MCP server for the whole media stack: Radarr, Sonarr, Prowlarr, Bazarr, Jellyfin, Seerr",
+  "version": "1.6.2",
+  "websiteUrl": "https://github.com/bardesss/arr-mcp",
+  "repository": {
+    "url": "https://github.com/bardesss/arr-mcp",
+    "source": "github",
+    "id": "1322956288"
+  },
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/bardesss/arr-mcp:1.6.2",
+      "runtimeHint": "docker",
+      "runtimeArguments": [
+        {
+          "type": "named",
+          "name": "-p",
+          "value": "6060:6060",
+          "description": "Publish the MCP and config-UI port"
+        },
+        {
+          "type": "named",
+          "name": "-v",
+          "value": "{config_dir}:/config",
+          "description": "Host directory holding config.yaml, the write audit and the log ring buffer",
+          "isRequired": true,
+          "variables": {
+            "config_dir": {
+              "description": "Directory on the host to keep arr-mcp's configuration in",
+              "format": "filepath",
+              "isRequired": true
+            }
+          }
+        }
+      ],
+      "environmentVariables": [
+        {
+          "name": "PUID",
+          "description": "User id owning the files in /config",
+          "default": "1000"
+        },
+        {
+          "name": "PGID",
+          "description": "Group id owning the files in /config",
+          "default": "1000"
+        },
+        {
+          "name": "TZ",
+          "description": "Timezone used for timestamps, e.g. Europe/Amsterdam"
+        }
+      ],
+      "transport": {
+        "type": "streamable-http",
+        "url": "http://localhost:6060/mcp",
+        "headers": [
+          {
+            "name": "Authorization",
+            "description": "Bearer token shown on the arr-mcp dashboard once the instance is claimed",
+            "value": "Bearer {token}",
+            "isRequired": true,
+            "isSecret": true,
+            "variables": {
+              "token": {
+                "description": "The bearer token from http://<host>:6060",
+                "isRequired": true,
+                "isSecret": true
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds the registry listing at `registry.modelcontextprotocol.io`, so MCP clients can discover arr-mcp as `io.github.bardesss/arr-mcp`.

The quickstart's npm path does not fit this server — it is a container serving streamable HTTP behind a bearer token, with a config volume, not a stdio package — so this uses the registry's **OCI package type**, pointing at `ghcr.io/bardesss/arr-mcp`.

## What is here

- **`server.json`** — the listing: the image, the `docker` arguments to run it (`-p 6060:6060`, a required `-v {config_dir}:/config`, `PUID`/`PGID`/`TZ`), and the `streamable-http` transport at `/mcp` with `Authorization: Bearer {token}` as a required secret.
- **`Dockerfile`** — `LABEL io.modelcontextprotocol.server.name`. This is the registry's only proof we own the image; it reads it from the image config at publish time, resolving the multi-arch index.
- **`release.yml`** — a `registry` job after `image`, releases only, authenticating with `mcp-publisher login github-oidc`. No new secret.
- **`release-please-config.json`** — bumps `server.json`'s version with everything else. The tag inside `packages[0].identifier` is a string release-please cannot rewrite, so the job derives both fields from the release version.
- **`README.md` / `RELEASING.md`** — one line in Quick start, a section on the two couplings that fail late, and the Distribution checkbox ticked.

## Verification

- `npm run lint`, `npm run typecheck`, `npm test` — 1414 pass
- `mcp-publisher validate server.json` — valid

Not verifiable before merge: the image label, which `validate` does not check — ownership is only read from a pushed image. The `main` image this push builds carries it, so `docker buildx imagetools inspect ghcr.io/bardesss/arr-mcp:main` confirms it before any release.

The entry itself appears when this ships: 1.6.2's image predates the label, so nothing can be published against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)