### PR TITLE
fix: pin and checksum the mcp-publisher binary the release runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,9 +135,19 @@ jobs:
             server.json > server.tmp && mv server.tmp server.json
           cat server.json
 
+      # Pinned and checksummed, unlike the `releases/latest` one-liner upstream
+      # documents: this step runs with `id-token: write`, so a binary swapped
+      # under `latest` could mint an OIDC token asserting this repository's
+      # identity. Bump both values together — see RELEASING.md.
       - name: Install mcp-publisher
+        env:
+          VERSION: v1.8.1
+          SHA256: a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          curl -fL -o mcp-publisher.tar.gz \
+            "https://github.com/modelcontextprotocol/registry/releases/download/${VERSION}/mcp-publisher_linux_amd64.tar.gz"
+          echo "${SHA256}  mcp-publisher.tar.gz" | sha256sum -c -
+          tar xzf mcp-publisher.tar.gz mcp-publisher
 
       # OIDC, so there is no token to store or rotate: the registry trusts the
       # workflow's own identity, and `io.github.bardesss/*` is ours because the

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -37,6 +37,16 @@ Two things it depends on, both of which fail late:
   release-please bumps `version`, but cannot rewrite a tag embedded in a string,
   so the job derives both from the release version with `jq`.
 
+The `mcp-publisher` binary is pinned to a release **and** its SHA-256, because
+that step runs with `id-token: write` — the upstream `releases/latest` one-liner
+would let a swapped asset mint an OIDC token in this repository's name. Nothing
+bumps the pin automatically; move the version and the digest together:
+
+```bash
+curl -fLO https://github.com/modelcontextprotocol/registry/releases/download/<tag>/mcp-publisher_linux_amd64.tar.gz
+sha256sum mcp-publisher_linux_amd64.tar.gz
+```
+
 Check a `server.json` change without publishing anything:
 
 ```bash


### PR DESCRIPTION
Follow-up to #114, from a security review of that push.

The `registry` job installed `mcp-publisher` the way the upstream docs document it — `curl` from `releases/latest`, piped into `tar`, then executed:

```
curl -L .../releases/latest/download/mcp-publisher_$(uname ...).tar.gz | tar xz mcp-publisher
./mcp-publisher login github-oidc
```

That step holds `id-token: write`. An asset replaced under the moving `latest` tag would run with the ability to mint a GitHub OIDC token asserting this repository's identity. `contents: read` and the absence of `packages: write` bound the rest — it cannot touch the image or the repo — but not that.

Now pinned to `v1.8.1` and checked against its SHA-256 **before** the binary is extracted, let alone run. The `uname` platform guess goes too: the runner is `ubuntu-latest`, so deriving the asset name only widened the set of downloads that could satisfy the step.

## Verification

- `a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc` computed locally from the v1.8.1 `linux_amd64` asset, and `sha256sum -c` accepts it
- The tarball does contain a member named `mcp-publisher`, so `tar xzf ... mcp-publisher` resolves
- Workflow YAML parses; the step's `env` and `run` are as intended

Upstream publishes sigstore bundles but no GitHub attestations (`gh attestation verify` 404s on the asset digest), so a pinned digest is the strongest check available without adding cosign. Renovate will not move it — `RELEASING.md` now carries the two commands to bump the version and digest together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)