### PR TITLE
fix(config): write the ui block so the theme switcher saves

### DIFF
--- a/src/config/save.ts
+++ b/src/config/save.ts
@@ -21,6 +21,14 @@ const FILENAME = 'config.yaml';
  * need positional matching that a reordered list would get wrong.
  */
 function mergeInto(doc: Document, path: string[], value: unknown): void {
+    // `undefined` is absence, not null. `setIn` would write a null-valued key,
+    // and the schema refuses those on the next load — a save that produced an
+    // instance which will not start.
+    if (value === undefined) {
+        doc.deleteIn(path);
+        return;
+    }
+
     const existing = doc.getIn(path);
     const isPlainObject = typeof value === 'object' && value !== null && !Array.isArray(value);
 
@@ -97,34 +105,21 @@ export async function saveConfig(configDir: string, next: Config, opts: { expect
         }
     }
 
-    doc.setIn(['auth', 'bearer_token'], value.auth.bearer_token);
-    doc.setIn(['auth', 'username'], value.auth.username);
-    // Deleted rather than set when absent: `setIn` with `undefined` writes a
-    // null-valued key, and a config carrying `password_hash: null` reads back
-    // as claimed-with-an-empty-hash — an instance nobody can sign in to, and
-    // one the setup page will not rescue because it no longer looks unclaimed.
-    if (value.auth.password_hash === undefined) doc.deleteIn(['auth', 'password_hash']);
-    else doc.setIn(['auth', 'password_hash'], value.auth.password_hash);
-    doc.setIn(['auth', 'allowed_hosts'], value.auth.allowed_hosts);
-
-    // Key by key, not `setIn(['services'], …)`.
+    // Driven by the schema, not by a list kept here. A list is a thing to
+    // forget, and `ui` was forgotten for a release: the Appearance card built
+    // the right config, the schema accepted it, and the save reported success
+    // over a file that had never been given a theme.
     //
-    // The wholesale form replaced the node with plain JS values, and every
-    // comment inside it went with them — which is property 1 above, broken in
-    // exactly the block people annotate most. `mergeInto` still removes what is
-    // gone (a service switched off, a field cleared), so the orphans the strict
-    // schema would reject never survive; it just leaves the nodes that remain,
-    // and their comments, in place.
-    mergeInto(doc, ['services'], value.services);
-
-    // Deleted when absent rather than written as null, for the same reason as
-    // `password_hash` above: the schema is strict, and `metadata: null` would
-    // fail to parse on the next start — turning a save into an instance that
-    // will not boot. Until 0.8 this key was preserved only because nothing
-    // here touched it, which held right up until the config page could switch
-    // the dataset on.
-    if (value.metadata === undefined) doc.deleteIn(['metadata']);
-    else mergeInto(doc, ['metadata'], value.metadata);
+    // Key by key rather than `setIn(['services'], …)`, which is property 1
+    // above: the wholesale form replaced each node with plain JS values and
+    // took every comment inside it with them. `mergeInto` still removes what is
+    // gone — a service switched off, a field cleared — and leaves the nodes
+    // that remain, and their comments, in place.
+    //
+    // Top-level keys the schema has never heard of are untouched, since nothing
+    // iterates them. They do nothing either way; the loader strips them.
+    const blocks = value as Record<string, unknown>;
+    for (const key of Object.keys(ConfigSchema.shape)) mergeInto(doc, [key], blocks[key]);
 
     // A unique temp name per save. A fixed `config.yaml.tmp` meant two
     // overlapping saves wrote into the same file and both renamed it into

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -399,6 +399,48 @@ describe('the metadata block', () => {
 });
 
 /**
+ * `saveConfig` walks the schema's top-level keys, so a block added to the
+ * schema cannot be left unwritten. It could once: `ui` was, and the theme
+ * switcher saved nothing while reporting that it had.
+ */
+describe('every top-level block', () => {
+    const FULL = ConfigSchema.parse({
+        auth: { bearer_token: 'f'.repeat(64), password_hash: 'scrypt$00$11', allowed_hosts: ['arr.lan'] },
+        services: { radarr: { url: 'http://192.0.2.10:7878', api_key: 'k' } },
+        metadata: { imdb: { enabled: true } },
+        ui: { theme: 'dark' }
+    });
+
+    // Fails the moment a block joins the schema, which is the point: the round
+    // trip below can only cover what this fixture carries.
+    it('appears in the fixture below', () => {
+        expect(Object.keys(FULL).sort()).toEqual(Object.keys(ConfigSchema.shape).sort());
+    });
+
+    it('reaches a file that had none of them', async () => {
+        const dir = await freshDir();
+        await writeFile(join(dir, 'config.yaml'), `auth:\n  bearer_token: ${'f'.repeat(64)}\nservices: {}\n`, 'utf8');
+
+        await saveConfig(dir, FULL);
+
+        expect((await loadConfig(dir)).config).toEqual(FULL);
+    });
+
+    it('goes away again when the config no longer carries it', async () => {
+        const dir = await freshDir();
+        await writeFile(join(dir, 'config.yaml'), `auth:\n  bearer_token: ${'f'.repeat(64)}\nservices: {}\n`, 'utf8');
+        await saveConfig(dir, FULL);
+
+        const { metadata: _m, ui: _u, ...bare } = FULL;
+        await saveConfig(dir, bare);
+
+        const { config } = await loadConfig(dir);
+        expect(config.metadata).toBeUndefined();
+        expect(config.ui).toBeUndefined();
+    });
+});
+
+/**
  * `saveConfig` edits an existing YAML document in place rather than
  * re-serialising the parsed config, so a key it does not know about is
  * preserved by omission rather than by design. That is worth a test: the

--- a/test/theme.test.ts
+++ b/test/theme.test.ts
@@ -1,4 +1,9 @@
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
+import { loadConfig } from '../src/config/load.ts';
+import { saveConfig } from '../src/config/save.ts';
 import { ConfigSchema, ThemeSchema } from '../src/config/schema.ts';
 import { CSS } from '../src/web/assets.ts';
 import { html, raw } from '../src/web/html.ts';
@@ -70,6 +75,47 @@ describe('buildAppearanceConfig', () => {
         const saved = buildAppearanceConfig(withServices, { 'ui.theme': 'dark' });
         expect(saved.metadata).toEqual({ imdb: { enabled: true } });
         expect(saved.auth).toEqual(base.auth);
+    });
+});
+
+/** `saveConfig` writes a hand-picked set of keys, and `ui` was not one of
+ *  them — so the card saved nothing and the banner claimed it had. */
+describe('the theme through a save', () => {
+    const BASE = `auth:\n  bearer_token: ${'f'.repeat(64)}\n  password_hash: scrypt$00$11\nservices: {}\n`;
+    const dirWith = async (yaml: string) => {
+        const dir = await mkdtemp(join(tmpdir(), 'arr-mcp-theme-'));
+        await writeFile(join(dir, 'config.yaml'), yaml, 'utf8');
+        return dir;
+    };
+
+    it('reaches the file when the card chooses one', async () => {
+        const dir = await dirWith(BASE);
+        const { config } = await loadConfig(dir);
+
+        await saveConfig(dir, buildAppearanceConfig(config, { 'ui.theme': 'light' }));
+
+        expect((await loadConfig(dir)).config.ui?.theme).toBe('light');
+    });
+
+    // `system` is the block being absent, so going back to it has to delete
+    // one already on disk — which a write-only fix would miss.
+    it('leaves the file with no ui block when the card chooses system', async () => {
+        const dir = await dirWith(`${BASE}ui:\n  theme: dark\n`);
+        const { config } = await loadConfig(dir);
+        expect(config.ui?.theme).toBe('dark');
+
+        await saveConfig(dir, buildAppearanceConfig(config, { 'ui.theme': 'system' }));
+
+        expect((await loadConfig(dir)).config.ui).toBeUndefined();
+    });
+
+    it('survives a save that was about something else entirely', async () => {
+        const dir = await dirWith(`${BASE}ui:\n  theme: dark\n`);
+        const { config } = await loadConfig(dir);
+
+        await saveConfig(dir, config);
+
+        expect((await loadConfig(dir)).config.ui?.theme).toBe('dark');
     });
 });
 


### PR DESCRIPTION
The theme switcher on the Configuration page saved nothing, in both directions, while reporting that it had.

## Root cause

`saveConfig` wrote a hand-picked list of top-level keys — `auth`, `services`, `metadata` — and `ui` was not one of them.

Everything upstream was correct. The select posted the right value, `buildAppearanceConfig` built the right config, `ConfigSchema` accepted it. The save then dropped the block on the floor, and the `runtime.reload()` it triggers read the theme back as `system`. The banner said *"Appearance saved. Applied immediately; no restart needed."* over a file that had never been given a theme.

Choosing **Follow the system** was broken the same way: for anyone who had hand-written `ui: theme: dark` in `config.yaml`, the block was never deleted, so it survived only because nothing touched it.

## The fix

The write is driven by the schema rather than by a list kept in `save.ts`:

```ts
const blocks = value as Record<string, unknown>;
for (const key of Object.keys(ConfigSchema.shape)) mergeInto(doc, [key], blocks[key]);
```

That replaced four explicit `auth` `setIn` calls, the `password_hash`-is-undefined special case, and the `metadata` block. `mergeInto` gained the one rule that made those redundant: `undefined` means delete, not write a null — which `password_hash` and `metadata` each implemented separately.

A block added to `ConfigSchema` now persists automatically. There is no line left to forget.

## One deliberate behaviour change

Keys *inside* `auth` that the schema does not know are now removed on save, as keys inside `services` and `metadata` already were. `auth` is a non-strict `z.object`, so the loader strips such a key and it does nothing today; the file just stops claiming otherwise. Top-level keys the schema has never heard of are still untouched — nothing iterates them.

## Tests

`test/theme.test.ts` — three round-trips through `saveConfig` + `loadConfig`, written failing first (the first two failed as expected; the third passed already, since unknown keys survive by omission):

- choosing a theme reaches the file
- choosing `system` deletes a `ui` block already on disk
- an existing `ui` block survives a save about something else

`test/config.test.ts` — a self-maintaining guard:

```ts
expect(Object.keys(FULL).sort()).toEqual(Object.keys(ConfigSchema.shape).sort());
```

Add a block to the schema and that fails until the fixture carries it, at which point the round-trip test beside it covers the new block for free.

## Verification

`tsc --noEmit` and `eslint .` clean; `vitest run` → 66 files, 1466 tests passing.

Not live-verified against a running instance — the round trip is proven at the file level only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
