### PR TITLE
docs: write down which services qualify for an adapter

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -10,7 +10,7 @@ body:
         the work; the code that answers it is the easy half.
 
         This matters because the answer is often a new parameter or a new field
-        on a tool that already exists. Twenty-one tools is close to the ceiling
+        on a tool that already exists. Twenty-two tools is close to the ceiling
         — model accuracy degrades measurably past roughly forty — so new
         capability extends an existing tool before it adds one. A request framed
         as a question can be answered that way. One framed as a tool name
@@ -70,6 +70,12 @@ body:
         maintainer does not run cannot be tested in review, so one you are
         willing to test yourself against a live instance goes much further than
         one nobody can exercise.
+
+        Not every service qualifies, and the bar is written down rather than
+        decided per request:
+        [which services qualify](https://github.com/bardesss/arr-mcp/blob/main/CONTRIBUTING.md#which-services-qualify).
+        Asking here first is the cheap way to find out — a service that misses
+        on age alone gets a date back, not a no.
       placeholder: 'Lidarr 2.14.0'
 
   - type: dropdown

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,6 +127,68 @@ why `stack_health` reports per-instance permissions.
 The highest-value contribution, and deliberately self-contained. Seven steps,
 each with a worked example already in the tree.
 
+### Which services qualify
+
+An adapter is not a patch that lands and is finished. It is a standing
+commitment to track someone else's release schedule, for a service the
+maintainer very likely does not run and therefore cannot exercise in review —
+only read. When it breaks, it breaks here, and the bug report arrives here.
+
+That cost is worth paying for a service people actually run, that actually
+makes arr-mcp better at its one job. It is not worth paying for a service that
+will not exist in a year. Which of the two you are looking at is genuinely hard
+to tell at the moment of the pull request, because the enthusiasm is identical.
+So the bar is written down in advance rather than decided case by case. Four
+things it is trying to establish, and the checks that stand in for them:
+
+**Survival — will this still be here?**
+
+- The service's first public release is **at least six months old**, and it has
+  **commits within the last sixty days**. Both halves, because neither implies
+  the other: self-hosted projects die overwhelmingly between months two and six
+  — after the launch thread, before the first real maintenance burden — and a
+  project can clear that cliff and then be abandoned with its version number
+  intact.
+
+**Stability — will the adapter still work?**
+
+- **1.0 or later**, or a documented, versioned API with a stated compatibility
+  policy. A pre-1.0 API is free to move, and an adapter pinned to one breaks on
+  the service's schedule rather than ours.
+- **Published API documentation.** OpenAPI is preferred and earns code
+  generation for free, but three adapters here are hand-written against a plain
+  written reference, and that is enough.
+
+**Demand — does anyone want it?**
+
+- **Packaged where people deploy** — Unraid Community Applications, TrueNAS
+  apps, linuxserver.io, or an official image with meaningful pull counts. Stars
+  can be manufactured; a place in a distribution channel is harder to.
+- **Someone other than the service's own author has asked for it.** Not a
+  judgement about anyone's motives. The author of a service is simply the last
+  person able to tell whether anyone *else* wants the integration, and their own
+  enthusiasm is not evidence that they do.
+
+**Fit — does it belong in this server?**
+
+- **It sits on the chain `diagnose` walks** — requested, managed, monitored,
+  downloaded, indexed, imported, scanned. arr-mcp exists because the interesting
+  questions live between services. A service that cannot make `diagnose` smarter
+  is a second product, not a ninth adapter.
+- **It adds no new tool**, or the pull request argues explicitly for the one it
+  adds. The forty-tool ceiling above is a hard constraint, and a new service
+  does not get to spend it quietly.
+- **It introduces no new risk class.** Code execution, credential brokering, or
+  outbound requests to hosts the operator never configured are changes to the
+  security model. Those get decided on their own terms, never as a side effect
+  of adding an adapter.
+
+This is a floor for what will be considered, not a ceiling on what can be
+accepted. Any of it can be waived — on the pull request, in writing, with the
+reason — and a rewrite shipping from a fresh repository is exactly what that is
+for. An adapter that misses on age alone is worth an issue rather than a
+weekend: the answer to that one is a date, not a no.
+
 **You will have to test it yourself, properly.** The maintainer does not run
 every service this could support — there is no Lidarr, no Plex, no qBittorrent
 here — so an adapter for one cannot be exercised in review, only read. That

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Twenty-two tools, but you never name them — you ask, and the model picks:
 | **[Configuration](docs/configuration.md)** | `config.yaml`, several Radarrs, Jellyfin's `default_user` |
 | **[Config UI](docs/config-ui.md)** | The four pages, and what each does that is not obvious |
 | **[IMDb ratings](docs/imdb.md)** | The only way to get an IMDb score for a series, and what it costs |
-| **[Contributing](CONTRIBUTING.md)** | Adding a service adapter, and the rules an AI agent tends to break |
+| **[Contributing](CONTRIBUTING.md)** | [Which services qualify](CONTRIBUTING.md#which-services-qualify), how to add an adapter, and the rules an AI agent tends to break |
 
 ## Requirements
 
@@ -136,9 +136,12 @@ model stops finding a renamed tool rather than raising an error.
 
 **Contributions are welcome, and new service adapters most of all** — Lidarr,
 Readarr, qBittorrent, Tautulli. An adapter is deliberately the most
-self-contained thing in the codebase. One thing to know first: **I cannot test a
-service I do not run**, so the bar is that you tested it against your own live
-instance and the PR says what you tested and against which version.
+self-contained thing in the codebase. Two things to know first: not every
+service qualifies, and the bar is written down rather than decided per pull
+request — [which services qualify](CONTRIBUTING.md#which-services-qualify). And
+**I cannot test a service I do not run**, so the second bar is that you tested
+it against your own live instance and the PR says what you tested and against
+which version.
 
 **AI-assisted contributions are welcome**, held to the same bar and no other;
 arr-mcp is itself built with a coding agent. Point yours at


### PR DESCRIPTION
## Why

An adapter is not a patch that lands and is finished — it is a standing commitment to track someone else's release schedule, for a service I do not run and therefore cannot exercise in review, only read. When it breaks, it breaks here.

That cost is worth paying for a service people actually run and that makes `diagnose` smarter. It is not worth paying for one that will not exist in a year. At the moment of the pull request those two look identical, because the enthusiasm is identical — so the bar is written down in advance rather than decided case by case, per contributor.

## What

A `### Which services qualify` section at the top of **Adding a service adapter** in CONTRIBUTING.md, ahead of the seven steps, grouped by what each check is actually trying to establish:

- **Survival** — first public release at least six months old, commits within sixty days. Both halves: self-hosted projects die between months two and six, and a project can clear that cliff and then be abandoned with its version number intact.
- **Stability** — 1.0+, or a documented versioned API with a compatibility policy. Plus published API docs.
- **Demand** — packaged where people deploy, and asked for by someone other than the service's own author.
- **Fit** — sits on the chain `diagnose` walks, adds no new tool, introduces no new risk class.

It is explicitly a floor for what will be considered, not a ceiling on what can be accepted: any rule can be waived on the PR, in writing, with the reason. A rewrite shipping from a fresh repository is exactly what that is for.

## Where it is linked

Both places the question actually arrives, so it is read before a weekend is spent rather than after:

- the README's **Contributing** section and its documentation table
- the feature-request template's *"a service arr-mcp does not support at all?"* field

Also corrects the stale tool count in that template (twenty-one → twenty-two).

## Gates

- `npm run lint` — passed
- `npm run typecheck` — passed
- `npm test` — 66 files, 1,466 tests passed

Docs only; no runtime change, and `docs:` cuts no release.