### PR TITLE
feat(mcp): accept the bearer token as a URL parameter for header-less clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,11 @@ username and a password of at least 12 characters.
 It applies immediately; there is no restart. Configure only what you run.
 
 Your MCP client goes to `http://<host>:6060/mcp` with the bearer token shown on
-the dashboard. Everything the UI does is still just `config.yaml`, and editing
-that by hand remains supported. Clients that read the
+the dashboard. A client that can only be given a URL, not a header, can carry
+the token as `?token=` instead — see
+[`allow_token_in_url`](docs/configuration.md#allow_token_in_url). Everything
+the UI does is still just `config.yaml`, and editing that by hand remains
+supported. Clients that read the
 [MCP Registry](https://registry.modelcontextprotocol.io) find it there as
 `io.github.bardesss/arr-mcp`.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -234,7 +234,8 @@ A phase that ships without its README change is not finished.
 - [ ] `docker run` the published tag against a real stack, not just the build
 - [ ] `npm run integration` — calls every tool against a real stack and fails
       if any tool has no case at all
-- [ ] `/healthz` responds, and an unauthenticated `/mcp` request is rejected
+- [ ] `/healthz` responds, and an unauthenticated `/mcp` request is rejected —
+      including `/mcp?token=…` against a config with `allow_token_in_url` off
 
 Calling every tool matters more than it sounds. Adapters are tested against
 recorded fixtures, which prove the mapping and nothing else. Every defect that

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -94,6 +94,7 @@ auth:
   username: admin
   password_hash: "…"         # scrypt; written by the setup page, never by you
   allowed_hosts: []          # empty accepts any Host — right for a LAN container
+  allow_token_in_url: false  # accept ?token=… when no Authorization header is sent
 ```
 
 Sign-in is a username and password you choose the first time you open the UI.
@@ -107,6 +108,25 @@ claims it.
 locks you out of the page you would fix it from.** Recover by editing
 `config.yaml` by hand and restarting. A literal IPv6 address is written with its
 brackets — `"[fd00::1]"` — and matches with or without a port.
+
+### `allow_token_in_url`
+
+Some MCP clients can only be given a URL — no headers, no token field. With this
+on, `/mcp?token=<bearer token>` authenticates the same as the header does.
+
+An `Authorization: Bearer` header still wins whenever one is sent, right or
+wrong, so turning this on cannot rescue a client that is sending the wrong
+token — it fails, which is what you want.
+
+The cost is that the token travels in the address, so a reverse proxy's access
+log, a browser history or a shell history will hold a working credential. Nothing
+in arr-mcp logs a URL, but everything in front of it might. Rotate the token from
+the config UI if one leaks.
+
+**This does not make Home Assistant work on its own.** Its MCP client
+integration also speaks only the older HTTP+SSE transport, and this server
+serves Streamable HTTP, so that setup still needs a proxy to bridge the
+transport.
 
 ### `allow_other_users`
 

--- a/scripts/lib/uiFixture.ts
+++ b/scripts/lib/uiFixture.ts
@@ -93,6 +93,7 @@ export const CONFIG: Config = {
         bearer_token: FIXTURE_TOKEN,
         username: 'admin',
         password_hash: 'scrypt$fixture$fixture',
+        allow_token_in_url: false,
         allowed_hosts: []
     },
     services: {

--- a/scripts/screenshots.ts
+++ b/scripts/screenshots.ts
@@ -43,6 +43,7 @@ const PAGES: { name: string; html: string }[] = [
             diagnoses: fixture.DIAGNOSES,
             configured: fixture.CONFIGURED,
             bearerToken: fixture.FIXTURE_TOKEN,
+            urlToken: fixture.CONFIG.auth.allow_token_in_url,
             mcpUrl: fixture.MCP_URL,
             writeCounts: fixture.WRITE_COUNTS,
             imdb: fixture.IMDB,

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,11 +1,11 @@
 import { createMcpHonoApp } from '@modelcontextprotocol/hono';
 import { McpServer, createMcpHandler } from '@modelcontextprotocol/server';
 import { Hono, type Context } from 'hono';
-import { timingSafeEqual } from 'node:crypto';
 import type { WriteAudit } from './core/audit.ts';
 import { logger } from './core/logger.ts';
 import type { LogStore } from './core/logs.ts';
 import type { Runtime } from './core/runtime.ts';
+import { presentedToken, tokenMatches } from './mcp/endpointAuth.ts';
 import { claimJsonBody } from './mcp/jsonBody.ts';
 import { acceptingBoth, acceptsStream, asPlainJson } from './mcp/plainJson.ts';
 import { registerAllPrompts } from './mcp/prompts.ts';
@@ -46,19 +46,6 @@ Writing:
 - A write refused for permissions names the config key that would allow it. Report that key rather than retrying.
 
 Arguments are strict: an argument a tool does not have is refused rather than ignored, and the error lists what it does accept.`;
-
-/** Constant-time compare that does not reveal the expected length by timing. */
-function tokenMatches(presented: string, expected: string): boolean {
-    const a = Buffer.from(presented);
-    const b = Buffer.from(expected);
-    if (a.length !== b.length) {
-        // Burn an equivalent comparison so a wrong-length token is not
-        // distinguishable from a wrong-bytes one.
-        timingSafeEqual(b, b);
-        return false;
-    }
-    return timingSafeEqual(a, b);
-}
 
 export function buildApp(opts: { runtime: Runtime; audit: WriteAudit; logs: LogStore }) {
     const { runtime, audit, logs } = opts;
@@ -143,17 +130,30 @@ export function buildApp(opts: { runtime: Runtime; audit: WriteAudit; logs: LogS
     registerWebRoutes(app, { runtime, audit, logs, version: VERSION });
 
     app.all('/mcp', async (c: Context) => {
-        const header = c.req.header('Authorization') ?? '';
-        const [scheme, presented] = header.split(' ');
+        // From the runtime, not a captured value, so rotating the token or
+        // flipping the flag in the config UI takes effect on the very next
+        // request.
+        const { auth } = runtime.config;
+        const presented = presentedToken(c.req.url, c.req.header('Authorization'), auth.allow_token_in_url);
 
-        // From the runtime, not a captured value, so rotating the token in the
-        // config UI takes effect on the very next request.
-        if (scheme !== 'Bearer' || !presented || !tokenMatches(presented, runtime.config.auth.bearer_token)) {
+        if (presented.via === 'none' || !tokenMatches(presented.token, auth.bearer_token)) {
             logger.warn(
                 { path: '/mcp', ip: c.req.header('x-forwarded-for') ?? 'unknown' },
                 'rejected unauthenticated MCP request'
             );
-            return c.json({ error: 'unauthorized' }, 401, { 'WWW-Authenticate': 'Bearer realm="arr-mcp"' });
+            return c.json(
+                {
+                    error: 'unauthorized',
+                    ...(presented.via === 'none' && presented.queryOffered
+                        ? {
+                              detail:
+                                  'A token in the URL is refused until auth.allow_token_in_url is enabled — turn it on in the config UI, under MCP endpoint.'
+                          }
+                        : {})
+                },
+                401,
+                { 'WWW-Authenticate': 'Bearer realm="arr-mcp"' }
+            );
         }
 
         // A client that never asked for a stream gets one JSON object with a

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -244,6 +244,12 @@ export const ConfigSchema = z.object({
          */
         password_hash: z.string().min(1).optional(),
         /**
+         * Whether `/mcp` accepts the token as `?token=` when no Authorization
+         * header is sent. Off by default: it works for clients that can only be
+         * given a URL, at the cost of the token reaching proxy logs.
+         */
+        allow_token_in_url: z.boolean().default(false),
+        /**
          * Hostnames the MCP endpoint may be reached on, for the SDK's DNS
          * rebinding protection. Empty means "accept any Host", which is the
          * right default for a LAN container reached by IP; pin hostnames when

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -16,6 +16,11 @@ export function attachLogStore(store: LogStore): void {
     sink = store;
 }
 
+/** For tests: undoes `attachLogStore` so the sink doesn't leak across files. */
+export function detachLogStore(): void {
+    sink = undefined;
+}
+
 /**
  * Writes to stdout **and** the ring buffer.
  *

--- a/src/mcp/endpointAuth.ts
+++ b/src/mcp/endpointAuth.ts
@@ -1,0 +1,46 @@
+import { timingSafeEqual } from 'node:crypto';
+
+/**
+ * What credential a request to `/mcp` presented, and through which channel.
+ *
+ * `queryOffered` is what lets the refusal name the flag when someone put a
+ * token in the URL against a config that does not accept one — without it, the
+ * two ways to arrive unauthenticated are indistinguishable.
+ */
+export type Presented = { via: 'header' | 'query'; token: string } | { via: 'none'; queryOffered: boolean };
+
+/** Constant-time compare that does not reveal the expected length by timing. */
+export function tokenMatches(presented: string, expected: string): boolean {
+    const a = Buffer.from(presented);
+    const b = Buffer.from(expected);
+    if (a.length !== b.length) {
+        // Burn an equivalent comparison so a wrong-length token is not
+        // distinguishable from a wrong-bytes one.
+        timingSafeEqual(b, b);
+        return false;
+    }
+    return timingSafeEqual(a, b);
+}
+
+/**
+ * A bearer header is decisive, right or wrong. A misconfigured client should
+ * fail rather than silently fall back to the weaker channel.
+ */
+export function presentedToken(url: string, header: string | undefined, allowQuery: boolean): Presented {
+    const [scheme, value] = (header ?? '').split(' ');
+    if (scheme === 'Bearer' && value !== undefined && value !== '') return { via: 'header', token: value };
+
+    const offered = queryToken(url);
+    if (offered !== undefined && allowQuery) return { via: 'query', token: offered };
+    return { via: 'none', queryOffered: offered !== undefined };
+}
+
+const queryToken = (url: string): string | undefined => {
+    let value: string | null;
+    try {
+        value = new URL(url).searchParams.get('token');
+    } catch {
+        return undefined;
+    }
+    return value === null || value === '' ? undefined : value;
+};

--- a/src/mcp/endpointAuth.ts
+++ b/src/mcp/endpointAuth.ts
@@ -4,11 +4,12 @@ import { timingSafeEqual } from 'node:crypto';
  *  query token showed up even when unhonoured, so a refusal can name the flag. */
 export type Presented = { via: 'header' | 'query'; token: string } | { via: 'none'; queryOffered: boolean };
 
-/** Constant-time compare that does not reveal the expected length by timing. */
+/** Constant-time compare; refuses a zero-length token outright rather than
+ *  letting an empty presented value match an empty expected one. */
 export function tokenMatches(presented: string, expected: string): boolean {
     const a = Buffer.from(presented);
     const b = Buffer.from(expected);
-    if (a.length !== b.length) {
+    if (a.length === 0 || a.length !== b.length) {
         // Burn an equivalent comparison so a wrong-length token is not
         // distinguishable from a wrong-bytes one.
         timingSafeEqual(b, b);
@@ -20,7 +21,7 @@ export function tokenMatches(presented: string, expected: string): boolean {
 /** A Bearer header always wins, right or wrong — never falls back to the query. */
 export function presentedToken(url: string, header: string | undefined, allowQuery: boolean): Presented {
     const [scheme, value] = (header ?? '').split(' ');
-    if (scheme === 'Bearer') return { via: 'header', token: value ?? '' };
+    if (scheme?.toLowerCase() === 'bearer') return { via: 'header', token: value ?? '' };
 
     const offered = queryToken(url);
     if (offered !== undefined && allowQuery) return { via: 'query', token: offered };

--- a/src/mcp/endpointAuth.ts
+++ b/src/mcp/endpointAuth.ts
@@ -1,12 +1,7 @@
 import { timingSafeEqual } from 'node:crypto';
 
-/**
- * What credential a request to `/mcp` presented, and through which channel.
- *
- * `queryOffered` is what lets the refusal name the flag when someone put a
- * token in the URL against a config that does not accept one — without it, the
- * two ways to arrive unauthenticated are indistinguishable.
- */
+/** What a request to `/mcp` presented, and how — `queryOffered` says whether a
+ *  query token showed up even when unhonoured, so a refusal can name the flag. */
 export type Presented = { via: 'header' | 'query'; token: string } | { via: 'none'; queryOffered: boolean };
 
 /** Constant-time compare that does not reveal the expected length by timing. */
@@ -22,13 +17,10 @@ export function tokenMatches(presented: string, expected: string): boolean {
     return timingSafeEqual(a, b);
 }
 
-/**
- * A bearer header is decisive, right or wrong. A misconfigured client should
- * fail rather than silently fall back to the weaker channel.
- */
+/** A Bearer header always wins, right or wrong — never falls back to the query. */
 export function presentedToken(url: string, header: string | undefined, allowQuery: boolean): Presented {
     const [scheme, value] = (header ?? '').split(' ');
-    if (scheme === 'Bearer' && value !== undefined && value !== '') return { via: 'header', token: value };
+    if (scheme === 'Bearer') return { via: 'header', token: value ?? '' };
 
     const offered = queryToken(url);
     if (offered !== undefined && allowQuery) return { via: 'query', token: offered };

--- a/src/web/assets.ts
+++ b/src/web/assets.ts
@@ -281,6 +281,27 @@ document.addEventListener('click', async (e) => {
   }
 });
 
+// Assembled here for the same reason the client config is: the token is masked
+// on the page, and rendering it into a readable field would undo that.
+document.addEventListener('click', async (e) => {
+  const btn = e.target.closest('[data-copy-url-token]');
+  if (!btn) return;
+  const url = document.getElementById(btn.dataset.copyUrlToken);
+  const token = document.getElementById('bearer');
+  const box = document.getElementById('mcp-url-token');
+  if (!url || !token || !box) return;
+
+  const value = url.value + '?token=' + encodeURIComponent(token.value);
+  try {
+    await navigator.clipboard.writeText(value);
+    flash(btn, 'Copied');
+  } catch {
+    box.value = value;
+    selectIn(box);
+    flash(btn, 'Selected — copy it');
+  }
+});
+
 // Reveal a secret only on request, so a screenshot or a shoulder does not
 // capture every API key on the page by default.
 document.addEventListener('click', (e) => {

--- a/src/web/configPage.ts
+++ b/src/web/configPage.ts
@@ -532,6 +532,19 @@ export function configPage(opts: {
                 value: opts.config.auth.allowed_hosts.join(', '),
                 note: 'Leave empty to accept any Host — right for a LAN container reached by IP. Applies immediately; pin the wrong name and you will lock yourself out until you edit config.yaml by hand.'
             })}
+            ${checkbox(
+                'auth.allow_token_in_url',
+                'auth.allow_token_in_url',
+                'Accept the token in the URL (?token=…)',
+                opts.config.auth.allow_token_in_url
+            )}
+            <p class="note">
+                For clients that can only be given a URL and no headers. The token then travels in the
+                address, so a reverse proxy's access log or the client's own logs will hold a working
+                credential — rotate it above if that happens. This does not make Home Assistant work on
+                its own: its MCP client also needs the older SSE transport, which this server does not
+                serve.
+            </p>
             <div class="row" style="margin-top:1rem">
                 <button type="submit">Save MCP settings</button>
             </div>

--- a/src/web/pages.ts
+++ b/src/web/pages.ts
@@ -299,6 +299,8 @@ export function dashboardPage(opts: {
     diagnoses: ConnectionDiagnosis[];
     configured: string[];
     bearerToken: string;
+    /** Whether `?token=` is accepted, which decides whether the copy button is offered. */
+    urlToken: boolean;
     /** Absent when the request carried no usable `Host` — see `origin.ts`. */
     mcpUrl?: string | undefined;
     writeCounts: { applied: number; denied: number; total: number };
@@ -455,6 +457,15 @@ export function dashboardPage(opts: {
                            the token here would undo the masked field above it, and a screenshot
                            of this page would carry it. -->
                       <textarea id="mcp-config" class="mono" rows="9" readonly hidden></textarea>`}
+            ${opts.mcpUrl === undefined || !opts.urlToken
+                ? raw('')
+                : html`<div class="row" style="margin-top:.75rem">
+                          <button class="ghost" type="button" data-copy-url-token="mcp-url">
+                              Copy URL with token
+                          </button>
+                          <span class="note" style="margin:0">For clients that take a URL and nothing else.</span>
+                      </div>
+                      <input id="mcp-url-token" type="text" readonly hidden>`}
         </div>
 
         <h2>Writes</h2>

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -180,6 +180,7 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
                 diagnoses: health.services,
                 configured: snapshot.adapters.map(a => a.id),
                 bearerToken: snapshot.config.auth.bearer_token,
+                urlToken: snapshot.config.auth.allow_token_in_url,
                 mcpUrl: mcpEndpoint(c.req.url, c.req.header('x-forwarded-proto')),
                 ...(runtime.dataset === undefined ? {} : { imdb: runtime.dataset.status() }),
                 disks: health.disks.items,
@@ -660,6 +661,7 @@ export function buildMcpConfig(current: Config, form: Record<string, unknown>): 
             bearer_token: on(form['auth.rotate_token'])
                 ? generateBearerToken()
                 : current.auth.bearer_token,
+            allow_token_in_url: on(form['auth.allow_token_in_url']),
             allowed_hosts: hosts
         }
     };

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -166,9 +166,9 @@ describe('the token in the URL', () => {
     });
 
     // `logger` only ever forwards to the store `attachLogStore` last set, and
-    // that pointer is process-global — so these attach it themselves and undo
+    // that pointer is process-global — so this attaches it itself and undoes
     // it afterward, or a leaked sink would corrupt logs in other test files.
-    it('never writes the token to a log line, on a rejected request', async () => {
+    it('never writes the token to a log line, on a rejected request or an accepted one', async () => {
         const logs = LogStore.ephemeral();
         attachLogStore(logs);
         try {
@@ -181,29 +181,17 @@ describe('the token in the URL', () => {
             await app.request(`http://localhost:6060/mcp?token=${WRONG}`, rpc(toolsList));
 
             // Proves the sink is actually wired up — without this, an
-            // unattached store would pass the assertion below vacuously.
+            // unattached store would pass the assertions below vacuously.
+            // Nothing logs on an accepted request, so this has to come from
+            // the rejection above, not from the accepted request below.
             expect(logs.recent().length).toBeGreaterThan(0);
-            expect(JSON.stringify(logs.recent())).not.toContain(WRONG);
-        } finally {
-            detachLogStore();
-            logs.close();
-        }
-    });
-
-    it('never writes the token to a log line, on an accepted request', async () => {
-        const logs = LogStore.ephemeral();
-        attachLogStore(logs);
-        try {
-            const app = buildApp({
-                runtime: Runtime.fromConfig(allowed, audit(), { adapters: [] }),
-                audit: audit(),
-                logs
-            });
 
             const res = await app.request(`http://localhost:6060/mcp?token=${TOKEN}`, rpc(toolsList));
-
             expect(res.status).toBe(200);
-            expect(JSON.stringify(logs.recent())).not.toContain(TOKEN);
+
+            const lines = JSON.stringify(logs.recent());
+            expect(lines).not.toContain(WRONG);
+            expect(lines).not.toContain(TOKEN);
         } finally {
             detachLogStore();
             logs.close();

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -113,6 +113,72 @@ describe('bearer auth on /mcp', () => {
     });
 });
 
+describe('the token in the URL', () => {
+    const allowed = configWith({ allow_token_in_url: true });
+
+    it('is refused by default, and the refusal names the flag', async () => {
+        const res = await app().request(`http://localhost:6060/mcp?token=${TOKEN}`, rpc(toolsList));
+        expect(res.status).toBe(401);
+        expect(await res.json()).toMatchObject({ detail: expect.stringContaining('auth.allow_token_in_url') });
+    });
+
+    it('says nothing about the flag when no token was offered at all', async () => {
+        const res = await app().request('http://localhost:6060/mcp', rpc(toolsList));
+        expect(res.status).toBe(401);
+        expect(await res.json()).not.toHaveProperty('detail');
+    });
+
+    it('is accepted once the flag is on', async () => {
+        const res = await appWith(allowed).request(`http://localhost:6060/mcp?token=${TOKEN}`, rpc(toolsList));
+        expect(res.status).toBe(200);
+        const payload = await rpcPayload(res);
+        expect(payload.result?.tools).toBeDefined();
+    });
+
+    it('still refuses a wrong token in the URL', async () => {
+        const res = await appWith(allowed).request(`http://localhost:6060/mcp?token=${WRONG}`, rpc(toolsList));
+        expect(res.status).toBe(401);
+    });
+
+    it('lets a wrong header lose, even beside a right parameter', async () => {
+        const res = await appWith(allowed).request(`http://localhost:6060/mcp?token=${TOKEN}`, {
+            ...rpc(toolsList),
+            headers: { ...rpc(toolsList).headers, Authorization: `Bearer ${WRONG}` }
+        });
+        expect(res.status).toBe(401);
+    });
+
+    it('leaves the header working with the flag on', async () => {
+        const res = await appWith(allowed).request(
+            'http://localhost:6060/mcp',
+            rpc(toolsList, { Authorization: `Bearer ${TOKEN}` })
+        );
+        expect(res.status).toBe(200);
+    });
+
+    it('authenticates nothing but /mcp', async () => {
+        const res = await appWith(allowed).request(`http://localhost:6060/ui?token=${TOKEN}`, {
+            redirect: 'manual'
+        });
+        expect(res.status).toBe(302);
+        expect(res.headers.get('location')).toBe('/ui/login');
+    });
+
+    it('never writes the token to a log line', async () => {
+        const logs = LogStore.ephemeral();
+        const app = buildApp({
+            runtime: Runtime.fromConfig(allowed, audit(), { adapters: [] }),
+            audit: audit(),
+            logs
+        });
+
+        await app.request(`http://localhost:6060/mcp?token=${WRONG}`, rpc(toolsList));
+
+        expect(JSON.stringify(logs.recent())).not.toContain(WRONG);
+        logs.close();
+    });
+});
+
 describe('the transport stays stateless', () => {
     it('never issues an Mcp-Session-Id header', async () => {
         const res = await app().request(

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { buildApp } from '../src/app.ts';
 import { ConfigSchema, type Config } from '../src/config/schema.ts';
 import { WriteAudit } from '../src/core/audit.ts';
+import { attachLogStore, detachLogStore } from '../src/core/logger.ts';
 import { LogStore } from '../src/core/logs.ts';
 import { Runtime } from '../src/core/runtime.ts';
 import { hashPassword } from '../src/core/session.ts';
@@ -164,18 +165,49 @@ describe('the token in the URL', () => {
         expect(res.headers.get('location')).toBe('/ui/login');
     });
 
-    it('never writes the token to a log line', async () => {
+    // `logger` only ever forwards to the store `attachLogStore` last set, and
+    // that pointer is process-global — so these attach it themselves and undo
+    // it afterward, or a leaked sink would corrupt logs in other test files.
+    it('never writes the token to a log line, on a rejected request', async () => {
         const logs = LogStore.ephemeral();
-        const app = buildApp({
-            runtime: Runtime.fromConfig(allowed, audit(), { adapters: [] }),
-            audit: audit(),
-            logs
-        });
+        attachLogStore(logs);
+        try {
+            const app = buildApp({
+                runtime: Runtime.fromConfig(allowed, audit(), { adapters: [] }),
+                audit: audit(),
+                logs
+            });
 
-        await app.request(`http://localhost:6060/mcp?token=${WRONG}`, rpc(toolsList));
+            await app.request(`http://localhost:6060/mcp?token=${WRONG}`, rpc(toolsList));
 
-        expect(JSON.stringify(logs.recent())).not.toContain(WRONG);
-        logs.close();
+            // Proves the sink is actually wired up — without this, an
+            // unattached store would pass the assertion below vacuously.
+            expect(logs.recent().length).toBeGreaterThan(0);
+            expect(JSON.stringify(logs.recent())).not.toContain(WRONG);
+        } finally {
+            detachLogStore();
+            logs.close();
+        }
+    });
+
+    it('never writes the token to a log line, on an accepted request', async () => {
+        const logs = LogStore.ephemeral();
+        attachLogStore(logs);
+        try {
+            const app = buildApp({
+                runtime: Runtime.fromConfig(allowed, audit(), { adapters: [] }),
+                audit: audit(),
+                logs
+            });
+
+            const res = await app.request(`http://localhost:6060/mcp?token=${TOKEN}`, rpc(toolsList));
+
+            expect(res.status).toBe(200);
+            expect(JSON.stringify(logs.recent())).not.toContain(TOKEN);
+        } finally {
+            detachLogStore();
+            logs.close();
+        }
     });
 });
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -130,6 +130,24 @@ describe('ConfigSchema', () => {
     });
 });
 
+describe('auth.allow_token_in_url', () => {
+    it('defaults to false, so an existing config gains nothing by being reparsed', () => {
+        const config = ConfigSchema.parse({
+            auth: { bearer_token: 'a'.repeat(64) },
+            services: {}
+        });
+        expect(config.auth.allow_token_in_url).toBe(false);
+    });
+
+    it('is honoured when set', () => {
+        const config = ConfigSchema.parse({
+            auth: { bearer_token: 'a'.repeat(64), allow_token_in_url: true },
+            services: {}
+        });
+        expect(config.auth.allow_token_in_url).toBe(true);
+    });
+});
+
 describe('an unclaimed config', () => {
     it('parses a config with no password_hash', () => {
         const parsed = ConfigSchema.parse({

--- a/test/configUi.test.ts
+++ b/test/configUi.test.ts
@@ -4,10 +4,12 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { buildApp } from '../src/app.ts';
 import { loadConfig } from '../src/config/load.ts';
+import { ConfigSchema } from '../src/config/schema.ts';
 import { WriteAudit } from '../src/core/audit.ts';
 import { LogStore } from '../src/core/logs.ts';
 import { Runtime } from '../src/core/runtime.ts';
 import { hashPassword } from '../src/core/session.ts';
+import { buildMcpConfig } from '../src/web/routes.ts';
 
 /**
  * The config UI driven through the real Hono app — same routes, same session
@@ -263,6 +265,34 @@ describe('MCP endpoint', () => {
         expect(page.split(BEARER).length - 1).toBe(1);
     });
 
+});
+
+describe('the MCP endpoint form', () => {
+    it('turns the URL token on and off', () => {
+        const base = ConfigSchema.parse({ auth: { bearer_token: 'a'.repeat(64) }, services: {} });
+
+        const on = buildMcpConfig(base, { 'auth.allow_token_in_url': 'on', 'auth.allowed_hosts': '' });
+        expect(on.auth.allow_token_in_url).toBe(true);
+
+        const off = buildMcpConfig(on, { 'auth.allowed_hosts': '' });
+        expect(off.auth.allow_token_in_url).toBe(false);
+    });
+});
+
+describe('the URL token on the dashboard', () => {
+    it('offers a copy button once enabled, without putting the token in the page', async () => {
+        await signIn();
+        expect(await (await call('/ui')).text()).not.toContain('data-copy-url-token');
+
+        await call(
+            '/ui/config/mcp',
+            form({ csrf: await csrfFrom(), 'auth.allow_token_in_url': 'on', 'auth.allowed_hosts': '' })
+        );
+
+        const page = await (await call('/ui')).text();
+        expect(page).toContain('data-copy-url-token');
+        expect(page).not.toContain('?token=');
+    });
 });
 
 describe('adding an instance', () => {

--- a/test/configUi.test.ts
+++ b/test/configUi.test.ts
@@ -292,6 +292,9 @@ describe('the URL token on the dashboard', () => {
         const page = await (await call('/ui')).text();
         expect(page).toContain('data-copy-url-token');
         expect(page).not.toContain('?token=');
+        // The masked-field occurrence only — a regression that embedded the
+        // token some other way would not necessarily contain '?token=' either.
+        expect(page.split(BEARER).length - 1).toBe(1);
     });
 });
 

--- a/test/endpointAuth.test.ts
+++ b/test/endpointAuth.test.ts
@@ -12,6 +12,10 @@ describe('tokenMatches', () => {
     it('rejects a token of the wrong length without throwing', () => {
         expect(tokenMatches('short', 'a'.repeat(64))).toBe(false);
     });
+
+    it('refuses an empty presented token, even against an empty expected one', () => {
+        expect(tokenMatches('', '')).toBe(false);
+    });
 });
 
 describe('presentedToken', () => {
@@ -53,5 +57,12 @@ describe('presentedToken', () => {
         const url = `${URL_BASE}?token=right`;
         expect(presentedToken(url, 'Bearer', true)).toEqual({ via: 'header', token: '' });
         expect(presentedToken(url, 'Bearer ', true)).toEqual({ via: 'header', token: '' });
+    });
+
+    it('recognizes a lowercase scheme as decisive too, per RFC 7235', () => {
+        expect(presentedToken(`${URL_BASE}?token=right`, 'bearer wrong', true)).toEqual({
+            via: 'header',
+            token: 'wrong'
+        });
     });
 });

--- a/test/endpointAuth.test.ts
+++ b/test/endpointAuth.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { presentedToken, tokenMatches } from '../src/mcp/endpointAuth.ts';
+
+const URL_BASE = 'http://localhost:6060/mcp';
+
+describe('tokenMatches', () => {
+    it('accepts an exact match and rejects anything else', () => {
+        expect(tokenMatches('a'.repeat(64), 'a'.repeat(64))).toBe(true);
+        expect(tokenMatches('b'.repeat(64), 'a'.repeat(64))).toBe(false);
+    });
+
+    it('rejects a token of the wrong length without throwing', () => {
+        expect(tokenMatches('short', 'a'.repeat(64))).toBe(false);
+    });
+});
+
+describe('presentedToken', () => {
+    it('reads a bearer header', () => {
+        expect(presentedToken(URL_BASE, 'Bearer abc', false)).toEqual({ via: 'header', token: 'abc' });
+    });
+
+    it('lets a header win over a query parameter, even a wrong one', () => {
+        expect(presentedToken(`${URL_BASE}?token=right`, 'Bearer wrong', true)).toEqual({
+            via: 'header',
+            token: 'wrong'
+        });
+    });
+
+    it('reads the query parameter when the flag is on and no header was sent', () => {
+        expect(presentedToken(`${URL_BASE}?token=abc`, undefined, true)).toEqual({ via: 'query', token: 'abc' });
+    });
+
+    it('ignores the query parameter when the flag is off, but records that one was offered', () => {
+        expect(presentedToken(`${URL_BASE}?token=abc`, undefined, false)).toEqual({
+            via: 'none',
+            queryOffered: true
+        });
+    });
+
+    it('treats an empty token parameter as absent', () => {
+        expect(presentedToken(`${URL_BASE}?token=`, undefined, true)).toEqual({ via: 'none', queryOffered: false });
+    });
+
+    it('reports nothing offered when there is neither header nor parameter', () => {
+        expect(presentedToken(URL_BASE, undefined, true)).toEqual({ via: 'none', queryOffered: false });
+    });
+
+    it('ignores a non-bearer authorization scheme', () => {
+        expect(presentedToken(URL_BASE, 'Basic abc', true)).toEqual({ via: 'none', queryOffered: false });
+    });
+});

--- a/test/endpointAuth.test.ts
+++ b/test/endpointAuth.test.ts
@@ -48,4 +48,10 @@ describe('presentedToken', () => {
     it('ignores a non-bearer authorization scheme', () => {
         expect(presentedToken(URL_BASE, 'Basic abc', true)).toEqual({ via: 'none', queryOffered: false });
     });
+
+    it('treats a valueless Bearer header as decisive, not as no header at all', () => {
+        const url = `${URL_BASE}?token=right`;
+        expect(presentedToken(url, 'Bearer', true)).toEqual({ via: 'header', token: '' });
+        expect(presentedToken(url, 'Bearer ', true)).toEqual({ via: 'header', token: '' });
+    });
 });

--- a/test/mutate.test.ts
+++ b/test/mutate.test.ts
@@ -11,7 +11,7 @@ import { ConfigSchema, type Config } from '../src/config/schema.ts';
  * silent rename would move a permission key out from under a live grant.
  */
 
-const AUTH = { bearer_token: 'a'.repeat(64), username: 'admin', allowed_hosts: [] };
+const AUTH = { bearer_token: 'a'.repeat(64), username: 'admin', allowed_hosts: [], allow_token_in_url: false };
 const base = (services: unknown = {}): Config => ConfigSchema.parse({ auth: AUTH, services });
 
 const ids = (config: Config) => listInstances(config).map(i => i.id);


### PR DESCRIPTION
Prompted by Reddit feedback: a user running arr-mcp on an RPi 4B could not connect Home Assistant to it, and had to put an MCP proxy in front with authentication disabled.

Some MCP clients can only be configured with a URL — no headers, no token field. Today the only way to serve them is an unauthenticated hop in front of the server, which moves the credential problem rather than solving it. This adds a default-off flag, `auth.allow_token_in_url`; when it is on and no `Authorization` header is sent, the same bearer token is accepted as `?token=…`.

## What this does not fix

**It does not make Home Assistant work on its own,** and the docs and the UI copy both say so. HA's MCP client integration has two independent limitations: it takes only a URL plus OAuth application credentials (no static token, no custom header), *and* it speaks only the legacy HTTP+SSE transport, which this server does not serve. That second half is upstream's, so an HA setup still needs a proxy to bridge the transport. Nobody should enable this expecting otherwise.

## Design

- **Off by default.** The same posture the write permissions already state out loud: nothing widens access because a config file was hand-edited. The flag is also the only honest place to hang the warning that the token now travels in URLs.
- **A `Bearer` header is decisive whether it is right or wrong.** The query parameter never rescues a request that sent a bad header — a misconfigured client should fail, not silently fall back. The scheme comparison is case-insensitive per RFC 7235, which matters here: with a case-sensitive check, `authorization: bearer <wrong>` plus `?token=<right>` *was* being rescued.
- **`src/mcp/endpointAuth.ts`** owns "what credential did this request present, and through which channel", so `app.ts` keeps one branch. `src/core/auth.ts` is outbound per-service shaping and says so in its first line, which is why this did not go there.
- **The refusal names the flag only when a `token` parameter was actually presented.** A caller that presented nothing gets the unchanged message.
- **The config UI button assembles the token-bearing URL in the browser at click time**, never server-side — the same rule `data-copy-config` already follows, because the token is masked on that page and a screenshot must not carry a working credential.

## Security notes

- No widening: the query path requires the same 64-hex token and goes through the same constant-time compare, length-burn branch intact.
- The flag's default-off state cannot be bypassed — with it off, the `via: 'query'` branch is unreachable.
- Nothing logs a URL or query string. Every `logger.*` call site was audited; the only URL the code touches is the one the dashboard renders, and `mcpEndpoint` discards the query.
- A query-param credential makes `/mcp` reachable by a cross-origin simple request in a way a header never was. That is closed already, not by accident: a `text/plain` or content-type-less POST is answered 415, and anything declaring `application/json` is preflighted.
- **Accepted trade-off, stated deliberately:** sending `?token=anything` reveals whether the flag is on, because the refusal names it only when off. That is one boolean about a documented feature, and the alternative is an unactionable 401.

## Verification

- `npm run lint`, `npm run typecheck`, `npm test` — **1490/1490**.
- `npm run integration` against a live stack — unchanged from `main` (same 3 pre-existing failures on both; none from this branch).
- A **full MCP session over `?token=`** against the real stack — `initialize` → `tools/list` (22 tools) → `stack_health` reaching 8 live services — plus every refusal path, 9/9:

```
PASS initialize over ?token= — HTTP 200
PASS tools/list over ?token= — 22 tools
PASS stack_health over ?token= hits the real stack — All 8 configured service(s) healthy.
PASS flag off refuses the same URL — HTTP 401
PASS the refusal names the flag
PASS a request presenting nothing gets no flag hint
PASS a wrong Bearer header is not rescued by a right ?token= — HTTP 401
PASS a wrong lowercase bearer header is not rescued either — HTTP 401
PASS the header still works with the flag on — HTTP 200
```

Two defects were caught by review rather than by the suite and are worth naming: a log-leak test that could not fail (the `LogStore` it inspected was never attached to the logger), and the lowercase-scheme rescue above, which only became visible when the branch was read as a whole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
