### PR TITLE
feat(ci): make the nightly spec re-fetch a compatibility verdict

### DIFF
--- a/.github/workflows/openapi-drift.yml
+++ b/.github/workflows/openapi-drift.yml
@@ -1,4 +1,4 @@
-name: OpenAPI drift
+name: Upstream compatibility
 
 on:
   schedule: [{ cron: '17 4 * * *' }]
@@ -8,36 +8,79 @@ permissions:
   contents: write
   pull-requests: write
 
-# Converts "Radarr shipped a breaking API change" from a user's bug report into
-# a PR reviewed on a Tuesday. Phase 1 vendors no specs yet, so the job reports
-# that and exits; Phase 2 only has to add URLs to scripts/fetch-specs.sh.
+# Re-fetches the vendored specs and runs the contract test against them, so a
+# breaking upstream change arrives as a red run rather than a user's bug report.
 jobs:
-  refetch:
+  check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+          cache: npm
+      - run: npm ci
 
       - name: Re-fetch vendored specs
-        id: refetch
-        run: |
-          if [ ! -d specs ] || [ ! -x scripts/fetch-specs.sh ]; then
-            echo "::notice::No vendored specs yet (Phase 2 adds them). Nothing to check."
-            echo "ran=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          ./scripts/fetch-specs.sh
-          echo "ran=true" >> "$GITHUB_OUTPUT"
+        run: ./scripts/fetch-specs.sh
 
-      - name: Open a PR if anything changed
-        if: steps.refetch.outputs.ran == 'true'
+      - name: Did anything change?
+        id: drift
+        run: |
+          if git diff --quiet -- specs; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Vendored specs are unchanged."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            git diff --stat -- specs
+          fi
+
+      # Against the freshly fetched specs, not the committed ones. Runs even
+      # when nothing changed, so a rewritten fetch script cannot quietly stop
+      # checking anything.
+      - name: Contract check
+        id: contract
+        continue-on-error: true
+        run: |
+          npx vitest run test/contract.test.ts 2>&1 | tee contract.log
+          exit "${PIPESTATUS[0]}"
+
+      - name: Summarise
+        id: verdict
+        if: steps.drift.outputs.changed == 'true'
+        run: |
+          {
+            if [ "${{ steps.contract.outcome }}" = "success" ]; then
+              echo "The nightly re-fetch found spec changes, and every field this"
+              echo "project reads is still declared. Additive drift; review and merge."
+            else
+              echo "**Upstream shipped a change this project does not survive.**"
+              echo
+              echo "The contract test failed against the newly fetched specs — a field"
+              echo "an adapter reads is no longer declared. Failing entries:"
+              echo
+              echo '```'
+              grep -E 'renamed or removed|missing from the recorded' -A 4 contract.log | head -60 || true
+              echo '```'
+            fi
+          } > body.md
+
+      # Opened with the default GITHUB_TOKEN, which by design cannot trigger
+      # ci.yml — hence the contract check above running in this job. The PR
+      # itself will show no status checks; close and reopen it to get them.
+      - name: Open a PR
+        if: steps.drift.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
           branch: chore/openapi-drift
           title: 'chore: upstream OpenAPI spec drift'
-          body: |
-            The nightly job re-fetched the vendored OpenAPI specs and found changes.
-
-            Review the diff before merging — an upstream breaking change should
-            arrive here as a reviewable PR rather than as a user's bug report.
+          body-path: body.md
           commit-message: 'chore: refresh vendored OpenAPI specs'
+          add-paths: specs
           delete-branch: true
+
+      - name: Fail if the contract broke
+        if: steps.contract.outcome == 'failure'
+        run: |
+          echo "::error::An upstream service changed a field an adapter reads."
+          exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -393,6 +393,18 @@ Radarr, Sonarr, Prowlarr, Jellyfin and Seerr are generated. Bazarr, SABnzbd and
 Transmission publish no usable spec and are hand-written against recorded
 fixtures.
 
+### The nightly compatibility check
+
+The same workflow runs `test/contract.test.ts` against the freshly fetched
+specs, so it can tell an upstream change that breaks this project from one that
+does not. A red run means a field an adapter reads is no longer declared; the
+PR body names it.
+
+The PR is opened with the default `GITHUB_TOKEN`, which GitHub refuses to let
+trigger other workflows, so it arrives with no status checks. Close and reopen
+it to run CI. The three spec-less services are invisible to this check — only a
+live call catches their drift.
+
 Two things worth knowing before you touch this:
 
 - **The generator runs through `npx` at a pinned version, not as a

--- a/test/contract.test.ts
+++ b/test/contract.test.ts
@@ -71,8 +71,8 @@ const deref = (spec: Record<string, unknown>, node: unknown): unknown => {
     return current;
 };
 
-/** Declared property names of a 200 response body, unwrapping $refs and arrays. */
-export function resolveResponseFields(spec: unknown, path: string, method: string): Set<string> | undefined {
+/** The 200 response body's schema, or undefined when the spec declares no such operation. */
+export function resolveResponseSchema(spec: unknown, path: string, method: string): unknown {
     const doc = spec as Record<string, never>;
     const operation = (doc.paths as Record<string, never> | undefined)?.[path]?.[method];
     if (operation === undefined) return undefined;
@@ -81,16 +81,50 @@ export function resolveResponseFields(spec: unknown, path: string, method: strin
     const ok = responses?.['200'] ?? responses?.default;
     const content = (ok as Record<string, never> | undefined)?.content as Record<string, never> | undefined;
     const media = content?.['application/json'] ?? Object.values(content ?? {})[0];
+    return (media as Record<string, never> | undefined)?.schema;
+}
 
-    let schema = deref(doc, (media as Record<string, never> | undefined)?.schema);
-    if ((schema as Record<string, unknown> | undefined)?.type === 'array') {
-        schema = deref(doc, (schema as Record<string, unknown>).items);
+/** Properties of a schema node, seeing through $refs, arrays and compositions. */
+function declaredProperties(spec: Record<string, unknown>, node: unknown): Record<string, unknown> | undefined {
+    let current = deref(spec, node);
+    for (let hops = 0; hops < 10; hops += 1) {
+        const here = current as Record<string, unknown> | undefined;
+        if (here === undefined || here === null) return undefined;
+        if (here.properties !== undefined) return here.properties as Record<string, unknown>;
+
+        if (here.items !== undefined) {
+            current = deref(spec, here.items);
+            continue;
+        }
+
+        const branches = (here.allOf ?? here.oneOf ?? here.anyOf) as unknown[] | undefined;
+        if (branches === undefined) return undefined;
+        if (branches.length === 1) {
+            current = deref(spec, branches[0]);
+            continue;
+        }
+
+        // Several branches: a field declared by any of them is declared.
+        const merged: Record<string, unknown> = {};
+        for (const branch of branches) Object.assign(merged, declaredProperties(spec, branch) ?? {});
+        return merged;
     }
+    return undefined;
+}
 
-    const properties = (schema as Record<string, unknown> | undefined)?.properties as
-        | Record<string, unknown>
-        | undefined;
-    return properties === undefined ? undefined : new Set(Object.keys(properties));
+/**
+ * Does the spec declare this dotted path, all the way down? Checking only the
+ * first segment would pass `Items.UserData.Played` on the strength of `Items`.
+ */
+export function specDeclaresField(spec: unknown, schema: unknown, dotted: string): boolean {
+    const doc = spec as Record<string, unknown>;
+    let node = schema;
+    for (const part of dotted.split('.')) {
+        const properties = declaredProperties(doc, node);
+        if (properties === undefined || !(part in properties)) return false;
+        node = properties[part];
+    }
+    return true;
 }
 
 /**
@@ -238,16 +272,24 @@ const CONTRACTS: Record<string, ServiceContract> = {
             // names to catch this would cost more than it is worth.
         ]
     },
-    // No spec: Jellyfin's is vendored, but the adapter uses local narrow types,
-    // so the fixture is what these are checked against.
+    // Spec-checked despite the adapter using local narrow types: a fixture is a
+    // frozen recording, so the spec is the only half that can drift.
     jellyfin: {
+        spec: 'specs/jellyfin.json',
         dependencies: [
-            { fixture: 'test/fixtures/jellyfin/system-info.json', fields: ['Version'] },
-            { fixture: 'test/fixtures/jellyfin/users.json', fields: ['Id', 'Name'] },
-            { fixture: 'test/fixtures/jellyfin/scheduled-tasks.json', fields: ['Key', 'State', 'LastExecutionResult'] },
-            { fixture: 'test/fixtures/jellyfin/sessions.json', fields: ['UserId', 'PlayState'] },
-            { fixture: 'test/fixtures/jellyfin/items-search.json', fields: ['Items'] },
+            { path: '/System/Info', method: 'get', fixture: 'test/fixtures/jellyfin/system-info.json', fields: ['Version'] },
+            { path: '/Users', method: 'get', fixture: 'test/fixtures/jellyfin/users.json', fields: ['Id', 'Name'] },
             {
+                path: '/ScheduledTasks',
+                method: 'get',
+                fixture: 'test/fixtures/jellyfin/scheduled-tasks.json',
+                fields: ['Key', 'State', 'LastExecutionResult']
+            },
+            { path: '/Sessions', method: 'get', fixture: 'test/fixtures/jellyfin/sessions.json', fields: ['UserId', 'PlayState'] },
+            { path: '/Items', method: 'get', fixture: 'test/fixtures/jellyfin/items-search.json', fields: ['Items'] },
+            {
+                path: '/Items',
+                method: 'get',
                 // Only assertable now that the capture requests Fields=ProviderIds.
                 // The resolver joins on these; an upstream change here breaks the
                 // three-way join silently.
@@ -264,6 +306,8 @@ const CONTRACTS: Record<string, ServiceContract> = {
                 // directly, and `get_library`'s `watched` filter runs on both,
                 // so a rename to either would silently make that filter match
                 // nothing with a green suite.
+                path: '/Items',
+                method: 'get',
                 fixture: 'test/fixtures/jellyfin/items-library.json',
                 fields: [
                     'Items.Id',
@@ -279,10 +323,13 @@ const CONTRACTS: Record<string, ServiceContract> = {
         ]
     },
     seerr: {
+        spec: 'specs/seerr.json',
         dependencies: [
-            { fixture: 'test/fixtures/seerr/status.json', fields: ['version'] },
-            { fixture: 'test/fixtures/seerr/user.json', fields: ['results'] },
+            { path: '/status', method: 'get', fixture: 'test/fixtures/seerr/status.json', fields: ['version'] },
+            { path: '/user', method: 'get', fixture: 'test/fixtures/seerr/user.json', fields: ['results'] },
             {
+                path: '/request',
+                method: 'get',
                 // `results.media.tvdbId` is read as the diagnose matcher's
                 // fallback when a request carries no tmdbId (Task 7 Finding
                 // B). Present but null on every recorded row, since the
@@ -291,9 +338,11 @@ const CONTRACTS: Record<string, ServiceContract> = {
                 fixture: 'test/fixtures/seerr/request.json',
                 fields: ['results', 'results.media.tvdbId']
             },
-            { fixture: 'test/fixtures/seerr/discover-movies.json', fields: ['results'] }
+            { path: '/discover/movies', method: 'get', fixture: 'test/fixtures/seerr/discover-movies.json', fields: ['results'] }
         ]
     },
+    // Bazarr, SABnzbd and Transmission publish no OpenAPI document, so the
+    // nightly job cannot see their drift. Fixture-only by necessity.
     bazarr: {
         dependencies: [
             { fixture: 'test/fixtures/bazarr/system-status.json', fields: ['data.bazarr_version'] },
@@ -347,10 +396,11 @@ describe('adapter contracts', () => {
 
                 if (spec !== undefined && path !== undefined) {
                     it(`${label} still declares those fields in the vendored spec`, () => {
-                        const declared = resolveResponseFields(read(spec), path, method);
-                        expect(declared, `no ${method} ${path} in ${spec}`).toBeDefined();
+                        const doc = read(spec);
+                        const schema = resolveResponseSchema(doc, path, method);
+                        expect(schema, `no ${method} ${path} in ${spec}`).toBeDefined();
 
-                        const missing = dep.fields.filter(f => !declared?.has(f.split('.')[0] ?? f));
+                        const missing = dep.fields.filter(f => !specDeclaresField(doc, schema, f));
                         expect(missing, 'upstream renamed or removed a field we read').toEqual([]);
                     });
                 }
@@ -391,5 +441,42 @@ describe('fixtureHasField', () => {
 
     it('still reports false when no element of the array carries the field, not just the first', () => {
         expect(fixtureHasField([{ a: 1 }, { a: 2 }, { a: 3 }], 'movieFile.size')).toBe(false);
+    });
+});
+
+describe('specDeclaresField', () => {
+    const spec = {
+        components: {
+            schemas: {
+                Item: { properties: { Id: { type: 'string' }, UserData: { $ref: '#/components/schemas/UserData' } } },
+                UserData: { properties: { Played: { type: 'boolean' } } },
+                Page: { properties: { Items: { type: 'array', items: { $ref: '#/components/schemas/Item' } } } }
+            }
+        }
+    };
+
+    it('finds a top-level property', () => {
+        expect(specDeclaresField(spec, { properties: { version: {} } }, 'version')).toBe(true);
+    });
+
+    it('walks into an array of $refs', () => {
+        expect(specDeclaresField(spec, { $ref: '#/components/schemas/Page' }, 'Items.Id')).toBe(true);
+    });
+
+    it('walks two $refs deep', () => {
+        expect(specDeclaresField(spec, { $ref: '#/components/schemas/Page' }, 'Items.UserData.Played')).toBe(true);
+    });
+
+    it('reports a leaf the spec does not declare, even when its parents exist', () => {
+        expect(specDeclaresField(spec, { $ref: '#/components/schemas/Page' }, 'Items.UserData.Watched')).toBe(false);
+    });
+
+    it('merges the branches of a composition', () => {
+        const schema = { allOf: [{ properties: { a: {} } }, { properties: { b: {} } }] };
+        expect(specDeclaresField(spec, schema, 'b')).toBe(true);
+    });
+
+    it('reports false rather than throwing when a segment bottoms out on a scalar', () => {
+        expect(specDeclaresField(spec, { properties: { version: { type: 'string' } } }, 'version.major')).toBe(false);
     });
 });


### PR DESCRIPTION
The nightly job re-fetched the vendored specs and opened a PR with the diff, but nothing judged that diff. "Radarr added a field" and "Radarr renamed a field an adapter reads" arrived under the same title, and the contract test that can tell them apart never ran on it — a PR opened with the default `GITHUB_TOKEN` cannot trigger `ci.yml`.

## What changes

**The workflow now returns a verdict.** It runs `test/contract.test.ts` inside the drift job, against the freshly fetched-but-uncommitted specs:

| Outcome | Result |
| --- | --- |
| No drift | Green, no PR |
| Drift, contract passes | PR, body says the drift is additive |
| Drift, contract fails | PR body names the broken field, **and the run fails** |

The contract step runs whether or not the specs changed, so a future edit to `fetch-specs.sh` cannot quietly stop it from checking anything. The job also does `npm ci` before fetching — it didn't before, and `scripts/fetch-specs.sh` needs `yaml` to normalise Seerr's YAML.

**The spec check now walks the whole dotted path.** `resolveResponseFields` compared only the first segment, so `Items.UserData.Played` passed on the strength of `Items` alone. `specDeclaresField` resolves each segment through `$ref`s, array wrappers and `allOf`/`oneOf` branches.

**Jellyfin and Seerr are spec-checked.** They were fixture-only — but a fixture is a frozen recording and cannot drift, so on its own it detects nothing this job is looking for. Spec-side coverage goes from 8 assertions across three services to 19 across five.

## Known limits

- The drift PR still arrives with no status checks, for the `GITHUB_TOKEN` reason above. Close and reopen it to run CI. A fine-grained PAT would fix it properly; left out deliberately to keep this secret-free.
- Bazarr, SABnzbd and Transmission publish no OpenAPI document and stay invisible to this. Catching their drift needs a live call.

## Verification

- `npm run lint`, `npm run typecheck`, `npm test` — 1507 passed across 67 files.
- Dry-ran the job locally: `bash scripts/fetch-specs.sh` against live upstream fetched all five, `git diff --quiet -- specs` came back clean, contract test green at 68.
- Confirmed the new checks can fail, since a check that only ever passes guards nothing: renaming `Items.UserData.Played` to `.Watched` turned 3 red — fixture side, spec side and the unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)