### PR TITLE
fix(ci): run fetch-specs.sh via bash, not its missing exec bit

### DIFF
--- a/.github/workflows/openapi-drift.yml
+++ b/.github/workflows/openapi-drift.yml
@@ -21,8 +21,11 @@ jobs:
           cache: npm
       - run: npm ci
 
+      # Via `bash`, not `./`, and matching package.json's specs:fetch. The file
+      # is mode 100644 — it was authored on Windows and never carried an exec
+      # bit, which is what made the old job's `[ ! -x ]` guard skip green.
       - name: Re-fetch vendored specs
-        run: ./scripts/fetch-specs.sh
+        run: bash scripts/fetch-specs.sh
 
       - name: Did anything change?
         id: drift


### PR DESCRIPTION
The first real run of the compatibility job (#127) failed with exit 126:

```
./scripts/fetch-specs.sh: Permission denied
```

`scripts/fetch-specs.sh` is mode `100644`. It was authored on Windows and has never carried an exec bit.

## The part that matters

This is why the job existed without working. The guard removed in #127 read:

```sh
if [ ! -d specs ] || [ ! -x scripts/fetch-specs.sh ]; then
  echo "::notice::No vendored specs yet (Phase 2 adds them). Nothing to check."
  exit 0
fi
```

`-x` has always been false, so every nightly run took the `exit 0` path — reporting "no vendored specs yet" for a repo that has vendored five of them since Phase 2, and going green. The run history shows it plainly: 6 to 15 seconds per run, for a job that is supposed to fetch five documents over the network.

So the drift detection has never run. #127 didn't break it; removing the guard is what made the breakage visible.

## The fix

Invoke it the way `package.json`'s `specs:fetch` already does — `bash scripts/fetch-specs.sh`. That doesn't depend on a mode bit a Windows checkout can silently drop. `git update-index --chmod=+x` was the alternative; this one can't regress.

## Verification

CI here only proves the workflow still parses. The real check is `gh workflow run openapi-drift.yml` after this merges — a run that takes minutes rather than seconds, with fetch output in the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)