### PR TITLE
feat(ui): give the project a mark, and collapse the service cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <div align="center">
 
+<img src="assets/logo.svg" alt="" width="64" height="64">
+
 # arr-mcp
 
 ### Talk to your entire media stack. One server, one endpoint, one conversation.

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#4c8dff" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M13.5 6.5h7M13.5 12h7M13.5 17.5h7"/><path d="M8 12h2.5"/><circle cx="5" cy="12" r="2.6" fill="#4c8dff" stroke="none"/></svg>

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:watch": "vitest",
     "specs:fetch": "bash scripts/fetch-specs.sh",
     "codegen": "node scripts/codegen.mjs",
+    "icon:write": "node scripts/write-logo.ts",
     "capture": "node scripts/capture-fixtures.ts",
     "integration": "node scripts/integration.ts",
     "multi-instance": "node scripts/multi-instance-check.ts",

--- a/scripts/write-logo.ts
+++ b/scripts/write-logo.ts
@@ -1,0 +1,9 @@
+// Writes assets/logo.svg from the constant the config UI serves at /ui/icon.svg,
+// so the README, the Unraid template and the favicon cannot drift apart.
+// test/webIcons.test.ts fails if they do.
+import { writeFileSync } from 'node:fs';
+import { MARK_SVG } from '../src/web/icons.ts';
+
+const target = new URL('../assets/logo.svg', import.meta.url);
+writeFileSync(target, MARK_SVG);
+console.log(`wrote ${target.pathname.slice(1)}`);

--- a/src/web/assets.ts
+++ b/src/web/assets.ts
@@ -51,8 +51,9 @@ header {
   display: flex; align-items: center; gap: 1.5rem; flex-wrap: wrap;
   padding: .9rem 1.25rem; background: var(--panel); border-bottom: 1px solid var(--line);
 }
-header h1 { font-size: 1rem; margin: 0; letter-spacing: .02em; }
+header h1 { font-size: 1rem; margin: 0; letter-spacing: .02em; display: flex; align-items: center; gap: .5rem; }
 header h1 span { color: var(--dim); font-weight: 400; }
+.logo { width: 22px; height: 22px; flex: none; color: var(--accent); }
 nav { display: flex; gap: .25rem; flex: 1; flex-wrap: wrap; }
 nav a {
   padding: .35rem .7rem; border-radius: 6px; text-decoration: none;

--- a/src/web/assets.ts
+++ b/src/web/assets.ts
@@ -81,7 +81,27 @@ p.note { color: var(--dim); font-size: .9rem; margin: .35rem 0 1rem; }
 .card dt { color: var(--dim); }
 .card dd { margin: 0; word-break: break-word; }
 .svc-icon { width: 20px; height: 20px; flex: none; color: var(--dim); }
-.svc-title { display: flex; align-items: center; gap: .5rem; margin: 0 0 .75rem; }
+/* Collapsed, a card is one row: mark, id, host, what it may write. Open, it is
+   the form it always was. The marker is drawn here because a summary set to
+   display:flex loses the browser's own triangle. */
+.svc-title { display: flex; align-items: center; gap: .5rem; margin: 0; cursor: pointer; list-style: none; }
+.svc-title::-webkit-details-marker { display: none; }
+.svc-title::after {
+  content: ''; flex: none; width: .45rem; height: .45rem; margin-left: .25rem;
+  border-right: 2px solid var(--dim); border-bottom: 2px solid var(--dim);
+  transform: rotate(45deg); transition: transform .15s ease;
+}
+.svc[open] > .svc-title { margin-bottom: .75rem; }
+.svc[open] > .svc-title::after { transform: rotate(-135deg); }
+@media (prefers-reduced-motion: reduce) { .svc-title::after { transition: none; } }
+.svc-host {
+  color: var(--dim); font-size: .85em; margin-left: auto;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;
+}
+.svc-writes {
+  flex: none; font-size: .75rem; padding: .1rem .45rem; border-radius: 999px;
+  border: 1px solid var(--line); background: var(--panel-2); color: var(--dim);
+}
 /* Status to the right edge, so the dots line up down the grid rather than
    sitting at eight different offsets after eight different service names. */
 .card h3 .dot { margin-left: auto; }

--- a/src/web/configPage.ts
+++ b/src/web/configPage.ts
@@ -203,12 +203,20 @@ function testResult(d: ConnectionDiagnosis): SafeHtml {
     </div>`;
 }
 
+/** What the collapsed row says about a card's writes, in one word. */
+function writeLabel(permissions: { safe_write: boolean; destructive: boolean }): string {
+    if (permissions.destructive) return 'destructive';
+    if (permissions.safe_write) return 'safe_write';
+    return 'read-only';
+}
+
 function instanceCard(
     instance: ServiceInstance,
     csrf: string,
     confirming: string | undefined,
     users: readonly string[] | undefined,
-    tested: ConnectionDiagnosis | undefined
+    tested: ConnectionDiagnosis | undefined,
+    open: boolean
 ): SafeHtml {
     const service = instance.config as AnyService;
     const p = `svc.${instance.id}`;
@@ -218,10 +226,13 @@ function instanceCard(
         <input type="hidden" name="csrf" value="${csrf}">
         <input type="hidden" name="instance" value="${instance.id}">
 
-        <h3 class="svc-title">
+        <details class="svc"${open ? raw(' open') : raw('')}>
+        <summary class="svc-title">
             ${serviceIcon(instance.id)}
             <span class="mono">${instance.id}</span>
-        </h3>
+            <span class="svc-host mono">${service.url}</span>
+            <span class="svc-writes">${writeLabel(service.permissions)}</span>
+        </summary>
 
         ${field({ id: `${p}.url`, name: 'url', label: 'URL', value: service.url })}
         ${serviceFields(instance, p, users)}
@@ -257,6 +268,7 @@ function instanceCard(
               </p>`
             : raw('')}
         ${tested === undefined ? raw('') : testResult(tested)}
+        </details>
     </form>`;
 }
 
@@ -402,6 +414,9 @@ export function configPage(opts: {
     users?: Record<string, readonly string[]>;
     /** The one instance whose Test button was pressed, and what came back. */
     tested?: { instance: string; diagnosis: ConnectionDiagnosis } | undefined;
+    /** The instance a submit just touched, so its card is not collapsed over
+     *  the result of what you did. */
+    openInstance?: string | undefined;
     /** The add dialog's own Test, which has no instance id to key on because
      *  the instance does not exist yet. Only the unscripted path reaches this —
      *  with scripting the result is fetched and filled in client-side. */
@@ -426,7 +441,12 @@ export function configPage(opts: {
                 opts.csrf,
                 opts.confirmingRemoval,
                 opts.users?.[i.id],
-                opts.tested?.instance === i.id ? opts.tested.diagnosis : undefined
+                opts.tested?.instance === i.id ? opts.tested.diagnosis : undefined,
+                // Collapsed by default — the page is a stack inventory first.
+                // Three things reopen a card: a Test whose result is inside it,
+                // a removal waiting on a second click, and whatever you last
+                // submitted.
+                opts.tested?.instance === i.id || opts.confirmingRemoval === i.id || opts.openInstance === i.id
             )
         )}
         ${addDialog(opts.config, opts.csrf, opts.openAdd === true, opts.testedAdd)}

--- a/src/web/icons.ts
+++ b/src/web/icons.ts
@@ -46,6 +46,40 @@ export const ICONS: Record<ServiceId, string> = {
     )
 };
 
+/**
+ * The project's own mark: layers gathered into one node.
+ *
+ * Drawn on the same grid and weight as the eight above, because it sits next to
+ * them. The filled node is the only solid shape in the set — it is the "one
+ * endpoint" the three layers converge on.
+ */
+export const LOGO =
+    `<svg class="logo" viewBox="0 0 24 24" fill="none" stroke="currentColor" ` +
+    `stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">` +
+    '<path d="M13 5.75h8M13 12h8M13 18.25h8"/>' +
+    '<path d="M6.7 11.1 12.6 6.1M6.7 12h5.9M6.7 12.9 12.6 17.9"/>' +
+    '<circle cx="4.3" cy="12" r="1.85" fill="currentColor" stroke="none"/>' +
+    '</svg>';
+
+/**
+ * The same mark as a standalone document, for the favicon and the README.
+ *
+ * Two things have to change at 16px. The converging strokes go, because at that
+ * size they are a smudge rather than three lines, and the weight goes up from
+ * 1.75 to 2.5. What survives is the silhouette: node, gap, layers.
+ *
+ * A literal colour rather than `currentColor`, which has nothing to inherit
+ * from in a favicon or an `<img>`. This blue holds on both a white README and a
+ * near-black one; the config UI's own accent does not, being tuned per theme.
+ */
+export const MARK_SVG =
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#4c8dff" ` +
+    `stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">` +
+    '<path d="M13.5 6.5h7M13.5 12h7M13.5 17.5h7"/>' +
+    '<path d="M8 12h2.5"/>' +
+    '<circle cx="5" cy="12" r="2.6" fill="#4c8dff" stroke="none"/>' +
+    '</svg>\n';
+
 /** For an id the schema does not know — a service removed from config while its
  *  card is still on screen, or one added before this file catches up. */
 const FALLBACK = draw(

--- a/src/web/pages.ts
+++ b/src/web/pages.ts
@@ -3,7 +3,7 @@ import type { LogRow } from '../core/logs.ts';
 import type { DatasetStatus } from '../metadata/imdbDataset.ts';
 import type { ConnectionDiagnosis, DiskSpace, HealthCheck, ScanState } from '../services/types.ts';
 import { esc, html, humanBytes, raw, shortTime, type SafeHtml } from './html.ts';
-import { serviceIcon } from './icons.ts';
+import { LOGO, serviceIcon } from './icons.ts';
 
 /**
  * Every page, server rendered. No client framework and no build step — the
@@ -65,6 +65,7 @@ export function layout(opts: {
      page for up to an hour, which is how a button that opens a dialog becomes a
      button that does nothing. -->
 <link rel="stylesheet" href="/ui/app.css?v=${encodeURIComponent(opts.version)}">
+<link rel="icon" type="image/svg+xml" href="/ui/icon.svg?v=${encodeURIComponent(opts.version)}">
 <!-- The add form lives in a dialog element that app.js opens. With no script there is
      nothing to open it, so it is styled back into the flow as the plain panel it
      used to be: every field visible, the server still validating, and the two
@@ -75,7 +76,7 @@ dialog { display: block; position: static; max-width: none; width: auto; margin:
 </style></noscript>
 </head>
 <body>
-<header><h1>arr-mcp <span>${esc(opts.version)}</span></h1>${nav}</header>
+<header><h1>${LOGO}arr-mcp <span>${esc(opts.version)}</span></h1>${nav}</header>
 <main>${message}${opts.body}</main>
 <!-- rel="noreferrer" because this page is served over plain http on a LAN and
      the link leaves for github.com: without it the Referer header hands them

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -303,6 +303,13 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
             const session = guard(c);
             if (session === undefined) return c.redirect(entry(), 302);
 
+            const form = await c.req.parseBody();
+
+            // Cards collapse by default, so the one you just submitted has to be
+            // named or the page swallows the outcome of what you did. Absent on
+            // an add, whose form carries no instance id — there is no card yet.
+            const touched = str(form.instance) === '' ? undefined : str(form.instance);
+
             // Re-asks who the users are, as a plain page load does: a save that
             // dropped the suggestions would have the card claim the service went
             // quiet, and a save that changed a Jellyfin key is exactly when the
@@ -318,6 +325,7 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
                         config: runtime.config,
                         csrf: runtime.sessions.csrfFor(session),
                         users: await usersByInstance(),
+                        ...(touched === undefined ? {} : { openInstance: touched }),
                         ...(confirming === undefined ? {} : { confirmingRemoval: confirming }),
                         ...(reopensAdd && status !== 200 ? { openAdd: true } : {}),
                         ...(message === undefined ? {} : { message })
@@ -325,7 +333,6 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
                     status
                 );
 
-            const form = await c.req.parseBody();
             if (!runtime.sessions.csrfValid(session, str(form.csrf))) {
                 logger.warn({ ip: ipOf(c) }, 'rejected config save with a bad CSRF token');
                 return render({ kind: 'err', text: 'That form was stale. Reload the page and try again.' }, 403);

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -20,6 +20,7 @@ import { buildAdapters } from '../services/registry.ts';
 import { hasUserDirectory } from '../services/types.ts';
 import { buildStackHealth } from '../tools/stackHealth.ts';
 import { CSS, JS } from './assets.ts';
+import { MARK_SVG } from './icons.ts';
 import { addInstance, removeInstance, updateInstance, type InstanceFields } from '../config/mutate.ts';
 import { configPage } from './configPage.ts';
 import { mcpEndpoint } from './origin.ts';
@@ -58,6 +59,7 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
     // the login page render unstyled, which looks broken.
     app.get('/ui/app.css', c => c.body(CSS, 200, { 'content-type': 'text/css; charset=utf-8', ...CACHE }));
     app.get('/ui/app.js', c => c.body(JS, 200, { 'content-type': 'text/javascript; charset=utf-8', ...CACHE }));
+    app.get('/ui/icon.svg', c => c.body(MARK_SVG, 200, { 'content-type': 'image/svg+xml; charset=utf-8', ...CACHE }));
 
     // --- setup ----------------------------------------------------------
     //

--- a/test/configUi.test.ts
+++ b/test/configUi.test.ts
@@ -128,6 +128,18 @@ describe('access control', () => {
         expect(res.headers.get('content-type')).toContain('text/css');
     });
 
+    // A browser asks for the favicon before anyone has signed in, and a
+    // redirect to the login page in its place is a broken tab icon.
+    it('serves the mark without a session, and the page points at it', async () => {
+        cookie = '';
+        const icon = await call('/ui/icon.svg');
+        expect(icon.status).toBe(200);
+        expect(icon.headers.get('content-type')).toContain('image/svg+xml');
+        expect(await icon.text()).toMatch(/^<svg/);
+
+        expect(await (await call('/ui/login')).text()).toContain('rel="icon" type="image/svg+xml"');
+    });
+
     it('rejects a wrong password', async () => {
         cookie = '';
         expect((await call('/ui/login', form({ username: 'admin', password: 'nope' }))).status).toBe(401);

--- a/test/configUi.test.ts
+++ b/test/configUi.test.ts
@@ -595,6 +595,75 @@ describe('testing a connection', () => {
         globalThis.fetch = realFetch;
     });
 
+    /**
+     * The page is a stack inventory before it is eight forms, so a card is a
+     * closed row until you open it. The risk that buys is a card collapsing
+     * over the answer to what you just did — hence the three reopen cases.
+     */
+    describe('collapsing', () => {
+        const TWO =
+            '  radarr:\n    url: http://192.0.2.10:7878\n    api_key: saved-key\n' +
+            '  sonarr:\n    url: http://192.0.2.11:8989\n    api_key: saved-key\n' +
+            '    permissions:\n      destructive: true\n';
+
+        it('starts every card closed, with the row still saying what it is', async () => {
+            await seed(TWO);
+            await signIn();
+            const page = await (await call('/ui/config')).text();
+
+            expect(page).toContain('<details class="svc">');
+            expect(page).not.toContain('<details class="svc" open>');
+            expect(page).toContain('http://192.0.2.10:7878');
+            expect(page).toContain('read-only');
+            expect(page).toContain('destructive');
+        });
+
+        it('reopens the card you just saved', async () => {
+            await seed(TWO);
+            await signIn();
+            const page = await (
+                await call(
+                    '/ui/config/save',
+                    form({ csrf: await csrfFrom(), instance: 'radarr', url: 'http://192.0.2.10:7878', api_key: '' })
+                )
+            ).text();
+
+            // The saved one only, so the page does not simply expand.
+            expect(/<details class="svc" open>[\s\S]*?radarr/.exec(page)).not.toBeNull();
+            expect(page.match(/<details class="svc" open>/g)).toHaveLength(1);
+        });
+
+        it('reopens the card whose Test you pressed, where the result is', async () => {
+            await seed(TWO);
+            globalThis.fetch = (async () =>
+                new Response(JSON.stringify({ version: '5.1.0' }), {
+                    headers: { 'content-type': 'application/json' }
+                })) as typeof fetch;
+            await signIn();
+
+            const page = await (
+                await call(
+                    '/ui/config/test',
+                    form({ csrf: await csrfFrom(), instance: 'radarr', url: 'http://192.0.2.10:7878', api_key: '' })
+                )
+            ).text();
+
+            expect(page).toContain('Reachable in');
+            expect(page.match(/<details class="svc" open>/g)).toHaveLength(1);
+        });
+
+        it('reopens the card waiting on a removal confirmation', async () => {
+            await seed(TWO);
+            await signIn();
+            const page = await (
+                await call('/ui/config/remove', form({ csrf: await csrfFrom(), instance: 'sonarr' }))
+            ).text();
+
+            expect(page).toContain('Yes, remove');
+            expect(page.match(/<details class="svc" open>/g)).toHaveLength(1);
+        });
+    });
+
     it('reports a service that answers', async () => {
         await seed(RADARR);
         globalThis.fetch = (async () =>

--- a/test/webIcons.test.ts
+++ b/test/webIcons.test.ts
@@ -1,6 +1,8 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { ServiceIdSchema } from '../src/config/schema.ts';
-import { ICONS, serviceIcon } from '../src/web/icons.ts';
+import { ICONS, LOGO, MARK_SVG, serviceIcon } from '../src/web/icons.ts';
 
 describe('the service icon set', () => {
     // The point of the test: adding a service to the schema without drawing it
@@ -26,6 +28,26 @@ describe('the service icon set', () => {
     // same word twice.
     it.each(ServiceIdSchema.options)('hides %s from assistive tech', id => {
         expect(ICONS[id]).toContain('aria-hidden="true"');
+    });
+});
+
+describe('the project mark', () => {
+    it('inherits colour like the service marks, so one drawing serves both themes', () => {
+        expect(LOGO).toContain('currentColor');
+        expect(LOGO).not.toMatch(/#[0-9a-f]{3,8}\b/i);
+    });
+
+    // A favicon and an <img> have nothing to inherit from, so this one must not.
+    it('carries a literal colour in the standalone variant', () => {
+        expect(MARK_SVG).toMatch(/#[0-9a-f]{6}\b/i);
+        expect(MARK_SVG).toContain('xmlns=');
+    });
+
+    // README and Unraid read the committed file; the config UI serves the
+    // constant. Regenerate with `npm run icon:write` if this fails.
+    it('matches the committed assets/logo.svg byte for byte', () => {
+        const committed = readFileSync(join(import.meta.dirname, '..', 'assets/logo.svg'), 'utf8');
+        expect(committed).toBe(MARK_SVG);
     });
 });
 


### PR DESCRIPTION
Two changes to the config UI. They ship together because they touch the same header and stylesheet.

---

## 1. The project has a mark

The repo had no image asset of any kind — no favicon, nothing beside the README title, and nothing for the Unraid Community Applications template, which is what that work has been parked on.

Borrowing one from Lucide or Tabler would have arrived at a different weight and padding and sat visibly wrong next to the eight service marks — and most icon licences want attribution the README would then owe. So this draws a ninth mark in the language `src/web/icons.ts` already establishes: 24×24 grid, `stroke-width 1.75`, stroke-only in `currentColor` so one drawing serves both themes.

Three layers gathered into one filled node. It is the only solid shape in the set, and it says the one thing the project is about — many services in, one endpoint out.

**Two variants, on purpose.** A 1.75 stroke is a smudge at 16px:

- **`LOGO`** — the full drawing, `currentColor`, in the page header beside the version.
- **`MARK_SVG`** — converging strokes dropped, weight raised to 2.5, and a literal `#4c8dff` rather than `currentColor`, which has nothing to inherit from in a favicon or an `<img>`. That blue holds on both a white README and a near-black one; the config UI's own accent is tuned per theme and does not.

`MARK_SVG` is served at `/ui/icon.svg` (unauthenticated, like the stylesheet — a browser asks for the favicon before anyone signs in) and written to `assets/logo.svg` by `npm run icon:write` for the README. A test asserts the served constant and the committed file are byte-identical, so they cannot drift.

---

## 2. The service cards collapse

Eight configured services meant eight full forms open at once, and the page stopped being something you could take in at a glance.

Each card is a `<details>` now, closed by default, with the summary carrying the service mark, the instance id, its URL and one word for what it may write (`read-only` / `safe_write` / `destructive`). Native disclosure, no JavaScript, and the `<details>` sits *inside* the existing `<form>`, so the "each card is its own form" rule that `configPage.ts` is built around is untouched.

Collapsing risks hiding the answer to what you just did, so three things reopen a card:

| Trigger | Why |
| --- | --- |
| A Test | The result renders inside that card |
| A removal awaiting its second click | The confirmation is in there |
| Whatever your last submit named | Otherwise a save collapses over its own outcome |

The third needed the instance id threading through `configMutation`, which had the form to hand but was not passing it on. The three access cards stay open — there are only three, and they are settings rather than stack inventory.

---

## Verification

- `npm run lint`, `npm run typecheck`, `npm test` — **1515 passed** across 67 files, up 8 from main.
- New coverage: the mark inherits colour and the standalone variant does not; `assets/logo.svg` matches `MARK_SVG` exactly; `/ui/icon.svg` returns 200 as `image/svg+xml` without a session and the login page carries the `rel="icon"` link; cards start closed with the row still naming host and permissions; each of the three reopen triggers opens exactly one card.
- Both features were checked against a deliberate break rather than trusted for passing: forcing every card open turns all four collapsing tests red, and the icon guard fails on a byte of drift.
- All three candidate marks were rendered at 96/48/24/16px on both grounds and against the eight existing service icons before this one was picked.

## Follow-on

The committed screenshots still show the old header and the expanded cards — worth a `npm run screenshots` pass, not folded in here. And with an image asset finally in the repo, the Unraid CA template is unblocked; it needs a PNG, which this SVG can be rasterised to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)