### PR TITLE
fix(http): keep the url base when joining adapter paths

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,6 +30,22 @@ startup with the offending field named**, rather than being silently ignored.
 Each service also takes an optional `permissions` block. Both flags default to
 false, so the config above is read-only — see [writes](writes.md).
 
+## Services behind a URL base
+
+If a service runs under a subpath — the arr apps call it "URL Base", and it is
+the usual arrangement behind one reverse proxy fronting the whole stack — put
+that path in `url` and nothing else is needed:
+
+```yaml
+services:
+  bazarr:
+    url: http://192.168.1.20:6767/bazarr
+    api_key: "…"
+```
+
+Requests are sent to `…/bazarr/api/…`. Give the URL exactly as you would type it
+in a browser; a trailing slash makes no difference.
+
 ## Jellyfin needs a `default_user`
 
 Not optional flavour. `get_library`, `get_media_details` (its title-query form)

--- a/src/core/http.ts
+++ b/src/core/http.ts
@@ -14,6 +14,7 @@ export const CIRCUIT_COOLDOWN_MS = 60_000;
 export class ServiceHttp {
     readonly #id: string;
     readonly #baseUrl: string;
+    readonly #basePath: string;
     readonly #timeoutMs: number;
     readonly #auth: AuthStrategy;
     readonly #fetch: typeof fetch;
@@ -24,6 +25,7 @@ export class ServiceHttp {
     constructor(id: string, config: BaseServiceConfig, auth: AuthStrategy, fetchImpl: typeof fetch = fetch) {
         this.#id = id;
         this.#baseUrl = config.url;
+        this.#basePath = new URL(config.url).pathname.replace(/\/+$/, '');
         this.#timeoutMs = config.timeout_ms;
         this.#auth = auth;
         this.#fetch = fetchImpl;
@@ -156,7 +158,10 @@ export class ServiceHttp {
         allowRecovery = true,
         discardBody = false
     ): Promise<T> {
-        const url = new URL(path, this.#baseUrl);
+        // Prefixed, not resolved: every adapter path is absolute, and `new URL`
+        // given an absolute path throws the base's own path away — which is how
+        // a service behind a URL base got its requests sent to the host root.
+        const url = new URL(this.#basePath + path, this.#baseUrl);
         const headers = new Headers({ Accept: 'application/json' });
         if (body !== undefined) headers.set('content-type', 'application/json');
 

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -63,6 +63,64 @@ describe('ServiceHttp request shaping', () => {
 });
 
 /**
+ * A service behind a URL base — the standard arrangement behind a reverse proxy,
+ * and what the arr apps themselves call "URL Base". Every adapter path is
+ * absolute, and `new URL('/api/...', 'http://host/bazarr')` *discards* the base
+ * path, so the request landed at the host root and came back as the HTML app.
+ */
+describe('ServiceHttp with a url base', () => {
+    const capture = (url: string) => {
+        const seen: string[] = [];
+        const client = new ServiceHttp(
+            'bazarr',
+            { ...config, url },
+            apiKeyHeader('X-Api-Key', 'secret'),
+            (async (input: string) => {
+                seen.push(String(input));
+                return json({ ok: true });
+            }) as unknown as typeof fetch
+        );
+        return { client, seen };
+    };
+
+    it('keeps the base path in front of the adapter path', async () => {
+        const { client, seen } = capture('http://bazarr:6767/bazarr');
+        await client.get('/api/system/status');
+        expect(seen[0]).toBe('http://bazarr:6767/bazarr/api/system/status');
+    });
+
+    it('does not double the slash when the base url ends in one', async () => {
+        const { client, seen } = capture('http://bazarr:6767/bazarr/');
+        await client.get('/api/system/status');
+        expect(seen[0]).toBe('http://bazarr:6767/bazarr/api/system/status');
+    });
+
+    it('still keeps the query string the adapter asked for', async () => {
+        const { client, seen } = capture('http://sab:8080/sabnzbd');
+        await client.get('/api?mode=version&output=json');
+        expect(seen[0]).toBe('http://sab:8080/sabnzbd/api?mode=version&output=json');
+    });
+
+    it('leaves a base url with no path alone', async () => {
+        const { client, seen } = capture('http://192.168.1.20:7878');
+        await client.get('/api/v3/system/status');
+        expect(seen[0]).toBe('http://192.168.1.20:7878/api/v3/system/status');
+    });
+
+    it('names the full path, base included, when the response is not JSON', async () => {
+        const client = new ServiceHttp(
+            'bazarr',
+            { ...config, url: 'http://bazarr:6767/bazarr' },
+            apiKeyHeader('X-Api-Key', 'secret'),
+            (async () => new Response('<html>', { status: 200 })) as unknown as typeof fetch
+        );
+        await expect(client.get('/api/system/status')).rejects.toThrow(
+            'response from /bazarr/api/system/status was not valid JSON'
+        );
+    });
+});
+
+/**
  * `put`'s `discardBody` and `deleteWithBody` had no direct test at all, and the
  * adapter suites cannot supply one: their fake fetch answers every PUT with an
  * empty 200 regardless, which makes `put(path, body, true)` and


### PR DESCRIPTION
Fixes #134.

## The bug

Every adapter path is absolute (`/api/system/status`, `/api/v3/…`), and
`new URL(path, base)` **discards the base URL's own path** when the first
argument is absolute:

```
new URL('/api/system/status', 'http://bazarr:6767/bazarr').href
  -> http://bazarr:6767/api/system/status
```

So a service behind a URL base — the standard arrangement behind a reverse
proxy, and what the arr apps themselves call "URL Base" — had every request
sent to the host root. Bazarr answers that with a redirect chain to the HTML
app, and the JSON parse then failed as `response from /api/system/status was
not valid JSON`. **All eight adapters** were affected. The reporter's diagnosis
in #134 was exactly right.

## The fix

Prefix the base's path rather than resolving against it. `ServiceHttp` computes
the base path once in the constructor (trailing slashes stripped) and prepends
it to each adapter path. `src/core/http.ts:159` was the only URL join in the
request path, so this is the whole fix for all eight.

No new config key: the URL field is a URL, and honouring the path that is
already in it is the least surprising reading. Nobody's working setup changes —
anyone with a path in `url` today is already broken in exactly this way.

Error messages now name the full path, base included
(`response from /bazarr/api/system/status was not valid JSON`), which addresses
the reporter's third point — the old message sent them down a config/key rabbit
hole for an hour.

## Tests

Five new cases in `test/http.test.ts`, written first and watched fail:
base path preserved, trailing slash not doubled, query string kept, no-path
base unchanged (the regression guard), and the error message naming the full
path.

## Verification

- `npm test` — 1520 passed
- `npm run typecheck`, `npm run lint` — clean
- `npm run integration` against a live stack — identical results before and
  after the change (37/40; the three failures are pre-existing and unrelated:
  one environmental `add_media` expectation and two config-UI login cases).

Not verified against a live service actually behind a URL base — I don't have
one deployed. The join itself is covered by the unit tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)