### PR TITLE
feat(tools): add trigger_subtitle_search

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ part it could not check rather than guessing across the hole.
 | 🛡️ **Indexer text is data, never instruction** | Release names from public indexers are attacker-controllable and flow straight into model context. arr-mcp fences every one of them. |
 | ✋ **Writes are opt-in, previewed, recorded** | Off until you turn them on, per service. Every write shows you exactly what it would do and waits for confirmation — and lands in an audit trail either way. |
 | 🖥️ **A config page that diagnoses** | Add services from a browser, see what is broken *and what to do about it*, read the logs and the write audit. No YAML required. |
-| 📚 **Twenty-two tools, one vocabulary** | Every list pages the same way, every error names the config key that would fix it, every write takes ids rather than titles. |
+| 📚 **Twenty-three tools, one vocabulary** | Every list pages the same way, every error names the config key that would fix it, every write takes ids rather than titles. |
 
 Nothing else in this space does the last four at all.
 
@@ -107,19 +107,20 @@ ARM NAS runs the same build as everything else.
 
 ## What you can ask it
 
-Twenty-two tools, but you never name them — you ask, and the model picks:
+Twenty-three tools, but you never name them — you ask, and the model picks:
 
 > *"What's downloading right now, and is anything stuck?"*
 > *"What aired this week that I haven't watched?"*
 > *"Which of my indexers are failing, and what did they say?"*
 > *"Find me something highly rated from 1994 I don't already have."*
+> *"Go and find Dutch subtitles for the film that just landed."*
 > *"Unmonitor season 5 and delete its files."* — previewed first, always.
 
 ## Documentation
 
 | | |
 | --- | --- |
-| **[Tools](docs/tools.md)** | All twenty-two, what each answers, and the fields whose meaning is not obvious |
+| **[Tools](docs/tools.md)** | All twenty-three, what each answers, and the fields whose meaning is not obvious |
 | **[Writes](docs/writes.md)** | Turning them on, the two tiers, and the preview-and-confirm handshake |
 | **[Configuration](docs/configuration.md)** | `config.yaml`, several Radarrs, Jellyfin's `default_user` |
 | **[Config UI](docs/config-ui.md)** | The four pages, and what each does that is not obvious |
@@ -157,7 +158,7 @@ arr-mcp is itself built with a coding agent. Point yours at
 
 **Missing a tool?** [Open an issue](../../issues/new/choose) describing the
 question you could not get answered rather than the tool you think should
-exist — at twenty-two tools the answer is usually a new parameter on one that
+exist — at twenty-three tools the answer is usually a new parameter on one that
 already exists.
 
 ## Security

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,6 +1,6 @@
 # Tools
 
-Twenty-two of them. The first thirteen read; the last nine write, and are off
+Twenty-three of them. The first thirteen read; the last ten write, and are off
 until you turn them on — see [writes](writes.md).
 
 | Tool | Answers |
@@ -20,6 +20,7 @@ until you turn them on — see [writes](writes.md).
 | `discover_media` | What exists in this genre, year, or rating band |
 | `trigger_search` | Go look for this again |
 | `trigger_scan` | Rescan a library — it downloaded but still will not play |
+| `trigger_subtitle_search` | Go and find the subtitles this is missing, now |
 | `set_monitoring` | Turn Sonarr monitoring on or off — a whole series, one season, or specific episodes |
 | `remove_queue_item` | Get rid of this stuck or wrong download |
 | `delete_media` | Remove this film or series, optionally from disk |
@@ -72,10 +73,10 @@ that sentence is prose and may be reworded.
 
 **A client can tell the reads from the writes without reading prose.** Every
 tool carries a title and an annotation: `readOnlyHint` on the thirteen that only
-read, and on the nine writes `destructiveHint`, taken from the same permission
+read, and on the ten writes `destructiveHint`, taken from the same permission
 tier the write gate itself runs on — so a tool cannot be gated as destructive
 and advertised as safe. A client deciding what to auto-approve, or what to warn
-about, reads those rather than guessing from twenty-two similarly-shaped
+about, reads those rather than guessing from twenty-three similarly-shaped
 descriptions. `idempotentHint` is deliberately absent: the confirmation token is
 single-use, so repeating a write does not repeat it, and neither answer would be
 true.
@@ -218,9 +219,26 @@ with no `seriesTitle`, `season` or `episode` (those three appear only on an
 episode), then compare `percentComplete` yourself — arr-mcp does not filter by
 how far in you are.
 
+## `trigger_subtitle_search`
+
+The write half of `get_subtitles`, and it takes its arguments straight from
+that tool's output: `kind`, `id` and one `code2` from the item's `missing`
+list. For an episode, `id` is the episode id — the series id it also needs is
+resolved here rather than being one more thing to pass.
+
+`language` is required. Bazarr searches one language at a time, and asking for
+one the item is not missing is reported as nothing to do rather than sent
+upstream — as is a mismatch on `forced` or `hearing_impaired`, which are part
+of what makes a wanted language distinct.
+
+It queues the search and returns. Whether a provider actually has the subtitle
+is not known at that point, so call `get_subtitles` again a minute later rather
+than reading success as "the subtitle is on disk". If nothing arrives, the
+`providers` block in that same response is usually the reason.
+
 ## Prompts and resources
 
-Twenty-two tools do not tell you which one to reach for, and the questions
+Twenty-three tools do not tell you which one to reach for, and the questions
 people actually ask are rarely one call.
 
 **Five prompts**, which most clients surface as slash commands:

--- a/docs/writes.md
+++ b/docs/writes.md
@@ -31,6 +31,7 @@ re-monitor it.
 | --- | --- | --- |
 | `trigger_search` | safe | `safe_write` |
 | `trigger_scan` | safe | `safe_write` |
+| `trigger_subtitle_search` | safe | `safe_write` |
 | `respond_to_request` | safe | `safe_write` |
 | `add_media` | safe | `safe_write` |
 | `set_monitoring` | safe | `safe_write` |

--- a/src/core/http.ts
+++ b/src/core/http.ts
@@ -88,6 +88,12 @@ export class ServiceHttp {
         await this.#request<unknown>('DELETE', path, undefined, false, true);
     }
 
+    /** Bazarr's subtitle actions are PATCH with everything in the query string,
+     *  answered with an empty 204. Like every write, never auto-retried. */
+    async patch(path: string): Promise<void> {
+        await this.#request<unknown>('PATCH', path, undefined, false, true);
+    }
+
     /** Sonarr's bulk episode-file delete is a DELETE *with* a body, which
      *  `delete` cannot express. Same no-retry, same discarded body. */
     async deleteWithBody(path: string, body: unknown): Promise<void> {

--- a/src/services/bazarr.ts
+++ b/src/services/bazarr.ts
@@ -13,13 +13,15 @@ import {
     type ServiceAdapter,
     type SubtitleCapable,
     type SubtitleGap,
-    type SubtitleProvider
+    type SubtitleProvider,
+    type SubtitleSearchCapable,
+    type SubtitleSearchTarget
 } from './types.ts';
 
 /**
- * Hand-written: Bazarr publishes no OpenAPI document, so
- * these shapes come from recorded fixtures and the contract test checks them
- * against those fixtures rather than against a spec.
+ * Hand-written, and checked by the contract test against recorded fixtures
+ * rather than a spec. Bazarr does serve swagger 2.0 at `/api/swagger.json` —
+ * useful for finding endpoints — but codegen here targets OpenAPI 3.
  *
  * Confirmed against a live Bazarr 1.6.0: every payload is wrapped in
  * `{ data: … }`, and the version field is `bazarr_version`.
@@ -31,6 +33,7 @@ type RawMissing = { name?: string; code2?: string; forced?: boolean; hi?: boolea
 type RawWantedMovie = { radarrId?: number; title?: string; sceneName?: string | null; missing_subtitles?: RawMissing[] };
 type RawWantedEpisode = {
     sonarrEpisodeId?: number;
+    sonarrSeriesId?: number;
     seriesTitle?: string;
     episodeTitle?: string;
     /** Combined, as `"5x2"` — Bazarr has no separate season/episode fields. */
@@ -52,7 +55,7 @@ function parseEpisodeNumber(value: string | undefined): { season?: number; episo
 }
 type RawProvider = { name?: string; status?: string; retry?: string };
 
-export class BazarrAdapter implements ServiceAdapter, HealthCheckCapable, SubtitleCapable {
+export class BazarrAdapter implements ServiceAdapter, HealthCheckCapable, SubtitleCapable, SubtitleSearchCapable {
     readonly type: ServiceId = 'bazarr';
     readonly instance: string | undefined;
     readonly id: string;
@@ -132,6 +135,7 @@ export class BazarrAdapter implements ServiceAdapter, HealthCheckCapable, Subtit
                     service: this.id,
                     kind: 'episode' as const,
                     id: e.sonarrEpisodeId,
+                    ...(typeof e.sonarrSeriesId === 'number' ? { seriesId: e.sonarrSeriesId } : {}),
                     title: fence('seriesTitle', e.seriesTitle ?? ''),
                     ...(e.episodeTitle === undefined ? {} : { episodeTitle: fence('episodeTitle', e.episodeTitle) }),
                     ...(season === undefined ? {} : { season }),
@@ -179,6 +183,33 @@ export class BazarrAdapter implements ServiceAdapter, HealthCheckCapable, Subtit
                     ...(retry === undefined ? {} : { retryAt: retry })
                 };
             });
+    }
+
+    /**
+     * Bazarr takes every argument in the query string and answers 204. It
+     * queues the search, so this resolving means asked, never found.
+     */
+    async triggerSubtitleSearch(target: SubtitleSearchTarget): Promise<void> {
+        const query = new URLSearchParams({
+            language: target.language,
+            forced: String(target.forced),
+            hi: String(target.hearingImpaired)
+        });
+
+        if (target.kind === 'movie') {
+            query.set('radarrid', String(target.id));
+            await this.#http.patch(`/api/movies/subtitles?${query.toString()}`);
+            return;
+        }
+
+        if (target.seriesId === undefined) {
+            throw new ServiceError('NotFound', this.id, 'an episode subtitle search needs the series id as well', {
+                remedy: 'Take both ids from get_subtitles.'
+            });
+        }
+        query.set('seriesid', String(target.seriesId));
+        query.set('episodeid', String(target.id));
+        await this.#http.patch(`/api/episodes/subtitles?${query.toString()}`);
     }
 
     async testConnection(): Promise<ConnectionDiagnosis> {

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -111,6 +111,8 @@ export type SubtitleGap = {
     service: string;
     kind: 'movie' | 'episode';
     id: number;
+    /** Episodes only. Bazarr's episode subtitle endpoint needs it; get_subtitles strips it. */
+    seriesId?: number;
     title: string;
     episodeTitle?: string;
     season?: number;
@@ -139,6 +141,25 @@ export interface SubtitleCapable {
 
 export const hasSubtitles = (a: ServiceAdapter): a is ServiceAdapter & SubtitleCapable =>
     typeof (a as Partial<SubtitleCapable>).getMissingSubtitles === 'function';
+
+export type SubtitleSearchTarget = {
+    kind: 'movie' | 'episode';
+    id: number;
+    /** Required for an episode. */
+    seriesId?: number;
+    /** Two-letter code, as `SubtitleGap.missing[].code2` reports it. */
+    language: string;
+    forced: boolean;
+    hearingImpaired: boolean;
+};
+
+export interface SubtitleSearchCapable {
+    /** Asks for one language for one item. Queued upstream, so it resolves before any subtitle exists. */
+    triggerSubtitleSearch(target: SubtitleSearchTarget): Promise<void>;
+}
+
+export const hasSubtitleSearch = (a: ServiceAdapter): a is ServiceAdapter & SubtitleSearchCapable =>
+    typeof (a as Partial<SubtitleSearchCapable>).triggerSubtitleSearch === 'function';
 
 export type QueueItem = {
     service: string;

--- a/src/tools/getSubtitles.ts
+++ b/src/tools/getSubtitles.ts
@@ -18,7 +18,9 @@ export type GetSubtitlesResult = {
     providers?: SubtitleProvider[];
 };
 
-const project = (g: SubtitleGap, detail: DetailLevel): SubtitleGap => {
+const project = (gap: SubtitleGap, detail: DetailLevel): SubtitleGap => {
+    // A join key, not a fact about the gap — so it goes at `full` too.
+    const { seriesId: _s, ...g } = gap;
     if (detail === 'full') return g;
     if (detail === 'standard') {
         const { releaseName: _r, ...rest } = g;

--- a/src/tools/register.ts
+++ b/src/tools/register.ts
@@ -31,6 +31,7 @@ import { registerSearchMedia } from './searchMedia.ts';
 import { registerSetMonitoring } from './setMonitoring.ts';
 import { registerStackHealth } from './stackHealth.ts';
 import { registerTriggerScan } from './triggerScan.ts';
+import { registerTriggerSubtitleSearch } from './triggerSubtitleSearch.ts';
 import { registerTriggerSearch } from './triggerSearch.ts';
 import type { WriteContext } from './write.ts';
 
@@ -147,6 +148,7 @@ export function registerAllTools(server: McpServer, context: ToolContext): void 
     // answer than a tool the model was told about and cannot find.
     registerTriggerSearch(server, write, adapters);
     registerTriggerScan(server, write, adapters);
+    registerTriggerSubtitleSearch(server, write, adapters);
     registerRemoveQueueItem(server, write, adapters);
     registerDeleteMedia(server, write, adapters);
     registerDeleteEpisodeFiles(server, write, adapters);
@@ -179,6 +181,7 @@ export const TOOL_NAMES = [
     'discover_media',
     'trigger_search',
     'trigger_scan',
+    'trigger_subtitle_search',
     'remove_queue_item',
     'delete_media',
     'delete_episode_files',

--- a/src/tools/triggerSubtitleSearch.ts
+++ b/src/tools/triggerSubtitleSearch.ts
@@ -1,0 +1,115 @@
+import type { McpServer } from '@modelcontextprotocol/server';
+import * as z from 'zod/v4';
+import { ServiceIdSchema, type ServiceId } from '../config/schema.ts';
+import { ServiceError } from '../core/errors.ts';
+import { hasSubtitleSearch, hasSubtitles, type ServiceAdapter, type SubtitleGap } from '../services/types.ts';
+import { INSTANCE_PARAM_DESCRIPTION, resolveInstance } from './resolveInstance.ts';
+import { registerWriteTool, type WriteContext, type WritePlan } from './write.ts';
+
+/**
+ * The other half of `get_subtitles`, which until now could only say what was
+ * missing. Safe, not destructive: it downloads a subtitle file, and the worst
+ * outcome is a wrong one you can replace.
+ */
+
+const findAdapter = (adapters: readonly ServiceAdapter[], service: ServiceId, instance?: string) => {
+    const adapter = resolveInstance(adapters, service, instance);
+    if (!hasSubtitleSearch(adapter) || !hasSubtitles(adapter)) {
+        throw new ServiceError('NotFound', service, `${service} cannot search for subtitles`, {
+            remedy: 'Only bazarr manages subtitles.'
+        });
+    }
+    return adapter;
+};
+
+const label = (gap: SubtitleGap): string =>
+    gap.kind === 'movie'
+        ? gap.title
+        : `${gap.title} ${gap.season ?? '?'}x${gap.episode ?? '?'}${gap.episodeTitle === undefined ? '' : ` ${gap.episodeTitle}`}`;
+
+export function registerTriggerSubtitleSearch(
+    server: McpServer,
+    context: WriteContext,
+    adapters: readonly ServiceAdapter[]
+): void {
+    registerWriteTool(server, context, {
+        name: 'trigger_subtitle_search',
+        title: 'Search for a subtitle',
+        description:
+            'Asks Bazarr to go looking for one language of subtitles for one item it already tracks — the "it is missing Dutch subs and I do not want to wait for the next round" action. Takes `kind`, `id` and `language` exactly as get_subtitles reports them. This queues a search and returns immediately; it does not wait, and finding a subtitle is not guaranteed. Previews by default — call again with the returned `confirm` token to actually run it.',
+        inputSchema: z.object({
+            service: ServiceIdSchema.describe('bazarr.'),
+            instance: z.string().optional().describe(INSTANCE_PARAM_DESCRIPTION),
+            kind: z.enum(['movie', 'episode']).describe('Which of the two lists get_subtitles reported the item in.'),
+            id: z
+                .string()
+                .min(1)
+                .describe("The item's id as get_subtitles reports it, as an integer string. For an episode this is the episode id, not the series id."),
+            language: z
+                .string()
+                .min(2)
+                .describe('The two-letter code from the item\'s `missing` list — "nl", "en".'),
+            forced: z.boolean().default(false).describe('Search for a forced subtitle track.'),
+            hearing_impaired: z.boolean().default(false).describe('Search for a hearing-impaired subtitle track.')
+        }),
+        service: ({ service, instance }) => findAdapter(adapters, service, instance).id,
+        operation: 'trigger_subtitle_search',
+        tier: 'safe',
+
+        async plan({ service, instance, kind, id, language, forced, hearing_impaired }): Promise<WritePlan> {
+            const adapter = findAdapter(adapters, service, instance);
+
+            // The wanted list is both the preview's source of a real title and
+            // the only place an episode's series id is offered.
+            const gaps = await adapter.getMissingSubtitles();
+            const gap = gaps.find(g => g.kind === kind && String(g.id) === id);
+            if (gap === undefined) {
+                throw new ServiceError('NotFound', adapter.id, `${adapter.id} has no ${kind} ${id} missing subtitles`, {
+                    remedy: 'Take kind and id from get_subtitles — it lists exactly the items with something missing.'
+                });
+            }
+
+            const target = `${adapter.id}:${kind}:${id}:${language}`;
+            const wanted = gap.missing.find(
+                m => m.code2 === language && m.forced === forced && m.hearingImpaired === hearing_impaired
+            );
+
+            if (wanted === undefined) {
+                const have = gap.missing.map(m => `${m.name} (${m.code2})`).join(', ');
+                return {
+                    target,
+                    summary: `Nothing to do — ${adapter.id} is not missing ${language} for ${label(gap)}.`,
+                    effects: [],
+                    noop: true,
+                    ...(have === '' ? {} : { args: { missing: have } })
+                };
+            }
+
+            return {
+                target,
+                summary: `Ask ${adapter.id} to search for ${wanted.name} subtitles for ${label(gap)}.`,
+                effects: [
+                    `Queries every enabled subtitle provider for ${wanted.name} subtitles and downloads the best match it finds.`,
+                    'Runs in the background — check get_subtitles again in a minute rather than expecting it to be done now.'
+                ],
+                args: { kind, id, language, forced, hearing_impaired }
+            };
+        },
+
+        async apply(_plan, { service, instance, kind, id, language, forced, hearing_impaired }) {
+            const adapter = findAdapter(adapters, service, instance);
+            const gap = (await adapter.getMissingSubtitles()).find(g => g.kind === kind && String(g.id) === id);
+
+            await adapter.triggerSubtitleSearch({
+                kind,
+                id: Number(id),
+                ...(gap?.seriesId === undefined ? {} : { seriesId: gap.seriesId }),
+                language,
+                forced,
+                hearingImpaired: hearing_impaired
+            });
+
+            return `${adapter.id} is searching for ${language} subtitles. Providers are queried in the background — check get_subtitles again shortly.`;
+        }
+    });
+}

--- a/test/adapters.test.ts
+++ b/test/adapters.test.ts
@@ -252,6 +252,81 @@ describe('BazarrAdapter', () => {
         expect(await adapter.getFailedHealthChecks()).toEqual([]);
     });
 
+    // The wanted list is the only place the series id is offered, and the
+    // episode subtitle endpoint is keyed on it.
+    it('carries the series id an episode subtitle search needs', async () => {
+        const wanted = new BazarrAdapter(
+            keyed(6767),
+            serving({
+                '/api/movies/wanted': { data: [] },
+                '/api/episodes/wanted': fixture('bazarr/episodes-wanted.json')
+            })
+        );
+        const gaps = await wanted.getMissingSubtitles();
+        expect(gaps[0]).toMatchObject({ kind: 'episode', id: 5169, seriesId: 67 });
+    });
+
+    describe('triggerSubtitleSearch', () => {
+        const probe = () => {
+            const seen: { url: string; method?: string }[] = [];
+            const impl = (async (input: string, init?: RequestInit) => {
+                seen.push({ url: String(input), ...(init?.method === undefined ? {} : { method: init.method }) });
+                return new Response(null, { status: 204 });
+            }) as unknown as typeof fetch;
+            return { adapter: new BazarrAdapter(keyed(6767), impl), seen };
+        };
+
+        it('patches the movie endpoint with the radarr id and language', async () => {
+            const { adapter: a, seen } = probe();
+            await a.triggerSubtitleSearch({ kind: 'movie', id: 1445, language: 'nl', forced: false, hearingImpaired: false });
+            expect(seen[0]?.method).toBe('PATCH');
+            const url = new URL(seen[0]?.url ?? '');
+            expect(url.pathname).toBe('/api/movies/subtitles');
+            expect(Object.fromEntries(url.searchParams)).toMatchObject({
+                radarrid: '1445',
+                language: 'nl',
+                forced: 'false',
+                hi: 'false'
+            });
+        });
+
+        // Both ids, or Bazarr answers 404 for an episode it plainly has.
+        it('patches the episode endpoint with both ids', async () => {
+            const { adapter: a, seen } = probe();
+            await a.triggerSubtitleSearch({
+                kind: 'episode',
+                id: 5169,
+                seriesId: 67,
+                language: 'nl',
+                forced: false,
+                hearingImpaired: false
+            });
+            const url = new URL(seen[0]?.url ?? '');
+            expect(url.pathname).toBe('/api/episodes/subtitles');
+            expect(Object.fromEntries(url.searchParams)).toMatchObject({
+                seriesid: '67',
+                episodeid: '5169',
+                language: 'nl'
+            });
+        });
+
+        it('refuses an episode search with no series id rather than calling without one', async () => {
+            const { adapter: a, seen } = probe();
+            await expect(
+                a.triggerSubtitleSearch({ kind: 'episode', id: 5169, language: 'nl', forced: false, hearingImpaired: false })
+            ).rejects.toThrow(/series id/i);
+            expect(seen).toHaveLength(0);
+        });
+
+        it('passes forced and hearing-impaired through as Bazarr spells them', async () => {
+            const { adapter: a, seen } = probe();
+            await a.triggerSubtitleSearch({ kind: 'movie', id: 1, language: 'en', forced: true, hearingImpaired: true });
+            const url = new URL(seen[0]?.url ?? '');
+            expect(url.searchParams.get('forced')).toBe('true');
+            expect(url.searchParams.get('hi')).toBe('true');
+        });
+    });
+
     expectsAuthDiagnosis(new BazarrAdapter(keyed(6767), unauthorized));
 });
 

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -296,10 +296,11 @@ describe('the advertised tool surface', () => {
         'respond_to_request',
         'set_monitoring',
         'trigger_scan',
-        'trigger_search'
+        'trigger_search',
+        'trigger_subtitle_search'
     ];
 
-    /** Of those nine, the four whose effect cannot be undone by calling again. */
+    /** Of those ten, the four whose effect cannot be undone by calling again. */
     const DESTRUCTIVE = ['delete_episode_files', 'delete_media', 'delete_request', 'remove_queue_item'];
 
     /**
@@ -327,11 +328,11 @@ describe('the advertised tool surface', () => {
     /**
      * Without `readOnlyHint`, `delete_media` and `get_queue` are the same kind
      * of thing to a client that decides what to auto-approve from annotations —
-     * so a surface with nine writes on it reads as either all safe or all
+     * so a surface with ten writes on it reads as either all safe or all
      * dangerous. The hint is the only machine-readable way to tell them apart;
      * the descriptions say so in prose, which nothing but a model can act on.
      */
-    it('says which tools only read, so a client can tell the nine writes from the rest', async () => {
+    it('says which tools only read, so a client can tell the ten writes from the rest', async () => {
         const tools = await listTools();
         const unmarked = tools.filter(t => t.annotations?.readOnlyHint === undefined);
         expect(unmarked.map(t => t.name)).toEqual([]);

--- a/test/getSubtitles.test.ts
+++ b/test/getSubtitles.test.ts
@@ -29,6 +29,7 @@ const EPISODES = {
     data: [
         {
             sonarrEpisodeId: 88,
+            sonarrSeriesId: 9,
             seriesTitle: 'Some Show',
             episodeTitle: 'Pilot',
             // Bazarr combines the position into one string; there are no
@@ -78,6 +79,13 @@ describe('get_subtitles', () => {
         const episode = result.items.find(i => i.kind === 'episode');
         expect(episode).toMatchObject({ id: 88, season: 1, episode: 1 });
         expect(episode?.missing[0]?.forced).toBe(true);
+    });
+
+    it('keeps the internal series id out of the tool output', async () => {
+        const result = await buildGetSubtitles([adapter()], { detail: 'full', limit: 50 });
+        const episode = result.items.find(i => i.kind === 'episode');
+        expect(episode).toBeDefined();
+        expect(episode).not.toHaveProperty('seriesId');
     });
 
     it('fences the release name, and a release name cannot escape its fence', async () => {

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -205,6 +205,28 @@ describe('ServiceHttp put and deleteWithBody', () => {
         );
     });
 
+    it('sends a PATCH to the given path and discards the response', async () => {
+        const seen: { method?: string; url: string }[] = [];
+        const client = http(async (input: string, init?: RequestInit) => {
+            seen.push({ url: String(input), ...(init?.method === undefined ? {} : { method: init.method }) });
+            return emptyOk();
+        });
+
+        await expect(client.patch('/api/movies/subtitles?radarrid=1')).resolves.toBeUndefined();
+        expect(seen[0]?.method).toBe('PATCH');
+        expect(seen[0]?.url).toBe('http://192.168.1.20:7878/api/movies/subtitles?radarrid=1');
+    });
+
+    it('never auto-retries a PATCH — it is a write', async () => {
+        let calls = 0;
+        const client = http(async () => {
+            calls += 1;
+            throw timeoutError();
+        });
+        await expect(client.patch('/x')).rejects.toThrow(/timed out/);
+        expect(calls).toBe(1);
+    });
+
     it('never auto-retries a deleteWithBody either', async () => {
         let calls = 0;
         const client = http(async () => {

--- a/test/plainJson.test.ts
+++ b/test/plainJson.test.ts
@@ -210,7 +210,7 @@ describe('a body that will not parse', () => {
         const res = await raw('POST', 'application/json; charset=utf-8', JSON.stringify(toolsList));
 
         expect(res.status).toBe(200);
-        expect((JSON.parse(await res.text()) as { result: { tools: unknown[] } }).result.tools).toHaveLength(22);
+        expect((JSON.parse(await res.text()) as { result: { tools: unknown[] } }).result.tools).toHaveLength(23);
     });
 });
 

--- a/test/triggerSubtitleSearch.test.ts
+++ b/test/triggerSubtitleSearch.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it, vi } from 'vitest';
+import * as z from 'zod/v4';
+import type { AnyServiceConfig, KeyedServiceConfig, ServiceId } from '../src/config/schema.ts';
+import { WriteAudit } from '../src/core/audit.ts';
+import { ConfirmTokens } from '../src/core/confirm.ts';
+import { permissionSourceFrom } from '../src/core/permissions.ts';
+import { BazarrAdapter } from '../src/services/bazarr.ts';
+import type { ServiceAdapter } from '../src/services/types.ts';
+import type { LibraryLoader } from '../src/tools/library.ts';
+import { registerTriggerSubtitleSearch } from '../src/tools/triggerSubtitleSearch.ts';
+import type { WriteToolResult } from '../src/tools/write.ts';
+import { instancesOf } from './helpers/instances.ts';
+import { jsonResponse } from './helpers/serve.ts';
+
+const keyed = (port: number): KeyedServiceConfig => ({
+    url: `http://192.0.2.10:${port}`,
+    api_key: 'k',
+    timeout_ms: 10_000,
+    permissions: { safe_write: false, destructive: false }
+});
+
+const permissive = (safe_write: boolean, destructive = false): AnyServiceConfig =>
+    ({ ...keyed(6767), permissions: { safe_write, destructive } }) as AnyServiceConfig;
+
+const MOVIES = {
+    data: [
+        {
+            radarrId: 1445,
+            title: 'Good Boy',
+            missing_subtitles: [
+                { name: 'Dutch', code2: 'nl', forced: false, hi: false },
+                { name: 'English', code2: 'en', forced: false, hi: false }
+            ]
+        }
+    ]
+};
+
+const EPISODES = {
+    data: [
+        {
+            sonarrEpisodeId: 5169,
+            sonarrSeriesId: 67,
+            seriesTitle: 'Rick and Morty',
+            episodeTitle: 'Mortyplicity',
+            episode_number: '5x2',
+            missing_subtitles: [{ name: 'Dutch', code2: 'nl', forced: false, hi: false }]
+        }
+    ]
+};
+
+function recordingFetch(routes: Record<string, unknown> = { '/api/movies/wanted': MOVIES, '/api/episodes/wanted': EPISODES }) {
+    const sent: { path: string; method: string; query: Record<string, string> }[] = [];
+    const impl = (async (input: string | URL | Request, init?: RequestInit) => {
+        const url = new URL(input instanceof Request ? input.url : String(input));
+        sent.push({
+            path: url.pathname,
+            method: init?.method ?? 'GET',
+            query: Object.fromEntries(url.searchParams)
+        });
+        if (init?.method === 'PATCH') return new Response(null, { status: 204 });
+        if (url.pathname in routes) return jsonResponse(routes[url.pathname]);
+        return jsonResponse({ message: 'not found' }, 404);
+    }) as unknown as typeof fetch;
+
+    return { impl, sent, patches: () => sent.filter(s => s.method === 'PATCH') };
+}
+
+type Call = (args: Record<string, unknown>) => Promise<{
+    content: { type: 'text'; text: string }[];
+    structuredContent: WriteToolResult;
+}>;
+
+function harness(opts: { permissions?: Partial<Record<ServiceId, AnyServiceConfig>>; adapters?: ServiceAdapter[]; routes?: Record<string, unknown> } = {}) {
+    const bazarrFetch = recordingFetch(opts.routes);
+    const adapters = opts.adapters ?? [new BazarrAdapter(keyed(6767), bazarrFetch.impl)];
+
+    let call: Call = () => Promise.reject(new Error('not registered'));
+    const server = {
+        registerTool(_name: string, config: { inputSchema: z.ZodObject }, handler: Call) {
+            call = args => handler(config.inputSchema.parse(args) as Record<string, unknown>);
+        }
+    };
+
+    registerTriggerSubtitleSearch(
+        server as never,
+        {
+            permissions: permissionSourceFrom(instancesOf(opts.permissions ?? { bazarr: permissive(true) })),
+            confirm: new ConfirmTokens(),
+            audit: WriteAudit.ephemeral(),
+            library: { invalidate: vi.fn() } as unknown as LibraryLoader
+        },
+        adapters
+    );
+
+    return { call: (args: Record<string, unknown>) => call(args), bazarrFetch };
+}
+
+const movie = { service: 'bazarr', kind: 'movie', id: '1445', language: 'nl' };
+const episode = { service: 'bazarr', kind: 'episode', id: '5169', language: 'nl' };
+
+describe('trigger_subtitle_search', () => {
+    it('previews with the real title and the language, not the bare id', async () => {
+        const { structuredContent } = await harness().call({ ...movie, dry_run: true });
+        expect(structuredContent.summary).toContain('Good Boy');
+        expect(structuredContent.summary).toContain('Dutch');
+        expect(structuredContent.target).toBe('bazarr:movie:1445:nl');
+    });
+
+    it('names the episode by its position, not just the series', async () => {
+        const { structuredContent } = await harness().call({ ...episode, dry_run: true });
+        expect(structuredContent.summary).toContain('Rick and Morty');
+        expect(structuredContent.summary).toContain('5x2');
+    });
+
+    it('changes nothing on a dry run', async () => {
+        const h = harness();
+        await h.call({ ...movie, dry_run: true });
+        expect(h.bazarrFetch.patches()).toHaveLength(0);
+    });
+
+    it('does not search on the first call, then does on the confirmed one', async () => {
+        const h = harness();
+        const first = await h.call(movie);
+        expect(h.bazarrFetch.patches()).toHaveLength(0);
+
+        const second = await h.call({ ...movie, confirm: first.structuredContent.confirm_token });
+        expect(second.structuredContent.applied).toBe(true);
+        expect(h.bazarrFetch.patches()).toHaveLength(1);
+        expect(h.bazarrFetch.patches()[0]?.query).toMatchObject({ radarrid: '1445', language: 'nl' });
+    });
+
+    // The model passes the episode id it saw from get_subtitles; the series id
+    // is resolved here rather than being one more thing to get right.
+    it('resolves the series id itself for an episode', async () => {
+        const h = harness();
+        const first = await h.call(episode);
+        await h.call({ ...episode, confirm: first.structuredContent.confirm_token });
+
+        expect(h.bazarrFetch.patches()[0]?.query).toMatchObject({ seriesid: '67', episodeid: '5169' });
+    });
+
+    it('is a no-op when that language is not actually missing', async () => {
+        const { structuredContent } = await harness().call({ ...movie, language: 'fr', dry_run: true });
+        expect(structuredContent.noop).toBe(true);
+        expect(structuredContent.confirm_token).toBeUndefined();
+    });
+
+    it('fails naming the item when Bazarr does not know the id', async () => {
+        const h = harness();
+        await expect(h.call({ ...movie, id: '9999', dry_run: true })).rejects.toThrow(/9999/);
+        expect(h.bazarrFetch.patches()).toHaveLength(0);
+    });
+
+    it('is a safe-tier write, so safe_write alone is enough', async () => {
+        const first = await harness({ permissions: { bazarr: permissive(true, false) } }).call(movie);
+        expect(first.structuredContent.tier).toBe('safe');
+        expect(first.structuredContent.confirm_token).toBeTypeOf('string');
+    });
+
+    it('refuses when safe_write is off for bazarr', async () => {
+        const h = harness({ permissions: { bazarr: permissive(false) } });
+        await expect(h.call(movie)).rejects.toThrow(/services\.bazarr\.permissions\.safe_write: true/);
+    });
+
+    it('refuses a configured service that cannot search for subtitles', async () => {
+        const radarr = {
+            id: 'radarr' as ServiceId,
+            type: 'radarr' as ServiceId,
+            testConnection: () => Promise.reject(new Error('unused')),
+            getVersion: () => Promise.resolve('4.0.0')
+        } as unknown as ServiceAdapter;
+
+        const h = harness({ adapters: [radarr], permissions: { radarr: permissive(true) } });
+        await expect(h.call({ ...movie, service: 'radarr', dry_run: true })).rejects.toThrow(/subtitle/i);
+    });
+
+    it('refuses an unconfigured service by name', async () => {
+        const h = harness({ adapters: [] });
+        await expect(h.call({ ...movie, dry_run: true })).rejects.toThrow(/not configured/);
+    });
+
+    it('reports that the search was queued rather than that a subtitle arrived', async () => {
+        const h = harness();
+        const first = await h.call(movie);
+        const second = await h.call({ ...movie, confirm: first.structuredContent.confirm_token });
+        expect(second.content[0]?.text.toLowerCase()).not.toContain('downloaded');
+    });
+});


### PR DESCRIPTION
From user feedback: `get_subtitles` could only report what was missing. If a
film had just landed and you wanted Dutch subs, there was nothing to call — you
waited for Bazarr's next automatic round. This adds the write half.

```
trigger_subtitle_search { service: "bazarr", kind: "movie", id: "1445", language: "nl" }
```

## What Bazarr actually offers

Bazarr serves swagger 2.0 at `/api/swagger.json` (the adapter's header comment
said it published no spec — corrected, though codegen here targets OpenAPI 3, so
the types stay hand-written). The relevant endpoints:

- `PATCH /api/movies/subtitles` — `radarrid`, `language`, `forced`, `hi`
- `PATCH /api/episodes/subtitles` — `seriesid`, `episodeid`, `language`, `forced`, `hi`

Everything goes in the query string; the answer is an empty 204. The heavier
`/api/providers/*` manual flow — list candidates, pick one — is deliberately not
used: it would put attacker-controllable release names in front of the model as
a choice.

## Notes

**`language` is required.** Bazarr searches one language at a time, so one call
stays one write and one audit row. `get_subtitles` already hands the model the
`code2` to use. Asking for a language the item isn't missing takes the existing
no-op path rather than reaching Bazarr — as does a mismatch on `forced` or
`hearing_impaired`, which are part of what makes a wanted language distinct.

**The series id.** The episode endpoint needs it, Bazarr returns it in the
wanted list, and the adapter was dropping it. It's now on `SubtitleGap` as an
internal join key: `plan()` resolves it so the model passes only the episode id
it saw, and `get_subtitles` strips it — including at `detail: "full"` — rather
than spending a field of every episode row on something nobody passes.

**Safe tier**, like `trigger_search` and `trigger_scan`. It downloads a subtitle
file; the worst outcome is a wrong one you can replace.

**`ServiceHttp.patch`** is new — no service had needed PATCH yet. No retry, like
every write.

Surface goes 22 → 23 tools, 9 → 10 writes; README, `docs/tools.md` and
`docs/writes.md` updated to match.

## Verification

- `npm test` — 1540 passed; `npm run typecheck` and `npm run lint` clean
- Tests written first. The one that passed on a weak RED (module-not-found) was
  re-checked by mutation: removing the series-id resolution fails
  `resolves the series id itself for an episode`.
- **Live against Bazarr 1.6.0** — both forms accepted:
  ```
  -> movie: asking for Dutch (nl) on movie 1147
     OK — Bazarr accepted the search
  -> episode: asking for Dutch (nl) on episode 5169 (series 67)
     OK — Bazarr accepted the search
  ```

Not verified: that a subtitle actually lands, which depends on the providers
rather than on this code. The tool deliberately reports the search as queued
rather than claiming a result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)