### PR TITLE
docs: stop the instructions comment naming a tool count

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -26,7 +26,7 @@ const VERSION = process.env.ARR_MCP_VERSION ?? '0.0.0-dev';
  * model that learns them from `get_library` has still not learned them for
  * `get_queue`.
  *
- * Deliberately not a tool index. `tools/list` already carries 22 descriptions
+ * Deliberately not a tool index. `tools/list` already carries every description
  * and repeating them here would cost every session the same tokens twice; what
  * it names instead is the shape a caller cannot infer from any one of them —
  * that a list reports the whole count rather than the window, and that a write


### PR DESCRIPTION
The comment above `INSTRUCTIONS` said `tools/list` carries 22 descriptions. The surface has been at 24 since `clean_queue` landed in 1.13.0 (#140).

That count was the one fact about the tool surface living outside `TOOL_NAMES`, so nothing could catch it drifting — `test/app.test.ts:314` and `:754` assert `tools/list` against `TOOL_NAMES`, never against prose. Saying "every description" makes the same point and cannot go stale as tools are added.

Comment only. The `instructions` string sent to clients at `initialize` never named a count, so nothing changes over the wire and no behaviour is affected.

`docs:` deliberately — this should not bump a version or open a release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
