### PR TITLE
refactor: decide the media-server half by capability, not by Jellyfin's name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -199,7 +199,7 @@ weekend: the answer to that one is a date, not a no.
 ### What would be accepted today
 
 The bar above is abstract, so here is the concrete answer, current as of
-2026-08-14. Grouped by slot on the chain rather than alphabetically, because
+2026-08-16. Grouped by slot on the chain rather than alphabetically, because
 that is the real question: a second service in a slot that already exists is a
 small, shaped change, and a service in no slot at all is a different product.
 
@@ -223,13 +223,27 @@ small, shaped change, and a service in no slot at all is a different product.
 - **Emby.** Jellyfin's ancestor, near-identical API, and therefore the cheapest
   adapter on this list — plausibly a variant of the Jellyfin one rather than a
   new file.
+- **Plex.** Wanted, on two conditions. It is the most-deployed media server this
+  server cannot talk to, and reach is the point: Plex support is what makes
+  arr-mcp useful to the many people who will never run Jellyfin.
+
+  **The design is the first condition.** Plex's usual auth brokers through
+  plex.tv — credential brokering *and* an outbound request to a host the
+  operator never configured, which is the risk class above and a no on its own
+  terms. An adapter that takes an operator-supplied `X-Plex-Token` and talks
+  only to the configured local server avoids all of it. Build that one; a pull
+  request built on the discovery flow is turned down for its architecture rather
+  than its code.
+
+  **Testers are the second, and they are what is actually missing.** Nobody here
+  runs Plex, so an adapter for it cannot be exercised in review — and one merged
+  against hand-written fixtures is a bug report waiting to be filed. I am
+  willing to do the integration work myself; what I cannot supply is a real Plex
+  library to prove it against. If you run Plex and will test a build against it
+  and report back, say so in an issue. That is the thing blocking this.
 
 Named and **not** accepted, so nobody spends a weekend finding out:
 
-- **Plex.** Not a no, but not an adapter decision either. Its auth brokers
-  through plex.tv, which is both credential brokering and an outbound request to
-  a host the operator never configured — the risk class that gets decided on its
-  own terms. Open an issue; do not open a pull request.
 - **Readarr.** Archived upstream. Nothing to track.
 - **Chaptarr.** Public since June 2026, so it misses on age alone. This is the
   date-not-a-no case, and it is on this list so the date is visible rather than

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ model stops finding a renamed tool rather than raising an error.
 ## Contributing
 
 **Contributions are welcome, and new service adapters most of all** — Lidarr,
-qBittorrent, Emby and Deluge would all be accepted today, and
+qBittorrent, Emby, Plex and Deluge would all be accepted today, and
 [the list says so in advance](CONTRIBUTING.md#what-would-be-accepted-today),
 along with the ones that would not be. An adapter is deliberately the most
 self-contained thing in the codebase. Two things to know first: not every
@@ -152,6 +152,16 @@ request — [which services qualify](CONTRIBUTING.md#which-services-qualify). An
 **I cannot test a service I do not run**, so the second bar is that you tested
 it against your own live instance and the PR says what you tested and against
 which version.
+
+**Plex: I will write it, if you will test it.** It is the most-deployed media
+server arr-mcp cannot talk to, and the only thing blocking it is that nobody
+here runs Plex — an adapter that cannot be exercised against a real library
+before it ships is a bug report waiting to be filed. If you run Plex and are
+willing to test builds against it and report back,
+[say so in an issue](../../issues/new/choose). There is one design constraint
+worth reading first: it has to work from an operator-supplied token against your
+own server, never through plex.tv —
+[why, and what else is on the list](CONTRIBUTING.md#what-would-be-accepted-today).
 
 **AI-assisted contributions are welcome**, held to the same bar and no other;
 arr-mcp is itself built with a coding agent. Point yours at

--- a/src/core/resolver.ts
+++ b/src/core/resolver.ts
@@ -22,13 +22,9 @@ export type MergedRatings = {
 /**
  * One season's watch state, joined from two services that each know half of it.
  *
- * Every field but `season` is optional because either half can be missing:
- * a `jellyfin_only` series has `watched` and no denominator, an `arr_only`
- * series has denominators and no `watched`. In both cases `complete` is
- * **absent, never `false`** — the rule `has_file` already follows at
- * `getLibrary.ts`'s `has_file` rule. A `false` here would put a season you had finished onto
- * a list of things still to watch, and `watched: 0` would claim Jellyfin looked
- * and found nothing played, which is a different fact from never having asked.
+ * Every field but `season` is optional because either half can be missing.
+ * `complete` is **absent, never `false`**: a `false` would put a season you had
+ * finished onto a list of things still to watch.
  */
 export type SeasonSummary = {
     season: number;
@@ -92,18 +88,14 @@ export type MergedItem = {
     seasons?: SeasonSummary[];
     ratings?: MergedRatings;
     /**
-     * What no single service can tell you.
+     * What no single service can tell you. `arr_only` **with a file** means a
+     * broken import; `jellyfin_only` means media nothing is managing.
      *
-     * `arr_only` **with a file** means a broken Jellyfin import — but only
-     * when Jellyfin actually answered. An *arr-managed item looks identical
-     * whether Jellyfin found nothing or was never asked, and asserting the
-     * first across the second is the collapse this guards: empty is "looked
-     * and found nothing", undefined is "could not look". `jellyfin_only`
-     * means media nothing is managing.
+     * A degraded or unconfigured media server gets `unknown`, never
+     * `arr_only` — that claim asserts the server looked and did not find it.
      *
-     * `unknown` is what a degraded or unconfigured Jellyfin gets, instead of
-     * `arr_only` and a false "Jellyfin cannot see this file" across the whole
-     * library — the only answer that does not fabricate a source.
+     * The value is named for Jellyfin because it is the only media server
+     * today. A second one renames it, with the old name aliased for a minor.
      */
     presence: 'both' | 'arr_only' | 'jellyfin_only' | 'unknown';
 };
@@ -112,17 +104,14 @@ export type IndexInput = Omit<MergedItem, 'presence'>;
 
 export type BuildOptions = {
     /**
-     * Whether Jellyfin's half of *this* build was gathered — configured *and*
-     * read without error. Defaults to `true`, so existing call sites are
-     * unchanged.
+     * Whether the media server's half of this build was gathered — configured
+     * *and* read without error. Defaults to `true`.
      *
-     * `LibraryIndex` cannot tell "Jellyfin looked and this is genuinely absent"
-     * from "Jellyfin was never asked": both arrive with `acquisition` set and
+     * "Looked and found nothing" and "was never asked" both arrive with
      * `playback` unset, and an unset field carries no reason. `LibraryLoader`
-     * owns the fetch, so it knows which — and passes it in rather than letting
-     * the index guess.
+     * owns the fetch, so it passes in which one this was.
      */
-    jellyfinGathered?: boolean;
+    playbackGathered?: boolean;
 };
 
 /**
@@ -191,7 +180,7 @@ export class LibraryIndex {
     }
 
     static build(inputs: readonly IndexInput[], opts: BuildOptions = {}): LibraryIndex {
-        const jellyfinGathered = opts.jellyfinGathered ?? true;
+        const playbackGathered = opts.playbackGathered ?? true;
         const byKey = new Map<string, MergedItem>();
         const items: MergedItem[] = [];
 
@@ -262,13 +251,9 @@ export class LibraryIndex {
                 item.acquisition !== undefined && item.playback !== undefined
                     ? 'both'
                     : item.acquisition !== undefined
-                      ? // `arr_only` claims Jellyfin looked and found nothing —
-                        // a claim this build cannot make when Jellyfin's half
-                        // was never gathered at all (degraded, or never
-                        // configured). `unknown` is the honest answer for the
-                        // whole build in that case, not just for the items
-                        // that happen to lack acquisition too.
-                        jellyfinGathered
+                      ? // `arr_only` claims the media server looked and found
+                        // nothing — not a claim to make when it was never read.
+                        playbackGathered
                           ? 'arr_only'
                           : 'unknown'
                       : item.playback !== undefined

--- a/src/tools/diagnose/evidence.ts
+++ b/src/tools/diagnose/evidence.ts
@@ -9,6 +9,7 @@ import {
     hasQueue,
     hasRequests,
     hasScanState,
+    hasUserLibrary,
     type IndexerRejection,
     type MediaRequest,
     type QueueItem,
@@ -107,13 +108,18 @@ async function resolveItem(
         // matched under either kind — there is no signal left to disambiguate,
         // so 'movie' is the least-committal default already implied by
         // `MergedItem.kind` having no third option.
+        //
+        // A media server contributes watch state and never acquisition, so it
+        // is the capability that decides the shape, not the service's name —
+        // a second one must not need editing here.
+        const isMediaServer = hasUserLibrary(adapter);
         return {
             kind: searchKind ?? 'movie',
             title: details.title,
             ...(details.year === undefined ? {} : { year: details.year }),
             ids: details.ids,
-            presence: adapter.id === 'jellyfin' ? 'jellyfin_only' : 'arr_only',
-            ...(adapter.id === 'jellyfin'
+            presence: isMediaServer ? 'jellyfin_only' : 'arr_only',
+            ...(isMediaServer
                 ? {}
                 : {
                       acquisition: {

--- a/src/tools/library.ts
+++ b/src/tools/library.ts
@@ -34,7 +34,7 @@ export class LibraryLoader {
 
     constructor(
         adapters: readonly ServiceAdapter[],
-        jellyfinIdentity: IdentityResolver | undefined,
+        mediaServerIdentity: IdentityResolver | undefined,
         cache: TtlCache = new TtlCache(),
         /**
          * Enrichment happens here, not per tool, for the reason this class
@@ -46,7 +46,7 @@ export class LibraryLoader {
         dataset?: ImdbDataset | undefined
     ) {
         this.#adapters = adapters;
-        this.#identity = jellyfinIdentity;
+        this.#identity = mediaServerIdentity;
         this.#cache = cache;
         this.#dataset = dataset;
     }
@@ -89,10 +89,9 @@ export class LibraryLoader {
      * Called after a successful write, so the next `get_library` reflects it
      * rather than up to five minutes of a library that no longer exists.
      *
-     * Clears every entry, not one key: keys are per Jellyfin user, and a film
-     * just deleted is gone from all of them. Recomputing a
-     * household's worth of snapshots costs one library read each; serving a
-     * stale one costs a wrong answer.
+     * Clears every entry, not one key: keys are per user, and a film just
+     * deleted is gone from all of them. Recomputing a household's worth of
+     * snapshots costs one library read each; a stale one costs a wrong answer.
      */
     invalidate(): void {
         this.#cache.clear();
@@ -134,52 +133,47 @@ export class LibraryLoader {
             .filter(hasLibrary)
             .map(a => ({ id: a.id, fetch: () => a.listLibrary() }));
 
-        const jellyfin = this.#adapters.find(hasUserLibrary);
-        if (jellyfin !== undefined) {
+        const mediaServer = this.#adapters.find(hasUserLibrary);
+        if (mediaServer !== undefined) {
             sources.push({
-                id: jellyfin.id,
+                id: mediaServer.id,
                 fetch:
                     user === undefined
                         ? // Reported as degraded rather than silently absent: the
                           // answer really is missing a service's contribution.
-                          () => Promise.reject(new Error('no Jellyfin user resolved'))
-                        : () => jellyfin.listUserLibrary(user)
+                          () => Promise.reject(new Error(`no ${mediaServer.id} user resolved`))
+                        : () => mediaServer.listUserLibrary(user)
             });
         }
 
         // Its own source, so `gather` degrades it by name. A try/catch inside
         // the adapter could not tell the snapshot *why* seasons were missing —
-        // the same ambiguity `BuildOptions.jellyfinGathered` exists to prevent.
+        // the same ambiguity `BuildOptions.playbackGathered` exists to prevent.
         const seasons = this.#adapters.find(hasUserSeasons);
         if (seasons !== undefined) {
             sources.push({
                 id: `${seasons.id}:episodes`,
                 fetch:
                     user === undefined
-                        ? () => Promise.reject(new Error('no Jellyfin user resolved'))
+                        ? () => Promise.reject(new Error(`no ${seasons.id} user resolved`))
                         : () => seasons.listUserSeasons(user)
             });
         }
 
         const { items, degraded, counts } = await gather(sources);
 
-        // `LibraryIndex` cannot tell "Jellyfin looked and found nothing" from
-        // "Jellyfin was never gathered" on its own (resolver.ts's
-        // `BuildOptions` doc) — this is the one place that knows which,
-        // because it owns the fetch. Gathered means both configured (a
-        // `jellyfin` source was even pushed above) *and* successful (its id
-        // is not in `degraded` — covering an outright fetch failure and the
-        // synthetic no-user-resolved rejection above alike).
-        const jellyfinGathered = jellyfin !== undefined && !degraded.includes(jellyfin.id);
+        // The one place that knows whether the media server was actually read:
+        // configured (a source was pushed above) *and* successful (its id is
+        // not in `degraded`, covering a fetch failure and the synthetic
+        // no-user-resolved rejection alike).
+        const playbackGathered = mediaServer !== undefined && !degraded.includes(mediaServer.id);
 
-        // Enriched *before* the merge rather than after it, because the index
-        // hands the same objects to `all()` and to its key map — replacing
-        // them afterwards would have to keep both in step, while an input a
-        // service never rated is simply an input with a gap to fill. It also
-        // means Jellyfin-only media gets a rating, which nothing in the stack
-        // could otherwise give it.
+        // Enriched *before* the merge: the index hands the same objects to
+        // `all()` and to its key map, so replacing them afterwards would have
+        // to keep both in step. It also means media-server-only items get a
+        // rating, which nothing else in the stack could give them.
         const rated = enrichWithImdb(items, this.#dataset);
 
-        return { index: LibraryIndex.build(rated, { jellyfinGathered }), degraded, counts };
+        return { index: LibraryIndex.build(rated, { playbackGathered }), degraded, counts };
     }
 }

--- a/test/resolver.test.ts
+++ b/test/resolver.test.ts
@@ -299,17 +299,17 @@ describe('LibraryIndex presence — a degraded or unconfigured Jellyfin must not
     // as `arr_only` — which `get_library`'s own description reads as "Jellyfin
     // cannot see a file the *arr believes is on disk", a broken-import claim
     // for every row, when Jellyfin was in fact never asked at all.
-    it('reports unknown, not arr_only, for an *arr-only item when jellyfinGathered is false', () => {
-        const index = LibraryIndex.build([arr()], { jellyfinGathered: false });
+    it('reports unknown, not arr_only, for an *arr-only item when playbackGathered is false', () => {
+        const index = LibraryIndex.build([arr()], { playbackGathered: false });
         expect(index.find({ tmdb: 550 })?.presence).toBe('unknown');
     });
 
     it('still reports arr_only for the same item when Jellyfin was actually gathered (the healthy case)', () => {
-        const index = LibraryIndex.build([arr()], { jellyfinGathered: true });
+        const index = LibraryIndex.build([arr()], { playbackGathered: true });
         expect(index.find({ tmdb: 550 })?.presence).toBe('arr_only');
     });
 
-    it('defaults jellyfinGathered to true, so a caller that omits it keeps reporting arr_only', () => {
+    it('defaults playbackGathered to true, so a caller that omits it keeps reporting arr_only', () => {
         // Every other call site in this codebase (and every other test in this
         // file) does not pass BuildOptions at all — the default must not
         // silently start reporting `unknown` everywhere.
@@ -319,7 +319,7 @@ describe('LibraryIndex presence — a degraded or unconfigured Jellyfin must not
 
     it('reports the whole library as unknown, not just items that also lack playback', () => {
         const index = LibraryIndex.build([arr({ ids: { tmdb: 1 } }), arr({ ids: { tmdb: 2 } })], {
-            jellyfinGathered: false
+            playbackGathered: false
         });
         for (const item of index.all()) expect(item.presence).toBe('unknown');
     });
@@ -327,12 +327,12 @@ describe('LibraryIndex presence — a degraded or unconfigured Jellyfin must not
     it('does not downgrade an item with genuine evidence from both halves', () => {
         // Real playback evidence beats a degraded-build flag meant for the
         // items that have no such evidence.
-        const index = LibraryIndex.build([arr(), jelly()], { jellyfinGathered: false });
+        const index = LibraryIndex.build([arr(), jelly()], { playbackGathered: false });
         expect(index.find({ tmdb: 550 })?.presence).toBe('both');
     });
 
-    it('leaves jellyfin_only untouched by jellyfinGathered — that claim never depended on the *arr half', () => {
-        const index = LibraryIndex.build([jelly()], { jellyfinGathered: false });
+    it('leaves jellyfin_only untouched by playbackGathered — that claim never depended on the *arr half', () => {
+        const index = LibraryIndex.build([jelly()], { playbackGathered: false });
         expect(index.find({ tmdb: 550 })?.presence).toBe('jellyfin_only');
     });
 });


### PR DESCRIPTION
Groundwork for a second media server, plus the policy change that makes Plex
worth discussing.

## The coupling was shallower than it looked

`gather` and `logs` were already general — their source ids are plain strings,
and only their comments named Jellyfin. `LibraryIndex` already joins an
`acquisition` half against a `playback` half without knowing which service
supplied either. What was genuinely Jellyfin-specific was four names and one
hardcode.

**The hardcode**: `evidence.ts` decided an item's shape with
`adapter.id === 'jellyfin'` — the line that becomes an `||` chain, wrong the
first time someone forgets to extend it. It now asks `hasUserLibrary`, the
capability predicate `library.ts` already used for the same question.

**The names**: `BuildOptions.jellyfinGathered` → `playbackGathered`, and the
locals in `LibraryLoader` follow. All internal, no alias owed. The two
`no Jellyfin user resolved` rejections now interpolate the adapter id — they
feed `degraded`, so a Plex source would otherwise have reported a Jellyfin
problem by name.

## Deliberately unchanged

`presence: 'jellyfin_only'` is a `get_library` filter value, so it is public
surface and a rename owes an alias for a full minor. That cost is the same
whenever it is paid and buys nothing until a second media server exists — so
it rides along with whichever one lands first, noted at the type. Identity
resolution stays Jellyfin-shaped: that is real coupling in the config, not a
stray name.

## Plex

Moved out of CONTRIBUTING's not-accepted list into the media-server slot beside
Emby. The plex.tv objection stands, restated as a design constraint rather than
a refusal: an operator-supplied `X-Plex-Token` against the configured local
server brokers no credentials and reaches no host the operator did not name.

The blocker is not the code — it is that nobody here runs Plex, and an adapter
that cannot be exercised against a real library before it ships is a bug report
waiting to be filed. So README and CONTRIBUTING both ask for **testers**, and
say the integration work itself is on offer.

## Verification

`npm run lint`, `npm run typecheck`, `npm test` (1558 tests, 69 files) and
`npm run build` all pass locally. No behaviour change is intended: the renames
are internal and the predicate returns exactly what the id check returned for
every adapter that exists today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)