### PR TITLE
chore: regenerate the types in the drift workflow, not by hand

### DIFF
--- a/.github/workflows/openapi-drift.yml
+++ b/.github/workflows/openapi-drift.yml
@@ -8,8 +8,9 @@ permissions:
   contents: write
   pull-requests: write
 
-# Re-fetches the vendored specs and runs the contract test against them, so a
-# breaking upstream change arrives as a red run rather than a user's bug report.
+# Re-fetches the vendored specs, regenerates the types from them, and checks the
+# project against both, so a breaking upstream change arrives as a red run rather
+# than a user's bug report.
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -27,15 +28,24 @@ jobs:
       - name: Re-fetch vendored specs
         run: bash scripts/fetch-specs.sh
 
+      # The specs and their generated types are committed as a pair, so they
+      # are refreshed as a pair. Committing only `specs` left the types
+      # declaring query params upstream had already dropped.
+      - name: Regenerate types
+        run: npm run codegen
+
+      # Both paths, so a spec committed by hand without codegen is caught here
+      # too: the specs come back unchanged, the regenerated types do not, and
+      # this opens the PR that reconciles them.
       - name: Did anything change?
         id: drift
         run: |
-          if git diff --quiet -- specs; then
+          if git diff --quiet -- specs src/services/generated; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Vendored specs are unchanged."
+            echo "::notice::Vendored specs and generated types are unchanged."
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
-            git diff --stat -- specs
+            git diff --stat -- specs src/services/generated
           fi
 
       # Against the freshly fetched specs, not the committed ones. Runs even
@@ -48,23 +58,46 @@ jobs:
           npx vitest run test/contract.test.ts 2>&1 | tee contract.log
           exit "${PIPESTATUS[0]}"
 
+      # The contract test reads the specs; this reads the types generated from
+      # them, so it catches the other half — a field whose *shape* changed under
+      # a mapper that still compiles against the old one. Non-fatal for the same
+      # reason as above: the PR must still open, carrying the bad news.
+      - name: Typecheck against the regenerated types
+        id: typecheck
+        continue-on-error: true
+        run: |
+          npm run typecheck 2>&1 | tee typecheck.log
+          exit "${PIPESTATUS[0]}"
+
       - name: Summarise
         id: verdict
         if: steps.drift.outputs.changed == 'true'
         run: |
           {
-            if [ "${{ steps.contract.outcome }}" = "success" ]; then
+            if [ "${{ steps.contract.outcome }}" = "success" ] \
+            && [ "${{ steps.typecheck.outcome }}" = "success" ]; then
               echo "The nightly re-fetch found spec changes, and every field this"
               echo "project reads is still declared. Additive drift; review and merge."
             else
               echo "**Upstream shipped a change this project does not survive.**"
               echo
-              echo "The contract test failed against the newly fetched specs — a field"
-              echo "an adapter reads is no longer declared. Failing entries:"
-              echo
-              echo '```'
-              grep -E 'renamed or removed|missing from the recorded' -A 4 contract.log | head -60 || true
-              echo '```'
+              if [ "${{ steps.contract.outcome }}" = "failure" ]; then
+                echo "The contract test failed against the newly fetched specs — a field"
+                echo "an adapter reads is no longer declared. Failing entries:"
+                echo
+                echo '```'
+                grep -E 'renamed or removed|missing from the recorded' -A 4 contract.log | head -60 || true
+                echo '```'
+                echo
+              fi
+              if [ "${{ steps.typecheck.outcome }}" = "failure" ]; then
+                echo "The project no longer typechecks against the regenerated types —"
+                echo "a field an adapter reads changed shape. Failing entries:"
+                echo
+                echo '```'
+                grep -E '^[^ ].*error TS' typecheck.log | head -40 || true
+                echo '```'
+              fi
             fi
           } > body.md
 
@@ -78,12 +111,14 @@ jobs:
           branch: chore/openapi-drift
           title: 'chore: upstream OpenAPI spec drift'
           body-path: body.md
-          commit-message: 'chore: refresh vendored OpenAPI specs'
-          add-paths: specs
+          commit-message: 'chore: refresh vendored OpenAPI specs and regenerate types'
+          add-paths: |
+            specs
+            src/services/generated
           delete-branch: true
 
-      - name: Fail if the contract broke
-        if: steps.contract.outcome == 'failure'
+      - name: Fail if either check broke
+        if: steps.contract.outcome == 'failure' || steps.typecheck.outcome == 'failure'
         run: |
           echo "::error::An upstream service changed a field an adapter reads."
           exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -399,9 +399,11 @@ config edit must not log you out of the page you are editing from.
 
 `specs/*.json` are upstream OpenAPI documents, refreshed by `npm run specs:fetch`
 and regenerated into `src/services/generated/` by `npm run codegen`. Both are
-committed. A nightly workflow re-fetches them and opens a PR when upstream
-changes, so **review `specs/` in that diff** — the generated files are output,
-not source, and are not meant to be read by hand.
+committed, and they move together — a spec refreshed without a regeneration
+leaves the types describing an API that no longer exists. A nightly workflow
+does both and opens a PR when either changes, so **review `specs/` in that
+diff** — the generated files are output, not source, and are not meant to be
+read by hand.
 
 Radarr, Sonarr, Prowlarr, Jellyfin and Seerr are generated. Bazarr, SABnzbd and
 Transmission publish no usable spec and are hand-written against recorded
@@ -410,9 +412,11 @@ fixtures.
 ### The nightly compatibility check
 
 The same workflow runs `test/contract.test.ts` against the freshly fetched
-specs, so it can tell an upstream change that breaks this project from one that
-does not. A red run means a field an adapter reads is no longer declared; the
-PR body names it.
+specs and `npm run typecheck` against the types regenerated from them, so it
+can tell an upstream change that breaks this project from one that does not.
+The two catch different halves: the contract test, a field an adapter reads
+that is no longer declared; the typecheck, one that changed shape under a
+mapper. A red run means either; the PR body names the failing entries.
 
 The PR is opened with the default `GITHUB_TOKEN`, which GitHub refuses to let
 trigger other workflows, so it arrives with no status checks. Close and reopen

--- a/scripts/codegen.mjs
+++ b/scripts/codegen.mjs
@@ -16,8 +16,9 @@
 //    TypeScript 6 never meet.
 //
 //    That is sound because this tool is not part of the shipped artefact. Its
-//    *output* is committed and reviewed, CI never runs codegen, and a version
-//    bump is a visible diff rather than a silent runtime change.
+//    *output* is committed and reviewed, only the nightly drift workflow runs
+//    it, and a version bump is a visible diff rather than a silent runtime
+//    change.
 import { execFileSync } from 'node:child_process';
 import { mkdirSync } from 'node:fs';
 


### PR DESCRIPTION
The nightly drift job commits `specs` alone, so the generated types keep
describing the previous version of an API until someone notices. #148 shipped
that way: the refreshed spec dropped the `sync` and `enable` query params from
`GET /settings/{plex,jellyfin}/library` and added the endpoints that replaced
them, while `src/services/generated/seerr.ts` went on declaring the old shape.
Nothing outside the generated file calls those paths, so it was harmless — this
time.

- **Codegen runs in the job**, and `add-paths` covers `src/services/generated`
  alongside `specs`.
- **The drift check widened to both paths.** A spec committed by hand without a
  regeneration is now caught too: the specs come back unchanged, the regenerated
  types do not, and the PR that reconciles them opens on its own.
- **Typecheck runs against the regenerated types.** The contract test reads the
  specs and catches a field an adapter reads that is no longer *declared*;
  nothing caught one that changed *shape* under a mapper still compiling against
  the old type. It is `continue-on-error` for the same reason the contract check
  is — the PR must still open, carrying the bad news — and the body names
  whichever failed.

## Verification

`npm run lint`, `npm run typecheck` and `npm test` (70 files, 1565 tests) pass.
`npm run codegen` against the current specs is a no-op, so the widened drift
check does not fire on today's tree.

The `Summarise` script was run locally across all four contract/typecheck
outcome combinations against sample logs; each renders the intended body, and
the `tsc` grep picks up the error lines without the npm preamble.

One thing to watch on the first nightly run after this merges: the committed
types were generated on Node 26 and the job runs Node 24. If `openapi-typescript`
output turns out to vary between them, the first run will open a PR whose diff is
pure churn. It self-stabilises after that one merge, since every later run
regenerates on Node 24 too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
