### PR TITLE
fix: close credential leakage paths

### DIFF
--- a/scripts/capture-fixtures.ts
+++ b/scripts/capture-fixtures.ts
@@ -23,20 +23,7 @@ import {
     type AuthStrategy
 } from '../src/core/auth.ts';
 import { ServiceHttp } from '../src/core/http.ts';
-import { hostsOf, redactHosts, secretsOf } from './lib/redact.ts';
-
-const REDACTED = '__REDACTED__';
-
-/**
- * `session[-_]id` is not a credential — Transmission hands one to any client
- * that asks, and that handshake is the whole point. It is redacted anyway for
- * two reasons: it rotates, so leaving it in produces a spurious diff on every
- * recapture, and it looks exactly like a secret to anyone reading the fixture.
- * The adapter reads the session id from the response *header*, never the body,
- * so nothing depends on the recorded value.
- */
-const SECRET_KEY =
-    /^(api_?key|apikey|token|access_?token|auth_?token|password|passwd|secret|nzb_?key|session[-_]?id)$/i;
+import { hostsOf, redact, redactHosts, secretsOf } from './lib/redact.ts';
 
 /**
  * `path` may be a function when the endpoint needs an id from something
@@ -437,43 +424,12 @@ function strategyFor(id: ServiceId, service: NonNullable<Config['services'][Serv
     return apiKeyHeader('X-Api-Key', key);
 }
 
-const ANONYMOUS_HOST = 'service.example.test';
-
-// `hostsOf` and `secretsOf` are shared with `integration.ts`
-// (`scripts/lib/redact.ts`) — all three scripts need the same "every host the
-// user configured" and "every credential" lists, and a second hand-written
-// copy is exactly the kind of drift this phase exists to eliminate.
-
-/**
- * Private and loopback IPv4 literals, for addresses a service reports about
- * *itself* rather than ones we configured — Jellyfin's `LocalAddress` is its
- * Docker bridge address, which no host substitution would ever match.
- *
- * Restricted to RFC1918, loopback and link-local on purpose. A blanket IPv4
- * pattern would rewrite version strings; scoping it to ranges that cannot be a
- * version number keeps that impossible. Replaced with TEST-NET-1, which is
- * reserved for documentation.
- */
-const PRIVATE_IPV4 =
-    /\b(?:10\.\d{1,3}\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3})\b/g;
-
-function redact(node: unknown, secrets: string[], hosts: string[]): unknown {
-    if (typeof node === 'string') {
-        const withoutSecrets = secrets.reduce((acc, secret) => acc.split(secret).join(REDACTED), node);
-        const withoutHosts = hosts.reduce((acc, host) => acc.split(host).join(ANONYMOUS_HOST), withoutSecrets);
-        return withoutHosts.replace(PRIVATE_IPV4, '192.0.2.10');
-    }
-    if (Array.isArray(node)) return node.map(v => redact(v, secrets, hosts));
-    if (node !== null && typeof node === 'object') {
-        return Object.fromEntries(
-            Object.entries(node).map(([key, value]) => [
-                key,
-                SECRET_KEY.test(key) && value !== null && value !== '' ? REDACTED : redact(value, secrets, hosts)
-            ])
-        );
-    }
-    return node;
-}
+// `hostsOf`, `secretsOf` and `redact` live in `scripts/lib/redact.ts`, shared
+// with `integration.ts` — all three scripts need the same "every host the user
+// configured" and "every credential" lists, and a second hand-written copy is
+// exactly the kind of drift this phase exists to eliminate. They are also the
+// only code standing between a live credential and a public repository, which
+// is why they are tested (`test/scriptsRedact.test.ts`) rather than inlined.
 
 const configDir = process.env.ARR_MCP_CAPTURE_CONFIG ?? './config';
 // `persist: false` — capturing fixtures reads the user's config; it must never

--- a/scripts/capture-fixtures.ts
+++ b/scripts/capture-fixtures.ts
@@ -23,7 +23,7 @@ import {
     type AuthStrategy
 } from '../src/core/auth.ts';
 import { ServiceHttp } from '../src/core/http.ts';
-import { hostsOf, redactHosts } from './lib/redact.ts';
+import { hostsOf, redactHosts, secretsOf } from './lib/redact.ts';
 
 const REDACTED = '__REDACTED__';
 
@@ -439,23 +439,10 @@ function strategyFor(id: ServiceId, service: NonNullable<Config['services'][Serv
 
 const ANONYMOUS_HOST = 'service.example.test';
 
-// `hostsOf` is shared with `integration.ts` (`scripts/lib/redact.ts`) — both
-// scripts need the same "every host the user configured" list, one to
-// anonymise fixture files, the other to keep a live error message off the
-// terminal, and a second hand-written copy is exactly the kind of drift this
-// phase exists to eliminate.
-
-/** Every configured credential, so the post-write scan can look for them exactly. */
-function secretsOf(config: Config): string[] {
-    const out: string[] = [];
-    for (const service of Object.values(config.services)) {
-        if (service === undefined) continue;
-        const s = service as { api_key?: string; password?: string };
-        if (s.api_key) out.push(s.api_key);
-        if (s.password) out.push(s.password);
-    }
-    return out;
-}
+// `hostsOf` and `secretsOf` are shared with `integration.ts`
+// (`scripts/lib/redact.ts`) — all three scripts need the same "every host the
+// user configured" and "every credential" lists, and a second hand-written
+// copy is exactly the kind of drift this phase exists to eliminate.
 
 /**
  * Private and loopback IPv4 literals, for addresses a service reports about

--- a/scripts/integration.ts
+++ b/scripts/integration.ts
@@ -37,7 +37,7 @@ import { WriteAudit } from '../src/core/audit.ts';
 import { LogStore } from '../src/core/logs.ts';
 import { Runtime } from '../src/core/runtime.ts';
 import { TOOL_NAMES } from '../src/tools/register.ts';
-import { hostsOf, redactHosts } from './lib/redact.ts';
+import { hostsOf, redactHosts, secretsOf } from './lib/redact.ts';
 
 type ToolName = (typeof TOOL_NAMES)[number];
 type Case = { tool: ToolName; args: Record<string, unknown> };
@@ -635,9 +635,10 @@ async function checkUi(): Promise<void> {
 
     await check('no API key is ever rendered into the configuration form', async () => {
         const body = await (await authed('/ui/config')).text();
-        const keys = Object.values(config.services)
-            .map(s => (s as { api_key?: string } | undefined)?.api_key)
-            .filter((k): k is string => typeof k === 'string' && k.length > 0);
+        // Through `secretsOf` so named instances are covered: the flat cast
+        // here contributed no keys for them, and one flat service was enough
+        // to satisfy the `length > 0` guard and report green.
+        const keys = secretsOf(config);
         return keys.length > 0 && keys.every(k => !body.includes(k));
     });
 }

--- a/scripts/lib/redact.ts
+++ b/scripts/lib/redact.ts
@@ -10,6 +10,7 @@
  * maintainer's terminal, so any raw error text they print is passed through
  * `redactHosts` first.
  */
+import { listInstances } from '../../src/config/instances.ts';
 import type { Config } from '../../src/config/schema.ts';
 
 const PLACEHOLDER = '<configured-host>';
@@ -17,13 +18,16 @@ const PLACEHOLDER = '<configured-host>';
 /**
  * Every host the user configured — hostname and host:port both, longest
  * first so `10.0.0.1:7878` is replaced before the bare `10.0.0.1` inside it.
+ *
+ * Through `listInstances` because bazarr, radarr and sonarr may each be a list
+ * of named instances: reading `.url` off the raw value skipped every one of
+ * them, and the catch below hid that it had.
  */
 export function hostsOf(config: Config): string[] {
     const out = new Set<string>();
-    for (const service of Object.values(config.services)) {
-        if (service === undefined) continue;
+    for (const instance of listInstances(config)) {
         try {
-            const url = new URL((service as { url: string }).url);
+            const url = new URL(instance.config.url);
             out.add(url.host);
             out.add(url.hostname);
         } catch {
@@ -31,6 +35,17 @@ export function hostsOf(config: Config): string[] {
         }
     }
     return [...out].sort((a, b) => b.length - a.length);
+}
+
+/** Every configured credential, so a post-write scan can look for them exactly. */
+export function secretsOf(config: Config): string[] {
+    const out: string[] = [];
+    for (const instance of listInstances(config)) {
+        const service = instance.config as { api_key?: string; password?: string };
+        if (service.api_key) out.push(service.api_key);
+        if (service.password) out.push(service.password);
+    }
+    return out;
 }
 
 /** Replaces every configured host with a placeholder, wherever it appears in `text`. */

--- a/scripts/lib/redact.ts
+++ b/scripts/lib/redact.ts
@@ -52,3 +52,47 @@ export function secretsOf(config: Config): string[] {
 export function redactHosts(text: string, hosts: readonly string[]): string {
     return hosts.reduce((acc, host) => acc.split(host).join(PLACEHOLDER), text);
 }
+
+export const REDACTED = '__REDACTED__';
+export const ANONYMOUS_HOST = 'service.example.test';
+
+/**
+ * `session[-_]id` is not a credential — Transmission hands one to any client
+ * that asks, and that handshake is the whole point. It is redacted anyway for
+ * two reasons: it rotates, so leaving it in produces a spurious diff on every
+ * recapture, and it looks exactly like a secret to anyone reading the fixture.
+ * The adapter reads the session id from the response *header*, never the body,
+ * so nothing depends on the recorded value.
+ */
+export const SECRET_KEY =
+    /^(api_?key|apikey|token|access_?token|auth_?token|password|passwd|secret|nzb_?key|session[-_]?id)$/i;
+
+/**
+ * Private and loopback IPv4 literals, for addresses a service reports about
+ * *itself* rather than ones we configured. Restricted to RFC1918, loopback and
+ * link-local on purpose: a blanket IPv4 pattern would rewrite version strings,
+ * and scoping it to ranges that cannot be a version number keeps that
+ * impossible. Replaced with TEST-NET-1, reserved for documentation.
+ */
+export const PRIVATE_IPV4 =
+    /\b(?:10\.\d{1,3}\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3})\b/g;
+
+/** Secrets by exact value, configured hosts by exact value, then private IPv4
+ *  literals by shape — recursively, so a nested credential cannot survive. */
+export function redact(node: unknown, secrets: string[], hosts: string[]): unknown {
+    if (typeof node === 'string') {
+        const withoutSecrets = secrets.reduce((acc, secret) => acc.split(secret).join(REDACTED), node);
+        const withoutHosts = hosts.reduce((acc, host) => acc.split(host).join(ANONYMOUS_HOST), withoutSecrets);
+        return withoutHosts.replace(PRIVATE_IPV4, '192.0.2.10');
+    }
+    if (Array.isArray(node)) return node.map(v => redact(v, secrets, hosts));
+    if (node !== null && typeof node === 'object') {
+        return Object.fromEntries(
+            Object.entries(node).map(([key, value]) => [
+                key,
+                SECRET_KEY.test(key) && value !== null && value !== '' ? REDACTED : redact(value, secrets, hosts)
+            ])
+        );
+    }
+    return node;
+}

--- a/src/core/audit.ts
+++ b/src/core/audit.ts
@@ -71,12 +71,20 @@ CREATE INDEX IF NOT EXISTS write_audit_service ON write_audit (service, at DESC)
  *  rather than by everyone remembering. */
 const SECRET_KEY = /(api[_-]?key|token|password|secret|authorization)/i;
 
-function safeArgs(args: Record<string, unknown>): string {
-    const clean: Record<string, unknown> = {};
-    for (const [key, value] of Object.entries(args)) {
-        clean[key] = SECRET_KEY.test(key) ? '__REDACTED__' : value;
+/** Recursive: matching key names only at the top level left a secret one
+ *  level down to be serialised verbatim. */
+const scrub = (value: unknown): unknown => {
+    if (Array.isArray(value)) return value.map(scrub);
+    if (value !== null && typeof value === 'object') {
+        return Object.fromEntries(
+            Object.entries(value).map(([key, v]) => [key, SECRET_KEY.test(key) ? '__REDACTED__' : scrub(v)])
+        );
     }
-    return JSON.stringify(clean);
+    return value;
+};
+
+function safeArgs(args: Record<string, unknown>): string {
+    return JSON.stringify(scrub(args));
 }
 
 /**

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -138,7 +138,9 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
         const passOk = auth.password_hash !== undefined && verifyPassword(password, auth.password_hash);
 
         if (!nameOk || !passOk) {
-            logger.warn({ ip: ipOf(c), username }, 'rejected config UI sign-in');
+            // No username: this field routinely catches a password typed into
+            // the wrong box, and the record is rendered at /ui/logs.
+            logger.warn({ ip: ipOf(c) }, 'rejected config UI sign-in');
             return c.html(loginPage({ version, error: 'Wrong username or password.', theme: theme() }), 401);
         }
 

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -161,10 +161,15 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
     // a session predating a credential reset must not outlive it.
     const guard = (c: Context): string | undefined => (unclaimed() ? undefined : sessionOf(c, runtime));
 
+    // Every page behind `guard` sends `cache-control: no-store`. The dashboard
+    // renders the MCP bearer token into its own HTML, and signing out does not
+    // invalidate a cached copy of it.
+
     app.get('/', c => c.redirect(guard(c) === undefined ? entry() : '/ui', 302));
 
     app.get('/ui', async c => {
         if (guard(c) === undefined) return c.redirect(entry(), 302);
+        c.header('cache-control', 'no-store');
 
         const snapshot = runtime.current;
 
@@ -203,6 +208,7 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
 
     app.get('/ui/logs', c => {
         if (guard(c) === undefined) return c.redirect(entry(), 302);
+        c.header('cache-control', 'no-store');
 
         const { stream, minLevel, service } = logQuery(c, logs);
         const url = `/ui/logs.json?stream=${stream}&service=${encodeURIComponent(service ?? '')}`;
@@ -233,6 +239,7 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
 
     app.get('/ui/audit', c => {
         if (guard(c) === undefined) return c.redirect(entry(), 302);
+        c.header('cache-control', 'no-store');
         return c.html(auditPage({ version, rows: audit.recent(300) as AuditRow[], theme: theme() }));
     });
 
@@ -275,6 +282,7 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
     app.get('/ui/config', async c => {
         const session = guard(c);
         if (session === undefined) return c.redirect(entry(), 302);
+        c.header('cache-control', 'no-store');
         return c.html(
             configPage({
                 version,

--- a/test/audit.test.ts
+++ b/test/audit.test.ts
@@ -120,3 +120,40 @@ describe('write audit', () => {
         expect(row?.args).not.toContain('hunter2');
     });
 });
+
+/**
+ * The redactor matched key names at the top level only, so a secret one level
+ * down was serialised into a durable row verbatim. The module's stated goal is
+ * that no write tool can leak one "by construction".
+ */
+describe('argument redaction', () => {
+    it('redacts a secret nested inside an object argument', () => {
+        const trail = open();
+        trail.begin(record({ args: { options: { api_key: 'supersecret' } } }));
+
+        const [row] = trail.recent() as Row[];
+        expect(row?.args).not.toContain('supersecret');
+        expect(row?.args).toContain('__REDACTED__');
+    });
+
+    it('redacts a secret nested inside an array argument', () => {
+        const trail = open();
+        trail.begin(record({ args: { items: [{ token: 'supersecret' }] } }));
+
+        expect((trail.recent() as Row[])[0]?.args).not.toContain('supersecret');
+    });
+
+    it('still redacts a secret at the top level', () => {
+        const trail = open();
+        trail.begin(record({ args: { api_key: 'supersecret' } }));
+
+        expect((trail.recent() as Row[])[0]?.args).not.toContain('supersecret');
+    });
+
+    it('leaves non-secret nested values intact', () => {
+        const trail = open();
+        trail.begin(record({ args: { options: { quality: 'HD-1080p' } } }));
+
+        expect((trail.recent() as Row[])[0]?.args).toContain('HD-1080p');
+    });
+});

--- a/test/configUi.test.ts
+++ b/test/configUi.test.ts
@@ -1504,3 +1504,29 @@ describe('the IMDb dataset in the config UI', () => {
         expect(runtime.config.metadata).toBeUndefined();
     });
 });
+
+/**
+ * The dashboard renders the MCP bearer token into its own HTML. /ui/logs.json
+ * already sends no-store; the pages carrying the credential sent nothing, so
+ * they persisted in disk cache and bfcache after a sign-out.
+ */
+describe('authenticated page caching', () => {
+    it('sends no-store on the dashboard, which renders the bearer token', async () => {
+        await signIn();
+        const res = await call('/ui');
+        expect(await res.text()).toContain(BEARER); // the premise: the token really is in the page
+        expect(res.headers.get('cache-control')).toBe('no-store');
+    });
+
+    it('sends no-store on every authenticated page', async () => {
+        await signIn();
+        for (const path of ['/ui', '/ui/logs', '/ui/audit', '/ui/config']) {
+            expect((await call(path)).headers.get('cache-control'), path).toBe('no-store');
+        }
+    });
+
+    it('does not send no-store on the stylesheet, which is cacheable and reveals nothing', async () => {
+        cookie = '';
+        expect((await call('/ui/app.css')).headers.get('cache-control')).not.toBe('no-store');
+    });
+});

--- a/test/configUi.test.ts
+++ b/test/configUi.test.ts
@@ -8,6 +8,7 @@ import { ConfigSchema } from '../src/config/schema.ts';
 import { WriteAudit } from '../src/core/audit.ts';
 import { LogStore } from '../src/core/logs.ts';
 import { Runtime } from '../src/core/runtime.ts';
+import { attachLogStore, detachLogStore } from '../src/core/logger.ts';
 import { hashPassword } from '../src/core/session.ts';
 import { buildMcpConfig } from '../src/web/routes.ts';
 
@@ -151,6 +152,28 @@ describe('access control', () => {
         expect(res.status).toBe(401);
         // Naming which half was wrong would confirm valid usernames.
         expect(await res.text()).toContain('Wrong username or password');
+    });
+
+    // The username field routinely catches a password typed into the wrong
+    // box, and this record is rendered at /ui/logs and in `docker logs`.
+    //
+    // `attachLogStore` is what routes logger output into the store — without
+    // it `recent()` is empty and the assertion below cannot fail, which is how
+    // this test first passed against the unfixed route.
+    it('does not log the attempted username when a sign-in is rejected', async () => {
+        cookie = '';
+        const typo = 'hunter2-typed-in-the-wrong-box';
+
+        attachLogStore(logs);
+        try {
+            await call('/ui/login', form({ username: typo, password: 'nope' }));
+        } finally {
+            detachLogStore();
+        }
+
+        const written = JSON.stringify(logs.recent({ limit: 50 }));
+        expect(written).toContain('rejected config UI sign-in'); // the premise: the store saw it
+        expect(written).not.toContain(typo);
     });
 
     it('signs in and reaches the dashboard', async () => {

--- a/test/fixtures.test.ts
+++ b/test/fixtures.test.ts
@@ -1,12 +1,12 @@
 import { readFile, readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
+// The same pattern the capture script redacts with, not a second copy: the two
+// had already drifted, and the guard silently stopped covering session ids.
+import { SECRET_KEY } from '../scripts/lib/redact.ts';
 
 const FIXTURES = join(import.meta.dirname, 'fixtures');
 const REDACTED = '__REDACTED__';
-
-/** Key names whose value must always be the placeholder. */
-const SECRET_KEY = /^(api_?key|apikey|token|access_?token|auth_?token|password|passwd|secret|nzb_?key)$/i;
 
 /**
  * Values long enough to be a credential rather than an identifier.
@@ -122,6 +122,11 @@ describe('committed fixtures', () => {
 });
 
 describe('the guard itself', () => {
+    it('flags a session id, which the capture script also redacts', () => {
+        expect(scan('t', { 'session-id': 'abc123' })).toHaveLength(1);
+        expect(scan('t', { session_id: 'abc123' })).toHaveLength(1);
+    });
+
     it('flags a secret-named key holding a real value', () => {
         expect(scan('t', { indexers: [{ apiKey: 'abc123' }] })).toHaveLength(1);
     });

--- a/test/scriptsRedact.test.ts
+++ b/test/scriptsRedact.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { ConfigSchema } from '../src/config/schema.ts';
 import { classifyFetchError } from '../src/core/errors.ts';
-import { hostsOf, redactHosts } from '../scripts/lib/redact.ts';
+import { hostsOf, redactHosts, secretsOf } from '../scripts/lib/redact.ts';
 
 const TOKEN = 'a'.repeat(64);
 
@@ -9,6 +9,23 @@ const configWith = (url: string) =>
     ConfigSchema.parse({
         auth: { bearer_token: TOKEN, password_hash: 'scrypt$00$11' },
         services: { radarr: { url, api_key: 'k' } }
+    });
+
+/**
+ * The shape the flat `(service as { url: string }).url` cast could not see:
+ * radarr as a *list* of named instances. Every host and key below was invisible
+ * to redaction, so the refuse-to-write gate had nothing to match on.
+ */
+const multiInstanceConfig = () =>
+    ConfigSchema.parse({
+        auth: { bearer_token: TOKEN, password_hash: 'scrypt$00$11' },
+        services: {
+            radarr: [
+                { name: 'hd', url: 'http://192.168.1.20:7878', api_key: 'hdkey' },
+                { name: '4k', url: 'http://192.168.1.21:7878', api_key: 'fourkkey' }
+            ],
+            sabnzbd: { url: 'http://192.168.1.30:8080', api_key: 'sabkey' }
+        }
     });
 
 describe('hostsOf', () => {
@@ -20,6 +37,38 @@ describe('hostsOf', () => {
     it('sorts longest first, so a host:port match wins before the bare hostname inside it', () => {
         const hosts = hostsOf(configWith('http://192.168.1.20:7878'));
         expect(hosts.indexOf('192.168.1.20:7878')).toBeLessThan(hosts.indexOf('192.168.1.20'));
+    });
+
+    it('extracts the host of every instance of a multi-instance service', () => {
+        expect(hostsOf(multiInstanceConfig())).toEqual(
+            expect.arrayContaining(['192.168.1.20:7878', '192.168.1.21:7878'])
+        );
+    });
+
+    it('still extracts hosts of single-block services alongside them', () => {
+        expect(hostsOf(multiInstanceConfig())).toEqual(expect.arrayContaining(['192.168.1.30:8080']));
+    });
+
+    it('redacts a message naming the second instance, which the flat cast missed entirely', () => {
+        expect(redactHosts('reached 192.168.1.21:7878', hostsOf(multiInstanceConfig()))).not.toContain('192.168.1.21');
+    });
+});
+
+describe('secretsOf', () => {
+    it('collects the api_key of every instance of a multi-instance service', () => {
+        expect(secretsOf(multiInstanceConfig())).toEqual(expect.arrayContaining(['hdkey', 'fourkkey']));
+    });
+
+    it('collects credentials of single-block services alongside them', () => {
+        expect(secretsOf(multiInstanceConfig())).toContain('sabkey');
+    });
+
+    it('collects a password as well as an api_key', () => {
+        const config = ConfigSchema.parse({
+            auth: { bearer_token: TOKEN, password_hash: 'scrypt$00$11' },
+            services: { transmission: { url: 'http://10.0.0.5:9091', username: 'u', password: 'pw' } }
+        });
+        expect(secretsOf(config)).toContain('pw');
     });
 });
 

--- a/test/scriptsRedact.test.ts
+++ b/test/scriptsRedact.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { ConfigSchema } from '../src/config/schema.ts';
 import { classifyFetchError } from '../src/core/errors.ts';
-import { hostsOf, redactHosts, secretsOf } from '../scripts/lib/redact.ts';
+import { hostsOf, redact, redactHosts, secretsOf } from '../scripts/lib/redact.ts';
 
 const TOKEN = 'a'.repeat(64);
 
@@ -98,5 +98,57 @@ describe('redactHosts', () => {
 
         expect(err.message).toContain('192.168.1.20:7878'); // the premise: it really is embedded
         expect(redactHosts(err.message, hostsOf(config))).not.toContain('192.168.1.20');
+    });
+});
+
+/**
+ * The pipeline that stands between a live credential and a public repository.
+ * It had no test at all: the review found the multi-instance hole above only
+ * by reading it, and nothing here would have caught a regression.
+ */
+describe('redact', () => {
+    const secrets = ['hdkey'];
+    const hosts = ['192.168.1.20:7878', '192.168.1.20'];
+
+    it('replaces an exact secret wherever it appears in a string', () => {
+        expect(redact('key=hdkey', secrets, hosts)).toBe('key=__REDACTED__');
+    });
+
+    it('replaces a value by key name even when the value was never in the config', () => {
+        expect(redact({ api_key: 'somethingelse' }, secrets, hosts)).toEqual({ api_key: '__REDACTED__' });
+    });
+
+    it('redacts a session id, which rotates and looks exactly like a credential', () => {
+        expect(redact({ 'session-id': 'abc' }, secrets, hosts)).toEqual({ 'session-id': '__REDACTED__' });
+    });
+
+    it('recurses into nested objects and arrays', () => {
+        expect(redact({ outer: [{ inner: { api_key: 'x' } }] }, secrets, hosts)).toEqual({
+            outer: [{ inner: { api_key: '__REDACTED__' } }]
+        });
+    });
+
+    it('rewrites a private IPv4 address that was never a configured host', () => {
+        expect(redact('seeded from 10.1.2.3', secrets, hosts)).toBe('seeded from 192.0.2.10');
+    });
+
+    it('leaves a version-shaped number alone, which a blanket IPv4 pattern would have eaten', () => {
+        expect(redact('version 4.0.14.2939', secrets, hosts)).toBe('version 4.0.14.2939');
+    });
+
+    it('replaces a configured host with the anonymous host', () => {
+        expect(redact('http://192.168.1.20:7878/api', secrets, hosts)).toContain('service.example.test');
+    });
+
+    it('leaves an empty or null value at a secret key alone, so shape is preserved', () => {
+        expect(redact({ api_key: '' }, secrets, hosts)).toEqual({ api_key: '' });
+        expect(redact({ api_key: null }, secrets, hosts)).toEqual({ api_key: null });
+    });
+
+    it('leaves ordinary values untouched', () => {
+        expect(redact({ title: 'The Fellowship of the Ring', year: 2001 }, secrets, hosts)).toEqual({
+            title: 'The Fellowship of the Ring',
+            year: 2001
+        });
     });
 });


### PR DESCRIPTION
Six fixes from an internal review pass, all in the same area: places where a
credential, host, or secret could outlive the moment it was needed.

## What changed

- **Host and secret redaction now sees named instances.** `hostsOf` and
  `secretsOf` read `.url`/`.api_key` off each raw `services` value, but bazarr,
  radarr and sonarr may each be a *list* of named instances. For those the cast
  yielded `undefined` and the `catch` written for unparsable URLs swallowed it,
  so no instance host or key reached the redaction list and `capture-fixtures`'
  refuse-to-write gate had nothing to match on. Both now go through
  `listInstances`, and `secretsOf` moved into `scripts/lib/redact.ts` so the
  capture script, the integration script and its config-form check share one
  implementation.

- **The redaction pipeline is now tested.** `redact()`, the private-IPv4
  rewrite and secret-key matching had no coverage despite being the only code
  between a live credential and this repository. Moved out of the top-level-await
  capture script so it can be imported, and covered.

- **The fixture guard and the capture script share one secret pattern.** They
  had drifted: capture redacts `session[-_]?id`, the guard did not.

- **Audit argument redaction recurses.** It matched key names at the top level
  only, so `{ options: { api_key: ... } }` reached a durable row verbatim.

- **A rejected sign-in no longer logs the attempted username.** That field
  routinely catches a password typed into the wrong box, and the record renders
  at `/ui/logs`. The success path still logs it.

- **Authenticated pages send `cache-control: no-store`.** `/ui/logs.json`
  already did; `/ui` renders the MCP bearer token into its own HTML and sent
  nothing.

## Verification

- `npm test` — 1623 passing (up from 1599; 24 new tests)
- `npm run typecheck`, `npm run lint` — clean
- `npm run integration` — exit 0, 41/41 (2 environmental skips: empty queue, no
  requests to preview against)
- Scanned every committed fixture for RFC1918 addresses and non-example
  hostnames: none. The redaction gap existed but never leaked into a fixture.

No user-facing behaviour or documented interface changes, so no README update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)