### PR TITLE
chore: keep lint working when a worktree is checked out

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,7 +8,12 @@ export default tseslint.config(
     // `tmp-config` is the gitignored scratch directory. It is not source, and
     // linting throwaway probe scripts only produces noise that hides real
     // errors in the output.
-    { ignores: ['dist', 'node_modules', 'coverage', 'src/services/generated', 'tmp-config'] },
+    // `.claude` holds git worktrees, each a full checkout with its own
+    // tsconfig.json. Without this, having one open fails the whole run with
+    // "No tsconfigRootDir was set, and multiple candidate TSConfigRootDirs are
+    // present" — a lint that breaks depending on what you have checked out
+    // elsewhere.
+    { ignores: ['dist', 'node_modules', 'coverage', 'src/services/generated', 'tmp-config', '.claude'] },
     js.configs.recommended,
     ...tseslint.configs.recommended,
     {


### PR DESCRIPTION
`.claude/worktrees/` holds git worktrees, each a full checkout carrying its own
`tsconfig.json`. With one open, `npm run lint` fails the entire run:

```
0:0  error  Parsing error: No tsconfigRootDir was set, and multiple candidate
            TSConfigRootDirs are present
```

That makes linting depend on what you have checked out somewhere else, which
is the kind of failure that gets worked around rather than fixed. Adding
`.claude` to the ignore list restores it.

## Verification

- `npm run lint` — exit 0 with three worktrees present; previously failed
- No source change

🤖 Generated with [Claude Code](https://claude.com/claude-code)