### PR TITLE
fix: run the IMDb ingest off the event loop

### DIFF
--- a/docs/imdb.md
+++ b/docs/imdb.md
@@ -35,6 +35,11 @@ IMDb's published files and keeps them in a local SQLite database beside the
 audit log. The first ingest takes a few minutes; every tool answers exactly as
 it did before until it lands, and the dashboard says when it has finished.
 
+The ingest runs in its own thread and writes to its own connection, so the
+server keeps answering throughout — reads see the previous dataset until the
+new one is committed, whole. That holds for the weekly refresh as much as the
+first one.
+
 ## What it costs
 
 Measured against the live dumps on 2026-08-10:

--- a/src/metadata/imdbDataset.ts
+++ b/src/metadata/imdbDataset.ts
@@ -74,6 +74,10 @@ const STORED_KINDS: ReadonlySet<string> = new Set([...Object.values(KIND_TO_IMDB
  */
 const VARIABLE_LIMIT = 900;
 
+/** `%`, `_` and the escape character itself, for a LIKE pattern built from
+ *  user input. Unescaped, `genre: "%"` matched every genre there is. */
+const escapeLike = (value: string): string => value.replace(/[\\%_]/g, m => `\\${m}`);
+
 export type RawTitle = {
     tconst: string;
     kind: string;
@@ -238,8 +242,8 @@ export class ImdbDataset {
         if (q.genre !== undefined) {
             // Genres ship as one comma-separated string. The commas on both
             // sides of the pattern are what stop "Drama" matching "Docudrama".
-            where.push(`(',' || LOWER(t.genres) || ',') LIKE ?`);
-            args.push(`%,${q.genre.toLowerCase()},%`);
+            where.push(`(',' || LOWER(t.genres) || ',') LIKE ? ESCAPE '\\'`);
+            args.push(`%,${escapeLike(q.genre.toLowerCase())},%`);
         }
         if (q.year !== undefined) {
             where.push('t.year = ?');

--- a/src/metadata/imdbDataset.ts
+++ b/src/metadata/imdbDataset.ts
@@ -144,8 +144,18 @@ export type DiscoverQuery = {
 export class ImdbDataset {
     readonly #db: Db;
 
-    private constructor(db: Db) {
+    /**
+     * Where the file lives, or `undefined` for an ephemeral one.
+     *
+     * The refresher needs it to hand the ingest to a worker thread: a
+     * better-sqlite3 handle cannot cross a thread boundary, so the worker
+     * opens its own connection to the same path.
+     */
+    readonly dir: string | undefined;
+
+    private constructor(db: Db, dir?: string) {
         this.#db = db;
+        this.dir = dir;
         // WAL for the reason audit.ts uses it: the weekly ingest writes while
         // tool calls read, and a reader must never block on a twenty-minute
         // rebuild.
@@ -191,7 +201,7 @@ export class ImdbDataset {
     }
 
     static open(dir: string): ImdbDataset {
-        return new ImdbDataset(new Database(join(dir, IMDB_FILENAME)));
+        return new ImdbDataset(new Database(join(dir, IMDB_FILENAME)), dir);
     }
 
     /** For tests: a real database, no file. */

--- a/src/metadata/ingestWorker.ts
+++ b/src/metadata/ingestWorker.ts
@@ -1,0 +1,26 @@
+/**
+ * The IMDb ingest, in its own thread.
+ *
+ * `replaceAll` is a synchronous better-sqlite3 transaction over millions of
+ * rows followed by a VACUUM. On the main thread that froze every tool call,
+ * connection test and web request for minutes, once a week — while `refresh.ts`
+ * promised "several minutes of normal service, not a container that looks
+ * broken". That was true of the download half only.
+ *
+ * This opens its **own** connection to the same file, because a better-sqlite3
+ * handle cannot cross a thread boundary. The database is in WAL mode, so the
+ * main thread keeps answering from the pre-transaction snapshot until this
+ * commits.
+ */
+import { workerData } from 'node:worker_threads';
+import { ImdbDataset } from './imdbDataset.ts';
+import { ingestOnce } from './refresh.ts';
+
+const { dir, baseUrl } = workerData as { dir: string; baseUrl?: string };
+
+const dataset = ImdbDataset.open(dir);
+try {
+    await ingestOnce(dataset, baseUrl === undefined ? {} : { baseUrl });
+} finally {
+    dataset.close();
+}

--- a/src/metadata/refresh.ts
+++ b/src/metadata/refresh.ts
@@ -50,6 +50,13 @@ export const REFRESH_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000;
 export const STAGING_PREFIX = 'arr-mcp-imdb-';
 
 /**
+ * Generous, because these are hundreds of megabytes over whatever connection
+ * the user has — but bounded, because every other network call in this project
+ * is. Without it a hung socket wedged the refresh until the process restarted.
+ */
+export const DOWNLOAD_TIMEOUT_MS = 30 * 60 * 1000;
+
+/**
  * How long a staging directory must have gone untouched before it counts as
  * abandoned rather than in use.
  *
@@ -123,7 +130,7 @@ export function sweepStaging(root: string, opts: { now?: number } = {}): number 
  * be finished with before the write begins.
  */
 async function downloadTo(baseUrl: string, file: string, path: string): Promise<void> {
-    const res = await fetch(`${baseUrl}/${file}`);
+    const res = await fetch(`${baseUrl}/${file}`, { signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS) });
     if (!res.ok || res.body === null) {
         // Names the file: "HTTP 404" alone would not say which of them, and they
         // fail independently.
@@ -223,6 +230,47 @@ export async function ingestOnce(dataset: ImdbDataset, opts: { baseUrl?: string 
 }
 
 /**
+ * Where the worker's entry point is, resolved at runtime.
+ *
+ * `tsc` rewrites `.ts` to `.js` in *import specifiers*, but this is a string
+ * inside `new URL(...)`, which it leaves alone. `npm run dev` runs the .ts
+ * sources directly and the image runs the compiled .js, so the extension is
+ * taken from whichever of the two this module itself is.
+ */
+const workerEntry = (): URL =>
+    new URL(import.meta.url.endsWith('.ts') ? './ingestWorker.ts' : './ingestWorker.js', import.meta.url);
+
+/**
+ * One ingest, off the event loop.
+ *
+ * `replaceAll` is a synchronous transaction over millions of rows plus a
+ * VACUUM, so running it here froze every tool call and web request for minutes
+ * — see `ingestWorker.ts`. A worker cannot be handed the open handle, so it
+ * opens its own connection to the same file; WAL is what lets the main thread
+ * keep reading meanwhile.
+ *
+ * An ephemeral dataset has no file for a second connection to open, so it runs
+ * in-process. That is every test that does not specifically exercise the
+ * worker.
+ */
+export async function runIngest(dataset: ImdbDataset, opts: { baseUrl?: string } = {}): Promise<void> {
+    if (dataset.dir === undefined) return ingestOnce(dataset, opts);
+
+    const { Worker } = await import('node:worker_threads');
+    const worker = new Worker(workerEntry(), {
+        workerData: { dir: dataset.dir, ...(opts.baseUrl === undefined ? {} : { baseUrl: opts.baseUrl }) }
+    });
+
+    await new Promise<void>((resolve, reject) => {
+        worker.once('error', reject);
+        worker.once('exit', code => {
+            if (code === 0) resolve();
+            else reject(new Error(`the IMDb ingest worker exited with code ${code}`));
+        });
+    });
+}
+
+/**
  * Start the weekly refresh, returning a function that stops it.
  *
  * Runs once immediately, then on the interval — which is what makes switching
@@ -234,19 +282,47 @@ export async function ingestOnce(dataset: ImdbDataset, opts: { baseUrl?: string 
  * minutes of normal service, not a container that looks broken — every tool
  * answers exactly as before until the first ingest lands.
  */
-export function startRefresh(dataset: ImdbDataset, opts: { baseUrl?: string } = {}): () => void {
+export function startRefresh(
+    dataset: ImdbDataset,
+    opts: {
+        baseUrl?: string;
+        /** Seams, for tests: the default reaches the network and spawns a
+         *  worker, and the default interval is a week. */
+        ingest?: (dataset: ImdbDataset, o: { baseUrl?: string }) => Promise<void>;
+        intervalMs?: number;
+    } = {}
+): () => void {
+    const ingest = opts.ingest ?? runIngest;
+    const ingestOpts = opts.baseUrl === undefined ? {} : { baseUrl: opts.baseUrl };
+
+    // An ingest takes minutes and the interval is a week, so an overlap means
+    // something is already wrong — but two of them sharing one staging sweep
+    // and one database is worse than skipping a beat.
+    let running = false;
+
     const run = (): void => {
-        ingestOnce(dataset, opts).catch((err: unknown) => {
-            // A failed refresh keeps the previous dataset, so this is a degraded
-            // answer rather than an outage — it warns instead of becoming an
-            // unhandled rejection that would take the process down over a 503.
-            logger.warn({ err }, 'IMDb dataset refresh failed; keeping the previous one');
-        });
+        if (running) {
+            logger.warn('an IMDb refresh is still running; skipping this one');
+            return;
+        }
+        running = true;
+
+        ingest(dataset, ingestOpts)
+            .catch((err: unknown) => {
+                // A failed refresh keeps the previous dataset, so this is a
+                // degraded answer rather than an outage — it warns instead of
+                // becoming an unhandled rejection that would take the process
+                // down over a 503.
+                logger.warn({ err }, 'IMDb dataset refresh failed; keeping the previous one');
+            })
+            .finally(() => {
+                running = false;
+            });
     };
 
     run();
 
-    const timer = setInterval(run, REFRESH_INTERVAL_MS);
+    const timer = setInterval(run, opts.intervalMs ?? REFRESH_INTERVAL_MS);
     // Unreffed so a pending refresh never holds the process open at shutdown.
     timer.unref();
 

--- a/test/imdbDataset.test.ts
+++ b/test/imdbDataset.test.ts
@@ -275,3 +275,25 @@ describe('replacing the dataset', () => {
         expect(store.ratingsFor(['tt0903747']).get('tt0903747')).toBe(9.5);
     });
 });
+
+/**
+ * The genre goes into a LIKE pattern, so an unescaped `%` or `_` made a filter
+ * that could not fail to match. Local read-only data, so this is a correctness
+ * wrinkle rather than an injection — but a filter that matches everything is
+ * worse than one that matches nothing.
+ */
+describe('genre wildcards', () => {
+    it('does not let a wildcard genre match everything', () => {
+        const db = seed();
+        expect(db.discover({ kind: 'movie', limit: 50 }).length).toBeGreaterThan(0); // the premise
+        expect(db.discover({ kind: 'movie', genre: '%', limit: 50 })).toHaveLength(0);
+    });
+
+    it('does not let a single-character wildcard match a real genre', () => {
+        expect(seed().discover({ kind: 'movie', genre: 'dram_', limit: 50 })).toHaveLength(0);
+    });
+
+    it('still matches a real genre exactly', () => {
+        expect(seed().discover({ kind: 'movie', genre: 'Drama', limit: 50 }).length).toBeGreaterThan(0);
+    });
+});

--- a/test/imdbRefresh.test.ts
+++ b/test/imdbRefresh.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import { createGzip } from 'node:zlib';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ImdbDataset } from '../src/metadata/imdbDataset.ts';
-import { ingestOnce, linesOf } from '../src/metadata/refresh.ts';
+import { ingestOnce, linesOf, startRefresh } from '../src/metadata/refresh.ts';
 
 /**
  * The one file that touches the network, driven against a stubbed `fetch`
@@ -148,5 +148,64 @@ describe('reading a staged dump', () => {
         const gen = linesOf(write('a\nb\nc'));
         expect(gen.next().value).toBe('a');
         gen.return(undefined);
+    });
+});
+
+describe('the weekly schedule', () => {
+    /**
+     * `setInterval` fired regardless of whether the previous ingest had
+     * finished, so two of them could share one staging sweep and one database.
+     */
+    it('does not start a second ingest while the first is still running', async () => {
+        let started = 0;
+        let release: (() => void) | undefined;
+        const blocked = new Promise<void>(resolve => {
+            release = resolve;
+        });
+
+        const stop = startRefresh({ dir: undefined } as unknown as ImdbDataset, {
+            ingest: async () => {
+                started += 1;
+                await blocked;
+            },
+            intervalMs: 5
+        });
+
+        await new Promise(r => setTimeout(r, 60));
+        expect(started).toBe(1);
+
+        release?.();
+        stop();
+        await blocked;
+    });
+
+    it('starts the next one once the previous has finished', async () => {
+        let started = 0;
+        const stop = startRefresh({ dir: undefined } as unknown as ImdbDataset, {
+            ingest: async () => {
+                started += 1;
+            },
+            intervalMs: 5
+        });
+
+        await new Promise(r => setTimeout(r, 60));
+        stop();
+        expect(started).toBeGreaterThan(1);
+    });
+
+    // A failing ingest must not wedge the guard shut for ever.
+    it('clears the guard when an ingest fails', async () => {
+        let started = 0;
+        const stop = startRefresh({ dir: undefined } as unknown as ImdbDataset, {
+            ingest: async () => {
+                started += 1;
+                throw new Error('nope');
+            },
+            intervalMs: 5
+        });
+
+        await new Promise(r => setTimeout(r, 60));
+        stop();
+        expect(started).toBeGreaterThan(1);
     });
 });

--- a/test/imdbWorker.test.ts
+++ b/test/imdbWorker.test.ts
@@ -1,0 +1,97 @@
+import { readFileSync } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { createServer, type Server } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { gzipSync } from 'node:zlib';
+import { afterEach, describe, expect, it } from 'vitest';
+import { ImdbDataset } from '../src/metadata/imdbDataset.ts';
+import { runIngest } from '../src/metadata/refresh.ts';
+
+/**
+ * The worker path, end to end.
+ *
+ * A real HTTP server rather than a stubbed `fetch`: the ingest runs in another
+ * thread, which has its own globals, so `vi.stubGlobal` reaches nothing. That
+ * is also the point of the test — proving the work really left this thread.
+ */
+
+const fixture = (name: string): Buffer =>
+    gzipSync(readFileSync(join(import.meta.dirname, 'fixtures', 'imdb', name)));
+
+const servingDumps = async (): Promise<{ url: string; close: () => Promise<void> }> => {
+    const bodies: Record<string, Buffer> = {
+        'title.basics.tsv.gz': fixture('title.basics.tsv'),
+        'title.ratings.tsv.gz': fixture('title.ratings.tsv')
+    };
+
+    const server: Server = createServer((req, res) => {
+        const name = (req.url ?? '').split('/').pop() ?? '';
+        const body = bodies[name];
+        if (body === undefined) {
+            res.writeHead(404).end();
+            return;
+        }
+        res.writeHead(200, { 'content-type': 'application/gzip' }).end(body);
+    });
+
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    const port = typeof address === 'object' && address !== null ? address.port : 0;
+
+    return {
+        url: `http://127.0.0.1:${port}`,
+        close: () => new Promise<void>(resolve => server.close(() => resolve()))
+    };
+};
+
+let cleanup: (() => Promise<void>)[] = [];
+afterEach(async () => {
+    for (const fn of cleanup) await fn();
+    cleanup = [];
+});
+
+describe('ingesting through a worker', () => {
+    it('writes the dataset without blocking the event loop', async () => {
+        const dir = await mkdtemp(join(tmpdir(), 'arr-mcp-imdb-worker-'));
+        const dataset = ImdbDataset.open(dir);
+        const server = await servingDumps();
+        cleanup.push(async () => {
+            dataset.close();
+            await server.close();
+            await rm(dir, { recursive: true, force: true });
+        });
+
+        // A timer that only advances if the main thread is still turning over.
+        let ticks = 0;
+        const ticker = setInterval(() => {
+            ticks += 1;
+        }, 2);
+
+        await runIngest(dataset, { baseUrl: server.url });
+        clearInterval(ticker);
+
+        expect(ticks).toBeGreaterThan(0);
+        expect(dataset.status().titles).toBeGreaterThan(0);
+        expect(dataset.status().ratings).toBeGreaterThan(0);
+    });
+
+    it('reports a failure in the worker rather than swallowing it', async () => {
+        const dir = await mkdtemp(join(tmpdir(), 'arr-mcp-imdb-worker-'));
+        const dataset = ImdbDataset.open(dir);
+        cleanup.push(async () => {
+            dataset.close();
+            await rm(dir, { recursive: true, force: true });
+        });
+
+        // Nothing listening, so the download fails inside the worker.
+        await expect(runIngest(dataset, { baseUrl: 'http://127.0.0.1:1' })).rejects.toThrow();
+    });
+
+    it('runs in-process for an ephemeral dataset, which has no file to share', async () => {
+        const dataset = ImdbDataset.ephemeral();
+        cleanup.push(async () => dataset.close());
+
+        expect(dataset.dir).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Three findings in `src/metadata/`. The first is the largest change in the
review set.

## The ingest no longer freezes the server

`replaceAll` is a synchronous better-sqlite3 transaction over ~12M parsed rows
— two large `DELETE`s, ~2M inserts — followed by a `VACUUM`, and it ran on the
event loop in the process serving MCP. Every tool call, connection test and web
request stalled for the duration, once a week. `refresh.ts` promised "several
minutes of normal service, not a container that looks broken"; that was true of
the download half only.

It now runs in a `node:worker_threads` worker with its own connection to the
same file, because a better-sqlite3 handle cannot cross a thread boundary. The
database was **already in WAL mode**, so the main thread keeps answering from
the pre-transaction snapshot until the worker commits — the single-transaction
atomicity the store deliberately relies on is unchanged, and readers never see
a half-replaced dataset.

An ephemeral dataset has no file for a second connection to open, so it runs
in-process. That is every existing test.

### Two traps worth naming

- **The worker path is tested against a real HTTP server**, not the stubbed
  `fetch` the other refresh tests use. A worker has its own globals and never
  sees `vi.stubGlobal`, so a stubbed test would have proved nothing. The test
  also ticks a timer during the ingest to assert the main thread kept running.
- **`tsc` rewrites `.ts` to `.js` in import specifiers, but not inside
  `new URL(...)`.** The entry path is resolved from `import.meta.url` at
  runtime so it works both under `npm run dev` (TS sources) and in the image
  (compiled JS). `npm run build` is part of the verification below precisely
  because that is where this would have broken silently.

## Also

- **The download is bounded** with `AbortSignal.timeout` — it was the only
  network call in the project without one, so a hung socket wedged the refresh
  until the process restarted.
- **Overlapping refreshes are refused.** `setInterval` fired regardless of
  whether the previous ingest had finished, so two could share one staging
  sweep and one database. The guard clears on failure too.
- **The discover genre filter escapes LIKE wildcards.** `genre: "%"` matched
  every genre and `dram_` matched `drama` — local read-only data, so a
  correctness wrinkle rather than an injection, but a filter that cannot fail
  to match is worse than one that matches nothing.

## Verification

- `npm test` — 1669 passing (71 files, 9 new tests)
- `npm run build` — emits `dist/src/metadata/ingestWorker.js`, and the emitted
  `refresh.js` resolves it correctly
- `npm run typecheck`, `npx eslint src test scripts`, `npm run integration` —
  all exit 0
- Each new regression test confirmed to fail with the fix reverted
- `docs/imdb.md` updated: staying responsive during the ingest is now a real
  property rather than an aspiration

🤖 Generated with [Claude Code](https://claude.com/claude-code)