### PR TITLE
fix: harden the HTTP and transport boundary

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -243,6 +243,10 @@ so far.
   and a signed, expiring session cookie (12 hours). It is a bigger target than
   the MCP endpoint, because it displays every service's API key and can change
   them.
+- `/ui/login` throttles itself after 5 free failed attempts, then delays each
+  further one with a growing backoff capped at 5 minutes. The counter is
+  global rather than per-IP — deliberate, since nothing validates the client's
+  claimed address.
 - Sessions end when you end them: signing out revokes that token, and changing
   the password revokes every session issued before it. Neither waits for the
   cookie to expire or for a restart.

--- a/docs/security.md
+++ b/docs/security.md
@@ -250,6 +250,10 @@ so far.
   the same reason: a security setting that appears to have applied when it has
   not is the worst kind.
 
+Request bodies are capped at 4 MB, refused with `413` before authentication
+runs. The cap is deliberately not configurable — every legitimate request is
+orders of magnitude below it.
+
 **What it does not solve.** There is no OAuth, no per-client identity, and no
 scoping of one token differently from another. One operator, one token. TLS is
 the reverse proxy's job; arr-mcp speaks plain HTTP and says so.

--- a/scripts/integration.ts
+++ b/scripts/integration.ts
@@ -514,7 +514,7 @@ async function checkUi(): Promise<void> {
     // maintainer's claim state instead of the login flow.
     const password = 'integration-only-not-persisted';
     const { hashPassword } = await import('../src/core/session.ts');
-    const uiConfig = { ...config, auth: { ...config.auth, password_hash: hashPassword(password) } };
+    const uiConfig = { ...config, auth: { ...config.auth, password_hash: await hashPassword(password) } };
     const uiRuntime = Runtime.fromConfig(uiConfig, WriteAudit.ephemeral(), { configDir: CONFIG_DIR });
     const uiApp = buildApp({ runtime: uiRuntime, audit: WriteAudit.ephemeral(), logs: LogStore.ephemeral() });
 

--- a/scripts/multi-instance-check.ts
+++ b/scripts/multi-instance-check.ts
@@ -205,7 +205,10 @@ console.log(`\n     search_media reported service labels: ${serviceLabels.join('
 
 const { hashPassword } = await import('../src/core/session.ts');
 const password = 'multi-instance-check-not-persisted';
-const uiApp = appFor({ ...multiConfig, auth: { ...multiConfig.auth, password_hash: hashPassword(password) } });
+const uiApp = appFor({
+    ...multiConfig,
+    auth: { ...multiConfig.auth, password_hash: await hashPassword(password) }
+});
 
 const signIn = await uiApp.request('http://localhost:6060/ui/login', {
     method: 'POST',

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,7 @@
 import { createMcpHonoApp } from '@modelcontextprotocol/hono';
 import { McpServer, createMcpHandler } from '@modelcontextprotocol/server';
 import { Hono, type Context } from 'hono';
+import { bodyLimit } from 'hono/body-limit';
 import type { WriteAudit } from './core/audit.ts';
 import { logger } from './core/logger.ts';
 import type { LogStore } from './core/logs.ts';
@@ -15,6 +16,13 @@ import { registerWebRoutes } from './web/routes.ts';
 
 const NAME = 'arr-mcp';
 const VERSION = process.env.ARR_MCP_VERSION ?? '0.0.0-dev';
+
+/**
+ * A tool call is a few kilobytes and the largest legitimate body is a config
+ * form. Not configurable: the only reason to raise it would be to work around
+ * a problem that is never actually this.
+ */
+const MAX_BODY_BYTES = 4 * 1024 * 1024;
 
 /**
  * What the whole server is, said once.
@@ -95,6 +103,29 @@ export function buildApp(opts: { runtime: Runtime; audit: WriteAudit; logs: LogS
      * the only position from which the refusal can be JSON. See `jsonBody.ts`.
      */
     const app = new Hono();
+    // First, ahead of `claimJsonBody` and therefore ahead of the Host
+    // allowlist and the bearer check below: both body parsers buffer the whole
+    // request, so an unauthenticated peer could otherwise spend our memory.
+    app.use(
+        '*',
+        bodyLimit({
+            maxSize: MAX_BODY_BYTES,
+            onError: c =>
+                c.json(
+                    {
+                        jsonrpc: '2.0',
+                        id: null,
+                        error: {
+                            // Invalid Request, not -32700: the body was never
+                            // parsed, so calling it a parse error is wrong.
+                            code: -32600,
+                            message: `Request body exceeds the ${MAX_BODY_BYTES} byte limit.`
+                        }
+                    },
+                    413
+                )
+        })
+    );
     app.use('*', claimJsonBody);
     app.route('/', transport);
 

--- a/src/core/auth.ts
+++ b/src/core/auth.ts
@@ -168,6 +168,11 @@ async function qbittorrentLogin(
         throw new ServiceError('AuthFailed', 'qbittorrent', 'the login request failed', { cause: err });
     }
 
+    // Read before the status check, not after: a banned client sees 403 on
+    // every future login, and skipping this on that path would leak one
+    // pinned connection per attempt for as long as the ban lasts.
+    const body = (await response.text()).trim();
+
     if (response.status === 403) {
         throw new ServiceError('AuthFailed', 'qbittorrent', 'login refused', {
             remedy: 'qBittorrent bans a client after repeated failed logins. Wait, or clear the ban in Options → Web UI.'
@@ -176,7 +181,6 @@ async function qbittorrentLogin(
 
     // A wrong password is HTTP 200 with the body "Fails.", so the status line
     // alone would read as a successful login that set no cookie.
-    const body = (await response.text()).trim();
     if (!response.ok || body !== 'Ok.') {
         throw new ServiceError('AuthFailed', 'qbittorrent', `login returned "${body || response.status}"`, {
             remedy: 'Check username and password against Options → Web UI in qBittorrent.'

--- a/src/core/http.ts
+++ b/src/core/http.ts
@@ -241,9 +241,9 @@ export class ServiceHttp {
         }
 
         let recovered = false;
-        if (allowRecovery && this.#auth.recover !== undefined) {
+        if (allowRecovery) {
             try {
-                recovered = (await this.#auth.recover(response)) === true;
+                recovered = (await this.#auth.recover?.(response)) === true;
             } catch (err) {
                 // A recover that throws leaves the original response unread on
                 // every other path out of this function.

--- a/src/core/http.ts
+++ b/src/core/http.ts
@@ -240,7 +240,19 @@ export class ServiceHttp {
             throw classifyFetchError(err, this.#id, safeUrl);
         }
 
-        if (allowRecovery && (await this.#auth.recover?.(response)) === true) {
+        let recovered = false;
+        if (allowRecovery && this.#auth.recover !== undefined) {
+            try {
+                recovered = (await this.#auth.recover(response)) === true;
+            } catch (err) {
+                // A recover that throws leaves the original response unread on
+                // every other path out of this function.
+                await discard(response);
+                throw err;
+            }
+        }
+
+        if (recovered) {
             // Nothing will read this one — the retry below supersedes it — and
             // an unread body pins its keep-alive connection until GC. A burst
             // of Transmission 409s or qBittorrent 403s otherwise degraded

--- a/src/core/loginThrottle.ts
+++ b/src/core/loginThrottle.ts
@@ -13,8 +13,8 @@ export const FREE_ATTEMPTS = 5;
 
 const BASE_DELAY_MS = 1_000;
 
-/** The ceiling matters more than the growth: a permanent lockout of the only
- *  account is a worse outcome than a slow attacker. */
+/** Caps how long any one block lasts. A persistent attacker renews it
+ *  indefinitely, so this buys recovery once they stop, not a lockout ceiling. */
 const MAX_DELAY_MS = 5 * 60_000;
 
 export class LoginThrottle {
@@ -31,13 +31,16 @@ export class LoginThrottle {
         return Math.max(0, this.#blockedUntil - this.#now());
     }
 
-    recordFailure(): void {
+    /** Returns whether this call just entered (or re-entered) a block, so a
+     *  caller can log once per block rather than once per attempt. */
+    recordFailure(): boolean {
         this.#failures++;
-        if (this.#failures < FREE_ATTEMPTS) return;
+        if (this.#failures < FREE_ATTEMPTS) return false;
 
         const over = this.#failures - FREE_ATTEMPTS;
         const delay = Math.min(BASE_DELAY_MS * 2 ** over, MAX_DELAY_MS);
         this.#blockedUntil = this.#now() + delay;
+        return true;
     }
 
     recordSuccess(): void {

--- a/src/core/loginThrottle.ts
+++ b/src/core/loginThrottle.ts
@@ -1,0 +1,47 @@
+/**
+ * Failure backoff for the config UI sign-in.
+ *
+ * Global rather than per-IP on purpose. `x-forwarded-for` is the only address
+ * available and nothing validates it, so per-IP keying would let an attacker
+ * reset their own counter by rotating a header — and let them lock the
+ * operator out by forging the operator's address.
+ */
+
+/** Failures allowed before any delay. Generous: a mistyped password twice over
+ *  is ordinary, and the delay is not what stops a serious attacker anyway. */
+export const FREE_ATTEMPTS = 5;
+
+const BASE_DELAY_MS = 1_000;
+
+/** The ceiling matters more than the growth: a permanent lockout of the only
+ *  account is a worse outcome than a slow attacker. */
+const MAX_DELAY_MS = 5 * 60_000;
+
+export class LoginThrottle {
+    #failures = 0;
+    #blockedUntil = 0;
+    readonly #now: () => number;
+
+    constructor(now: () => number = Date.now) {
+        this.#now = now;
+    }
+
+    /** Milliseconds still to wait, or 0 when an attempt is allowed. */
+    blockedFor(): number {
+        return Math.max(0, this.#blockedUntil - this.#now());
+    }
+
+    recordFailure(): void {
+        this.#failures++;
+        if (this.#failures < FREE_ATTEMPTS) return;
+
+        const over = this.#failures - FREE_ATTEMPTS;
+        const delay = Math.min(BASE_DELAY_MS * 2 ** over, MAX_DELAY_MS);
+        this.#blockedUntil = this.#now() + delay;
+    }
+
+    recordSuccess(): void {
+        this.#failures = 0;
+        this.#blockedUntil = 0;
+    }
+}

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -1,4 +1,5 @@
-import { createHmac, randomBytes, scryptSync, timingSafeEqual } from 'node:crypto';
+import { createHmac, randomBytes, scrypt as scryptCallback, timingSafeEqual } from 'node:crypto';
+import { promisify } from 'node:util';
 
 /**
  * Password storage and browser sessions for the config UI.
@@ -16,6 +17,15 @@ import { createHmac, randomBytes, scryptSync, timingSafeEqual } from 'node:crypt
 const SCRYPT_N = 16_384;
 const KEY_LENGTH = 64;
 
+/** Async, not `scryptSync`: at N=16384 the sync form blocks the one thread the
+ *  MCP endpoint runs on, so a burst of logins stalls every tool call. */
+const scrypt = promisify(scryptCallback) as (
+    password: string,
+    salt: Buffer,
+    keylen: number,
+    options: { N: number }
+) => Promise<Buffer>;
+
 export const SESSION_COOKIE = 'arr_mcp_session';
 
 /** Long enough not to interrupt a config edit; short enough that a forgotten
@@ -27,13 +37,13 @@ const MAX_REVOKED = 1024;
 
 /** `scrypt$<saltHex>$<hashHex>`, so the format names its own algorithm and a
  *  future change can be detected rather than guessed. */
-export function hashPassword(password: string): string {
+export async function hashPassword(password: string): Promise<string> {
     const salt = randomBytes(16);
-    const hash = scryptSync(password, salt, KEY_LENGTH, { N: SCRYPT_N });
+    const hash = await scrypt(password, salt, KEY_LENGTH, { N: SCRYPT_N });
     return `scrypt$${salt.toString('hex')}$${hash.toString('hex')}`;
 }
 
-export function verifyPassword(password: string, stored: string): boolean {
+export async function verifyPassword(password: string, stored: string): Promise<boolean> {
     const [scheme, saltHex, hashHex] = stored.split('$');
     if (scheme !== 'scrypt' || saltHex === undefined || hashHex === undefined) return false;
 
@@ -45,7 +55,7 @@ export function verifyPassword(password: string, stored: string): boolean {
     }
     if (expected.length !== KEY_LENGTH) return false;
 
-    const actual = scryptSync(password, Buffer.from(saltHex, 'hex'), KEY_LENGTH, { N: SCRYPT_N });
+    const actual = await scrypt(password, Buffer.from(saltHex, 'hex'), KEY_LENGTH, { N: SCRYPT_N });
     return timingSafeEqual(actual, expected);
 }
 

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -17,8 +17,14 @@ import { promisify } from 'node:util';
 const SCRYPT_N = 16_384;
 const KEY_LENGTH = 64;
 
-/** Async, not `scryptSync`: at N=16384 the sync form blocks the one thread the
- *  MCP endpoint runs on, so a burst of logins stalls every tool call. */
+/**
+ * Async, not `scryptSync`: at N=16384 the sync form blocks the one thread the
+ * MCP endpoint runs on, so a burst of logins stalls every tool call.
+ *
+ * `SCRYPT_N` equals `crypto.scrypt`'s own default cost, so the cast's
+ * `options` field is currently belt-and-braces — it stops being redundant the
+ * day `SCRYPT_N` changes.
+ */
 const scrypt = promisify(scryptCallback) as (
     password: string,
     salt: Buffer,

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -3,6 +3,7 @@ import { saveConfig } from '../config/save.ts';
 import { ServiceIdSchema, ThemeSchema, type Config, type Theme } from '../config/schema.ts';
 import type { WriteAudit } from '../core/audit.ts';
 import { logger } from '../core/logger.ts';
+import { LoginThrottle } from '../core/loginThrottle.ts';
 import type { LogStore } from '../core/logs.ts';
 import type { Runtime } from '../core/runtime.ts';
 import {
@@ -144,6 +145,10 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
 
     // --- login ----------------------------------------------------------
 
+    // Per app, not per module: tests build many apps and must not share a
+    // counter, and a real deployment builds exactly one.
+    const loginThrottle = new LoginThrottle();
+
     app.get('/ui/login', c => {
         if (unclaimed()) return c.redirect('/ui/setup', 302);
         if (sessionOf(c, runtime) !== undefined) return c.redirect('/ui', 302);
@@ -152,6 +157,21 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
 
     app.post('/ui/login', async c => {
         if (unclaimed()) return c.redirect('/ui/setup', 302);
+
+        const waitMs = loginThrottle.blockedFor();
+        if (waitMs > 0) {
+            const seconds = Math.ceil(waitMs / 1000);
+            logger.warn({ ip: ipOf(c), seconds }, 'throttled config UI sign-in');
+            c.header('retry-after', String(seconds));
+            return c.html(
+                loginPage({
+                    version,
+                    error: `Too many failed attempts. Try again in ${seconds}s.`,
+                    theme: theme()
+                }),
+                429
+            );
+        }
 
         const form = await c.req.parseBody();
         const username = str(form.username);
@@ -166,12 +186,14 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
         const passOk = auth.password_hash !== undefined && (await verifyPassword(password, auth.password_hash));
 
         if (!nameOk || !passOk) {
+            loginThrottle.recordFailure();
             // No username: this field routinely catches a password typed into
             // the wrong box, and the record is rendered at /ui/logs.
             logger.warn({ ip: ipOf(c) }, 'rejected config UI sign-in');
             return c.html(loginPage({ version, error: 'Wrong username or password.', theme: theme() }), 401);
         }
 
+        loginThrottle.recordSuccess();
         const token = runtime.sessions.issue();
         c.header('set-cookie', sessionCookie(token, Math.floor(SESSION_TTL_MS / 1000)));
         logger.info({ ip: ipOf(c), username }, 'config UI sign-in');

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -126,7 +126,7 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
                 runtime.configDir,
                 {
                     ...runtime.config,
-                    auth: { ...runtime.config.auth, username, password_hash: hashPassword(password) }
+                    auth: { ...runtime.config.auth, username, password_hash: await hashPassword(password) }
                 },
                 { expected: runtime.config }
             );
@@ -163,7 +163,7 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
         // user tells an attacker which names exist. A missing hash must never
         // read as a valid login.
         const nameOk = username === auth.username;
-        const passOk = auth.password_hash !== undefined && verifyPassword(password, auth.password_hash);
+        const passOk = auth.password_hash !== undefined && (await verifyPassword(password, auth.password_hash));
 
         if (!nameOk || !passOk) {
             // No username: this field routinely catches a password typed into
@@ -352,7 +352,7 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
     const configMutation =
         (
             what: string,
-            next: (form: Record<string, unknown>) => Config | { ask: string },
+            next: (form: Record<string, unknown>) => Config | { ask: string } | Promise<Config | { ask: string }>,
             opts: {
                 /** The add form is a dialog, so a refusal has to bring it back —
                  *  a message about a form nobody can see explains nothing. */
@@ -408,7 +408,7 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
 
             let updated: Config;
             try {
-                const result = next(form);
+                const result = await next(form);
                 // Not an error: the removal is waiting for a second click.
                 if ('ask' in result) return render(undefined, 200, result.ask);
                 updated = result;
@@ -680,7 +680,7 @@ export function addCandidateFrom(
  */
 
 /** The Config UI's own credentials. Owns `username` and `password_hash`. */
-export function buildAccountConfig(current: Config, form: Record<string, unknown>): Config {
+export async function buildAccountConfig(current: Config, form: Record<string, unknown>): Promise<Config> {
     const username = str(form['auth.username']).trim();
     const password = str(form['auth.password']);
 
@@ -689,7 +689,7 @@ export function buildAccountConfig(current: Config, form: Record<string, unknown
     // this guard stops a blank password field on a config save from writing a
     // config with no hash — silently un-claiming a live instance and handing it
     // to whoever loads /ui/setup next.
-    const carriedHash = password === '' ? current.auth.password_hash : hashPassword(password);
+    const carriedHash = password === '' ? current.auth.password_hash : await hashPassword(password);
     if (carriedHash === undefined) {
         throw new Error('This instance has no password set yet. Reload the page and set one up.');
     }

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -122,14 +122,17 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
         // uses: `parseBody` and `saveConfig` both yield, so the check at the top
         // of this handler is not still true by the time the write lands.
         if (!unclaimed()) return c.redirect('/ui/login', 302);
+        // Captured before hashPassword yields, so a concurrent reload cannot
+        // make `expected` newer than the config this write was built from.
+        const expected = runtime.config;
         try {
             await saveConfig(
                 runtime.configDir,
                 {
-                    ...runtime.config,
-                    auth: { ...runtime.config.auth, username, password_hash: await hashPassword(password) }
+                    ...expected,
+                    auth: { ...expected.auth, username, password_hash: await hashPassword(password) }
                 },
-                { expected: runtime.config }
+                { expected }
             );
         } catch {
             // Someone else claimed it while this request was in flight.
@@ -161,7 +164,6 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
         const waitMs = loginThrottle.blockedFor();
         if (waitMs > 0) {
             const seconds = Math.ceil(waitMs / 1000);
-            logger.warn({ ip: ipOf(c), seconds }, 'throttled config UI sign-in');
             c.header('retry-after', String(seconds));
             return c.html(
                 loginPage({
@@ -171,6 +173,17 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
                 }),
                 429
             );
+        }
+
+        // Reserved before the first await, not after verifying: a burst of
+        // concurrent posts all read `blockedFor() === 0` before any of them
+        // resolves `verifyPassword`, so without this every one of them would
+        // reach the scrypt hash regardless of FREE_ATTEMPTS. A real login
+        // clears the reservation below, via `recordSuccess`.
+        const justBlocked = loginThrottle.recordFailure();
+        if (justBlocked) {
+            const seconds = Math.ceil(loginThrottle.blockedFor() / 1000);
+            logger.warn({ ip: ipOf(c), seconds }, 'throttled config UI sign-in');
         }
 
         const form = await c.req.parseBody();
@@ -186,7 +199,6 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
         const passOk = auth.password_hash !== undefined && (await verifyPassword(password, auth.password_hash));
 
         if (!nameOk || !passOk) {
-            loginThrottle.recordFailure();
             // No username: this field routinely catches a password typed into
             // the wrong box, and the record is rendered at /ui/logs.
             logger.warn({ ip: ipOf(c) }, 'rejected config UI sign-in');
@@ -395,6 +407,11 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
 
             const form = await c.req.parseBody();
 
+            // Captured before `next(form)` yields (`buildAccountConfig` awaits
+            // `hashPassword`), so a concurrent reload cannot make this newer
+            // than the config the form below was built from.
+            const expected = runtime.config;
+
             // Cards collapse by default, so the one you just submitted has to be
             // named or the page swallows the outcome of what you did. Absent on
             // an add, whose form carries no instance id — there is no card yet.
@@ -442,7 +459,7 @@ export function registerWebRoutes(app: Hono, deps: WebDeps): void {
                 // `expected` is the snapshot this page's form was built from,
                 // so a service hand-added to config.yaml since then is a
                 // refusal rather than a silent deletion under a "Saved" banner.
-                await saveConfig(runtime.configDir, updated, { expected: runtime.config });
+                await saveConfig(runtime.configDir, updated, { expected });
                 await runtime.reload();
 
                 if (opts.endsSessions?.(form) === true) {

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -767,10 +767,19 @@ describe('request body limit', () => {
     const oversized = 'x'.repeat(5 * 1024 * 1024);
 
     it('refuses an oversized body on /mcp before checking the token', async () => {
+        // With a declared Content-Length, hono/body-limit takes its early-return
+        // branch — the one `@hono/node-server` actually forwards the client's
+        // header into in production. No header (the other test below) exercises
+        // the streaming/counting branch instead; both need coverage.
+        const body = JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: { pad: oversized } });
         const res = await app().request('http://localhost:6060/mcp', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream' },
-            body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: { pad: oversized } })
+            headers: {
+                'Content-Type': 'application/json',
+                Accept: 'application/json, text/event-stream',
+                'Content-Length': String(Buffer.byteLength(body))
+            },
+            body
         });
 
         // 413 rather than 401: the point is that the limit runs first. A 401

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -17,9 +17,11 @@ const WRONG = 'b'.repeat(64);
 /** In-memory, so these tests never touch a config directory. */
 const audit = () => WriteAudit.ephemeral();
 
+const PASSWORD_HASH = await hashPassword('unused-here');
+
 const configWith = (over: Record<string, unknown> = {}): Config =>
     ConfigSchema.parse({
-        auth: { bearer_token: TOKEN, password_hash: hashPassword('unused-here'), ...over },
+        auth: { bearer_token: TOKEN, password_hash: PASSWORD_HASH, ...over },
         services: {}
     });
 
@@ -642,7 +644,7 @@ describe('every tool declares the shape it answers in', () => {
      * shape this is here to validate.
      */
     const writable = ConfigSchema.parse({
-        auth: { bearer_token: TOKEN, password_hash: hashPassword('unused-here') },
+        auth: { bearer_token: TOKEN, password_hash: PASSWORD_HASH },
         services: { radarr: { url: 'http://192.0.2.10:7878', api_key: 'k', permissions: { safe_write: true } } }
     });
 

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -758,3 +758,40 @@ describe('prompts and resources, beside the tools rather than instead of them', 
         expect(TOOL_NAMES.length).toBeLessThan(40);
     });
 });
+
+describe('request body limit', () => {
+    // Comfortably over the 4 MB cap without building a string so large the
+    // test itself is slow.
+    const oversized = 'x'.repeat(5 * 1024 * 1024);
+
+    it('refuses an oversized body on /mcp before checking the token', async () => {
+        const res = await app().request('http://localhost:6060/mcp', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream' },
+            body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: { pad: oversized } })
+        });
+
+        // 413 rather than 401: the point is that the limit runs first. A 401
+        // here would mean the body was buffered before it was rejected.
+        expect(res.status).toBe(413);
+        expect(res.headers.get('content-type')).toContain('application/json');
+        expect(await res.json()).toMatchObject({ error: { code: -32600 } });
+    });
+
+    it('refuses an oversized body on the login form', async () => {
+        const res = await app().request('http://localhost:6060/ui/login', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: `username=admin&password=${oversized}`
+        });
+        expect(res.status).toBe(413);
+    });
+
+    it('lets an ordinary tool call through', async () => {
+        const res = await app().request(
+            'http://localhost:6060/mcp',
+            rpc(toolsList, { Authorization: `Bearer ${TOKEN}` })
+        );
+        expect(res.status).toBe(200);
+    });
+});

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -143,6 +143,19 @@ describe('qbittorrentSession', () => {
         await expect(session({}, impl).recover?.(forbidden())).rejects.toThrow(/bans a client/i);
     });
 
+    // A banned client sees this 403 on every login attempt for the ban's
+    // duration, so leaving its body unread pins one connection per attempt.
+    it('reads the login response body even when the login itself is refused', async () => {
+        let loginResponse: Response | undefined;
+        const impl = (async () => {
+            loginResponse = new Response('', { status: 403 });
+            return loginResponse;
+        }) as unknown as typeof fetch;
+
+        await expect(session({}, impl).recover?.(forbidden())).rejects.toThrow(/bans a client/i);
+        expect(loginResponse?.bodyUsed).toBe(true);
+    });
+
     it('does not attempt a login when no credentials are configured', async () => {
         let called = false;
         const impl = (async () => {

--- a/test/configUi.test.ts
+++ b/test/configUi.test.ts
@@ -184,6 +184,29 @@ describe('access control', () => {
         expect(written).not.toContain(typo);
     });
 
+    it('blocks sign-in after repeated failures, and says so', async () => {
+        cookie = '';
+
+        for (let i = 0; i < 5; i++) {
+            const res = await call('/ui/login', form({ username: 'admin', password: 'wrong' }));
+            expect(res.status).toBe(401);
+        }
+
+        const blocked = await call('/ui/login', form({ username: 'admin', password: 'wrong' }));
+        expect(blocked.status).toBe(429);
+        expect(blocked.headers.get('retry-after')).not.toBeNull();
+    });
+
+    it('does not reveal which field was wrong', async () => {
+        cookie = '';
+
+        const badUser = await call('/ui/login', form({ username: 'nobody', password: 'wrong' }));
+        const badPass = await call('/ui/login', form({ username: 'admin', password: 'wrong' }));
+
+        expect(badUser.status).toBe(badPass.status);
+        expect(await badUser.text()).toBe(await badPass.text());
+    });
+
     it('signs in and reaches the dashboard', async () => {
         await signIn();
         const res = await call('/ui');

--- a/test/configUi.test.ts
+++ b/test/configUi.test.ts
@@ -22,6 +22,7 @@ import { buildMcpConfig } from '../src/web/routes.ts';
  */
 
 const PASSWORD = 'test-password-1234';
+const PASSWORD_HASH = await hashPassword(PASSWORD);
 const BEARER = 'a'.repeat(64);
 
 let dir: string;
@@ -60,7 +61,7 @@ const seed = async (extra = '') => {
     dir = await mkdtemp(join(tmpdir(), 'arr-mcp-ui-'));
     await writeFile(
         join(dir, 'config.yaml'),
-        `auth:\n  bearer_token: ${BEARER}\n  username: admin\n  password_hash: ${hashPassword(PASSWORD)}\n  allowed_hosts: []\nservices:${extra === '' ? ' {}' : `\n${extra}`}\n`,
+        `auth:\n  bearer_token: ${BEARER}\n  username: admin\n  password_hash: ${PASSWORD_HASH}\n  allowed_hosts: []\nservices:${extra === '' ? ' {}' : `\n${extra}`}\n`,
         'utf8'
     );
 
@@ -1003,7 +1004,7 @@ describe('each access card saves only itself', () => {
     const withDataset = async () => {
         await writeFile(
             join(dir, 'config.yaml'),
-            `auth:\n  bearer_token: ${BEARER}\n  username: admin\n  password_hash: ${hashPassword(PASSWORD)}\n  allowed_hosts: [${PINNED}]\nservices: {}\nmetadata:\n  imdb:\n    enabled: true\n`,
+            `auth:\n  bearer_token: ${BEARER}\n  username: admin\n  password_hash: ${PASSWORD_HASH}\n  allowed_hosts: [${PINNED}]\nservices: {}\nmetadata:\n  imdb:\n    enabled: true\n`,
             'utf8'
         );
         await runtime.reload();
@@ -1460,7 +1461,7 @@ describe('the IMDb dataset in the config UI', () => {
         await seed();
         await writeFile(
             join(dir, 'config.yaml'),
-            `auth:\n  bearer_token: ${BEARER}\n  username: admin\n  password_hash: ${hashPassword(PASSWORD)}\n  allowed_hosts: []\nservices: {}\nmetadata:\n  imdb:\n    enabled: true\n`,
+            `auth:\n  bearer_token: ${BEARER}\n  username: admin\n  password_hash: ${PASSWORD_HASH}\n  allowed_hosts: []\nservices: {}\nmetadata:\n  imdb:\n    enabled: true\n`,
             'utf8'
         );
         await runtime.reload();

--- a/test/configUi.test.ts
+++ b/test/configUi.test.ts
@@ -1,15 +1,17 @@
 import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { buildApp } from '../src/app.ts';
 import { loadConfig } from '../src/config/load.ts';
 import { ConfigSchema } from '../src/config/schema.ts';
 import { WriteAudit } from '../src/core/audit.ts';
 import { LogStore } from '../src/core/logs.ts';
+import { FREE_ATTEMPTS } from '../src/core/loginThrottle.ts';
 import { Runtime } from '../src/core/runtime.ts';
 import { attachLogStore, detachLogStore } from '../src/core/logger.ts';
 import { hashPassword } from '../src/core/session.ts';
+import * as session from '../src/core/session.ts';
 import { buildMcpConfig } from '../src/web/routes.ts';
 
 /**
@@ -195,6 +197,26 @@ describe('access control', () => {
         const blocked = await call('/ui/login', form({ username: 'admin', password: 'wrong' }));
         expect(blocked.status).toBe(429);
         expect(blocked.headers.get('retry-after')).not.toBeNull();
+    });
+
+    // Regression guard for the race the throttle exists to close: a burst of
+    // concurrent posts all read `blockedFor() === 0` before any of them
+    // resolves `verifyPassword`, so the reservation has to happen ahead of
+    // that await or the free-attempt count bounds nothing under concurrency.
+    it('reserves an attempt before verifying, so a concurrent burst cannot outrun the throttle', async () => {
+        cookie = '';
+        const spy = vi.spyOn(session, 'verifyPassword');
+        try {
+            const total = FREE_ATTEMPTS + 5;
+            await Promise.all(
+                Array.from({ length: total }, () =>
+                    call('/ui/login', form({ username: 'admin', password: 'wrong' }))
+                )
+            );
+            expect(spy.mock.calls.length).toBeLessThanOrEqual(FREE_ATTEMPTS);
+        } finally {
+            spy.mockRestore();
+        }
     });
 
     it('does not reveal which field was wrong', async () => {

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -492,3 +492,47 @@ describe('ServiceHttp body encoding and response reading', () => {
         expect(calls).toBe(2);
     });
 });
+
+describe('ServiceHttp recovery failures', () => {
+    it('cancels the failed response body when recover throws', async () => {
+        let cancelled = false;
+        const failed = new Response('denied', { status: 403 });
+        // Spying on the real body stream: `discard` calls `body.cancel()`, and
+        // an uncancelled body is what pins the connection.
+        const original = failed.body?.cancel.bind(failed.body);
+        if (failed.body !== null) {
+            failed.body.cancel = async (reason?: unknown) => {
+                cancelled = true;
+                return original?.(reason);
+            };
+        }
+
+        const boom = new Error('login refused');
+        const client = http(async () => failed, {
+            apply: () => {},
+            recover: async () => {
+                throw boom;
+            }
+        });
+
+        await expect(client.get('/api/v3/system/status')).rejects.toBe(boom);
+        expect(cancelled).toBe(true);
+    });
+
+    it('still discards an error response when recover declines', async () => {
+        let cancelled = false;
+        const failed = new Response('denied', { status: 403 });
+        const original = failed.body?.cancel.bind(failed.body);
+        if (failed.body !== null) {
+            failed.body.cancel = async (reason?: unknown) => {
+                cancelled = true;
+                return original?.(reason);
+            };
+        }
+
+        const client = http(async () => failed, { apply: () => {}, recover: async () => false });
+
+        await expect(client.get('/api/v3/system/status')).rejects.toThrow();
+        expect(cancelled).toBe(true);
+    });
+});

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -509,6 +509,7 @@ describe('ServiceHttp recovery failures', () => {
 
         const boom = new Error('login refused');
         const client = http(async () => failed, {
+            id: 'test-throw',
             apply: () => {},
             recover: async () => {
                 throw boom;
@@ -530,7 +531,7 @@ describe('ServiceHttp recovery failures', () => {
             };
         }
 
-        const client = http(async () => failed, { apply: () => {}, recover: async () => false });
+        const client = http(async () => failed, { id: 'test-decline', apply: () => {}, recover: async () => false });
 
         await expect(client.get('/api/v3/system/status')).rejects.toThrow();
         expect(cancelled).toBe(true);

--- a/test/loginThrottle.test.ts
+++ b/test/loginThrottle.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { FREE_ATTEMPTS, LoginThrottle } from '../src/core/loginThrottle.ts';
+
+/** Injected clock rather than fake timers: the throttle only ever asks what
+ *  time it is, so a counter is a truthful stand-in and the tests stay sync. */
+const at = (start = 0) => {
+    let now = start;
+    return { clock: () => now, advance: (ms: number) => (now += ms) };
+};
+
+describe('LoginThrottle', () => {
+    it('allows the first attempts without delay', () => {
+        const { clock } = at();
+        const throttle = new LoginThrottle(clock);
+        for (let i = 0; i < FREE_ATTEMPTS; i++) {
+            expect(throttle.blockedFor()).toBe(0);
+            throttle.recordFailure();
+        }
+    });
+
+    it('blocks once the free attempts are spent', () => {
+        const { clock } = at();
+        const throttle = new LoginThrottle(clock);
+        for (let i = 0; i < FREE_ATTEMPTS; i++) throttle.recordFailure();
+        expect(throttle.blockedFor()).toBeGreaterThan(0);
+    });
+
+    it('lengthens the block with each further failure', () => {
+        const { clock, advance } = at();
+        const throttle = new LoginThrottle(clock);
+        for (let i = 0; i < FREE_ATTEMPTS; i++) throttle.recordFailure();
+
+        const first = throttle.blockedFor();
+        advance(first);
+        expect(throttle.blockedFor()).toBe(0);
+
+        throttle.recordFailure();
+        expect(throttle.blockedFor()).toBeGreaterThan(first);
+    });
+
+    it('caps the block so a locked-out operator is not locked out forever', () => {
+        const { clock, advance } = at();
+        const throttle = new LoginThrottle(clock);
+        for (let i = 0; i < 40; i++) {
+            throttle.recordFailure();
+            advance(throttle.blockedFor());
+        }
+        throttle.recordFailure();
+        expect(throttle.blockedFor()).toBeLessThanOrEqual(5 * 60_000);
+    });
+
+    it('forgets the failures after a success', () => {
+        const { clock, advance } = at();
+        const throttle = new LoginThrottle(clock);
+        for (let i = 0; i < FREE_ATTEMPTS; i++) throttle.recordFailure();
+        advance(throttle.blockedFor());
+
+        throttle.recordSuccess();
+        for (let i = 0; i < FREE_ATTEMPTS; i++) {
+            expect(throttle.blockedFor()).toBe(0);
+            throttle.recordFailure();
+        }
+    });
+});

--- a/test/plainJson.test.ts
+++ b/test/plainJson.test.ts
@@ -24,8 +24,10 @@ import { acceptingBoth, acceptsStream, asPlainJson } from '../src/mcp/plainJson.
 
 const TOKEN = 'a'.repeat(64);
 
+const PASSWORD_HASH = await hashPassword('unused-here');
+
 const config: Config = ConfigSchema.parse({
-    auth: { bearer_token: TOKEN, password_hash: hashPassword('unused-here') },
+    auth: { bearer_token: TOKEN, password_hash: PASSWORD_HASH },
     services: {}
 });
 

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -12,31 +12,42 @@ import {
 } from '../src/core/session.ts';
 
 describe('password storage', () => {
-    it('accepts the right password', () => {
-        const stored = hashPassword('correct horse battery staple');
-        expect(verifyPassword('correct horse battery staple', stored)).toBe(true);
+    it('accepts the password it hashed', async () => {
+        const stored = await hashPassword('correct horse battery staple');
+        expect(await verifyPassword('correct horse battery staple', stored)).toBe(true);
     });
 
-    it('rejects the wrong one', () => {
-        const stored = hashPassword('correct horse');
-        expect(verifyPassword('wrong horse', stored)).toBe(false);
+    it('rejects a wrong password', async () => {
+        const stored = await hashPassword('correct horse');
+        expect(await verifyPassword('wrong horse', stored)).toBe(false);
     });
 
     // The password must not be recoverable from config.yaml, only replaceable.
-    it('never stores the password itself', () => {
-        const stored = hashPassword('hunter2');
+    it('never stores the password itself', async () => {
+        const stored = await hashPassword('hunter2');
         expect(stored).not.toContain('hunter2');
         expect(stored.startsWith('scrypt$')).toBe(true);
     });
 
-    it('salts, so the same password hashes differently every time', () => {
-        expect(hashPassword('same')).not.toBe(hashPassword('same'));
+    it('salts, so the same password hashes differently every time', async () => {
+        expect(await hashPassword('same')).not.toBe(await hashPassword('same'));
     });
 
-    it('rejects a malformed or truncated stored value rather than throwing', () => {
+    it('rejects a malformed or truncated stored value rather than throwing', async () => {
         for (const bad of ['', 'nonsense', 'scrypt$', 'scrypt$aa', 'bcrypt$aa$bb', 'scrypt$aa$bb']) {
-            expect(verifyPassword('x', bad), bad).toBe(false);
+            expect(await verifyPassword('x', bad), bad).toBe(false);
         }
+    });
+
+    it('does not block the event loop while hashing', async () => {
+        let ticked = false;
+        // A macrotask scheduled before the hash starts. With scryptSync it
+        // could not run until hashing finished; with async scrypt it does.
+        setTimeout(() => {
+            ticked = true;
+        }, 0);
+        await hashPassword('some password');
+        expect(ticked).toBe(true);
     });
 });
 


### PR DESCRIPTION
Three defects at the HTTP and auth boundary, each a case where a hostile or merely broken peer costs the process more than it should. None needed a config change to reach.

## 1. Unbounded request bodies, buffered before any authentication

`claimJsonBody` and the MCP adapter's own parser both buffered the whole request body with no cap, and both ran *above* the Host allowlist and the `/mcp` bearer check. Anything that could open a TCP connection to the port could spend the server's memory — a 2 GB JSON body on `POST /mcp` with no token was an OOM kill, available on repeat.

A 4 MB cap now mounts as the first middleware, ahead of `claimJsonBody`. The ordering is the whole point, so the test asserts a 413 on `/mcp` **with no Authorization header** — a future reordering turns that back into a 401. The refusal is JSON (`-32600`, not `-32700`: the body was never parsed at all).

## 2. `/ui/login` had no throttle, and scrypt blocked the event loop

`scryptSync` at N=16384 costs ~50 ms of blocked event loop, on the single thread the MCP endpoint shares. There was no lockout, and the default username is `admin`.

Hashing moved to async scrypt, and a failure backoff was added: five free attempts, then a growing delay capped at five minutes, with `retry-after`. The counter is **global rather than per-IP** on purpose — `ipOf` reads `x-forwarded-for` with no trusted-proxy list, so per-IP keying would let an attacker reset their own counter by rotating a header, and lock the real operator out by forging theirs.

The reservation is taken *before* the handler yields. Taking it after `await verifyPassword` left the throttle bypassable by concurrency: N simultaneous posts all observed zero and all reached scrypt, saturating the libuv threadpool that also serves `getaddrinfo` — stalling outbound DNS for every service call. A concurrency test covers it.

## 3. A throwing `recover()` leaked the failed response

`ServiceHttp` discarded the failed response when `recover()` returned false, and when it returned true, but not when it threw — pinning an undici keep-alive connection per attempt. `qbittorrentLogin` has three throw paths.

`qbittorrentLogin`'s own 403 path had the same leak and is fixed here too. It is the steady state of this scenario: repeated failures make qBittorrent ban the client, after which the *login* returns 403, so one connection leaked per request indefinitely.

## Also

- Two compare-and-swap windows in the config-save path were widened by the new awaits; the snapshot is now captured before yielding.
- Throttled attempts log once when the block is entered, not on every refusal — a free-to-trigger refusal that writes a log row lets an attacker evict the 5000-row ring in seconds.
- `docs/security.md` documents both the body cap and the throttle.

## Known edge case

A 5th attempt carrying the *correct* password trips the block transition: it logs a "throttled" line for a login that then succeeds, and for the ~50 ms until the counter clears, a concurrent request sees a spurious 429. Self-healing within the same request and not attacker-reachable — it needs the operator's own correct password after four of their own failures. Deliberately not fixed; the alternative is a second in-flight counter for a cleaner log line.

## Verification

`npm test` 1698/1698 exit 0 · `npm run typecheck` exit 0 · `npm run lint` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)