### PR TITLE
fix: keep /healthz reachable when allowed_hosts is pinned

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -178,6 +178,12 @@ export function buildApp(opts: { runtime: Runtime; audit: WriteAudit; logs: LogS
     app.use('*', claimJsonBody);
     app.route('/', transport);
 
+    // Ahead of the Host allowlist on purpose: the container probes
+    // `localhost:${ARR_MCP_PORT}`, a name nobody pinning a proxy hostname
+    // lists, so a gated `/healthz` is 403 for ever. It answers only a name and
+    // a version, both already public on the login page. Nothing else is exempt.
+    app.get('/healthz', c => c.json({ status: 'ok', name: NAME, version: VERSION }));
+
     /**
      * An empty list means "accept any Host", which is the right default for a
      * LAN container reached by IP — and the reason the adapter's own option
@@ -204,8 +210,6 @@ export function buildApp(opts: { runtime: Runtime; audit: WriteAudit; logs: LogS
         logger.warn({ host, ip: c.req.header('x-forwarded-for') ?? 'unknown' }, 'rejected request with an unlisted Host');
         return c.text('forbidden: Host not allowed', 403);
     });
-
-    app.get('/healthz', c => c.json({ status: 'ok', name: NAME, version: VERSION }));
 
     registerWebRoutes(app, { runtime, audit, logs, version: VERSION });
 

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -267,12 +267,15 @@ describe('the transport stays stateless', () => {
 });
 
 describe('DNS rebinding protection', () => {
+    // Probed through `/ui/app.css`, not `/healthz`: health sits ahead of the
+    // allowlist (see below), so it would pass whether the middleware worked or
+    // not. The stylesheet is unauthenticated but gated, so it reports honestly.
     it('serves requests when no hostnames are pinned', async () => {
         // Regression: the adapter gates its host-validation middleware on
         // `if (allowedHosts)`, and [] is truthy — passing an empty array
         // installs validation with an empty allow-list and 403s everything.
         // A container that rejects 100% of traffic looks healthy until used.
-        const res = await app().request('http://192.168.1.50:6060/healthz');
+        const res = await app().request('http://192.168.1.50:6060/ui/app.css');
         expect(res.status).toBe(200);
     });
 
@@ -282,15 +285,35 @@ describe('DNS rebinding protection', () => {
         // Hono's synthetic request helper does not derive a Host header from
         // the URL, so set it explicitly — the validator reads the header, not
         // the URL, and treats a missing one as invalid.
-        const allowed = await pinned.request('http://arr.example.com:6060/healthz', {
+        const allowed = await pinned.request('http://arr.example.com:6060/ui/app.css', {
             headers: { Host: 'arr.example.com:6060' }
         });
-        const foreign = await pinned.request('http://evil.example.com:6060/healthz', {
+        const foreign = await pinned.request('http://evil.example.com:6060/ui/app.css', {
             headers: { Host: 'evil.example.com:6060' }
         });
 
         expect(allowed.status).toBe(200); // port-agnostic match on the hostname
         expect(foreign.status).toBe(403);
+    });
+
+    /**
+     * The Dockerfile probes `localhost:${ARR_MCP_PORT}` — a name no operator
+     * pinning their reverse-proxy hostname would list. Behind the allowlist
+     * every probe 403s, the container is never healthy, and that stalls
+     * `depends_on: service_healthy` and restart-loops under autoheal.
+     */
+    it('keeps health reachable from an unlisted Host, so the container probe passes', async () => {
+        const pinned = appWith(configWith({ allowed_hosts: ['arr.example.com'] }));
+
+        const health = await pinned.request('http://localhost:6060/healthz', {
+            headers: { Host: 'localhost:6060' }
+        });
+        const gated = await pinned.request('http://localhost:6060/ui/app.css', {
+            headers: { Host: 'localhost:6060' }
+        });
+
+        expect(health.status).toBe(200);
+        expect(gated.status).toBe(403);
     });
 
     it('matches a bracketed IPv6 Host, with and without a port', async () => {
@@ -300,8 +323,10 @@ describe('DNS rebinding protection', () => {
         // web/origin.ts already parses this shape correctly.
         const pinned = appWith(configWith({ allowed_hosts: ['[fd00::1]'] }));
 
-        const withPort = await pinned.request('http://[fd00::1]:6060/healthz', { headers: { Host: '[fd00::1]:6060' } });
-        const withoutPort = await pinned.request('http://[fd00::1]/healthz', { headers: { Host: '[fd00::1]' } });
+        const withPort = await pinned.request('http://[fd00::1]:6060/ui/app.css', {
+            headers: { Host: '[fd00::1]:6060' }
+        });
+        const withoutPort = await pinned.request('http://[fd00::1]/ui/app.css', { headers: { Host: '[fd00::1]' } });
 
         expect(withPort.status).toBe(200);
         expect(withoutPort.status).toBe(200);

--- a/test/configUi.test.ts
+++ b/test/configUi.test.ts
@@ -1243,7 +1243,10 @@ describe('access settings', () => {
 });
 
 describe('allowed_hosts', () => {
-    const get = (host: string) => call('/healthz', { headers: { host } });
+    // `/ui/app.css`, not `/healthz`: health sits ahead of the allowlist so the
+    // container probe keeps working, so it would pass whether the pin applied
+    // or not. The stylesheet is unauthenticated but gated.
+    const get = (host: string) => call('/ui/app.css', { headers: { host } });
 
     it('accepts any Host when nothing is pinned', async () => {
         expect((await get('192.168.1.50:6060')).status).toBe(200);


### PR DESCRIPTION
-