### PR TITLE
feat: let the download clients and Prowlarr be configured more than once

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Thirty-four tools, but you never name them — you ask, and the model picks:
 | --- | --- |
 | **[Tools](docs/tools.md)** | All thirty-four, what each answers, and the fields whose meaning is not obvious |
 | **[Writes](docs/writes.md)** | Turning them on, the two tiers, and the preview-and-confirm handshake |
-| **[Configuration](docs/configuration.md)** | `config.yaml`, several Radarrs, Jellyfin's `default_user` |
+| **[Configuration](docs/configuration.md)** | `config.yaml`, the seven services that take a list, Jellyfin's `default_user` |
 | **[Config UI](docs/config-ui.md)** | The four pages, and what each does that is not obvious |
 | **[IMDb ratings](docs/imdb.md)** | The only way to get an IMDb score for a series, and what it costs |
 | **[Security](docs/security.md)** | The threat model, walked against the OWASP MCP Top 10, including what it does not solve |

--- a/docs/config-ui.md
+++ b/docs/config-ui.md
@@ -90,9 +90,9 @@ save is one the service actually knows rather than one you typed from memory. If
 the service does not answer, the field stays a plain text box and says so — you
 can always configure a service that is currently down.
 
-Adding a second Radarr, Sonarr or Bazarr asks you to name the one you already
-have, and says why: the name becomes part of the id, and that id is the
-permission key, the audit column, and what your agent passes. Removing an
+Adding a second instance of a service that takes several asks you to name the
+one you already have, and says why: the name becomes part of the id, and that id
+is the permission key, the audit column, and what your agent passes. Removing an
 instance asks once before it goes, because its API key is not recovered by
 re-adding it.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,7 +102,7 @@ reads.
 `get_library`'s per-user join needs exactly one counterparty, and the schema
 refuses a config that sets both.
 
-## Several Radarrs, Sonarrs or Bazarrs
+## Several instances of one service
 
 Running an HD and a 4K Radarr side by side is a common setup, and arr-mcp reads
 both. Give each one a name:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -144,10 +144,32 @@ is deliberate, and it only affects writes.
 a configuration you can express — each entry carries its own `permissions`
 block.
 
-Only Radarr, Sonarr and Bazarr take a list. The other five are one each:
-Prowlarr feeds every *arr from one place, Seerr connects to your instances
-itself, and a second download client is a different kind of setup from a quality
-tier.
+**Three services stay single.** Jellyfin and Plex because `get_library`'s
+`presence` asks whether the media server can see a file, and with two of them
+that question has no answer — which is also why the two cannot both be
+configured. Seerr because a request carries the identity of the person who made
+it, and a second Seerr makes "which one do I ask" a guess with an approver on
+the other end of it.
+
+Everything else takes a list: Radarr, Sonarr, Bazarr, Prowlarr, SABnzbd,
+Transmission and qBittorrent.
+
+Two download clients, one behind a VPN and one not:
+
+```yaml
+services:
+  qbittorrent:
+    - name: vpn
+      url: http://192.168.1.20:8081
+      username: admin
+      password: "…"
+    - name: direct
+      url: http://192.168.1.20:8082
+```
+
+`get_queue` reports both, each row saying which client it came from as
+`qbittorrent/vpn`. `pause_downloads` needs `instance` to say which one to stop —
+with two configured, omitting it is refused rather than guessed.
 
 ## Access
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -144,12 +144,10 @@ is deliberate, and it only affects writes.
 a configuration you can express — each entry carries its own `permissions`
 block.
 
-**Three services stay single.** Jellyfin and Plex because `get_library`'s
-`presence` asks whether the media server can see a file, and with two of them
-that question has no answer — which is also why the two cannot both be
-configured. Seerr because a request carries the identity of the person who made
-it, and a second Seerr makes "which one do I ask" a guess with an approver on
-the other end of it.
+**Three services stay single.** Jellyfin and Plex because, as explained above,
+`get_library`'s per-user join needs exactly one counterparty. Seerr because a
+request carries the identity of the person who made it, and a second Seerr makes
+"which one do I ask" a guess with an approver on the other end of it.
 
 Everything else takes a list: Radarr, Sonarr, Bazarr, Prowlarr, SABnzbd,
 Transmission and qBittorrent.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -66,6 +66,10 @@ Tools spanning several services also report which ones they could not reach, and
 how many results each contributed, so a long answer from one service can never
 silently hide another.
 
+`get_indexers` does the same across instances of one service: it merges every
+configured Prowlarr, each row naming the instance it came from, and one
+unreachable instance degrades by name rather than emptying the answer.
+
 `diagnose` takes a title, or an exact `service` plus `id`, and returns a verdict
 rather than a list. With several instances of a service configured it also takes
 `instance`, worded exactly as the write tools word it.

--- a/scripts/capture-fixtures.ts
+++ b/scripts/capture-fixtures.ts
@@ -605,6 +605,7 @@ function strategyFor(id: ServiceId, service: NonNullable<Config['services'][Serv
     if (id === 'qbittorrent') {
         const q = service as { url: string; timeout_ms: number; username?: string; password?: string };
         return qbittorrentSession({
+            id,
             url: q.url,
             timeoutMs: q.timeout_ms,
             ...(q.username === undefined ? {} : { username: q.username }),

--- a/scripts/multi-instance-check.ts
+++ b/scripts/multi-instance-check.ts
@@ -178,11 +178,15 @@ await run('diagnose over the doubled library', 'diagnose', { query: 'the' });
 // caught by the zero-total SKIP below.
 type FanOutContent = { total?: number; items?: { service?: string }[]; counts?: Record<string, number> };
 
-const checkFanOut = async (tool: 'get_queue' | 'get_indexers', types: readonly string[]) => {
+const checkFanOut = async (
+    tool: 'get_queue' | 'get_indexers',
+    types: readonly string[],
+    args: Record<string, unknown> = {}
+) => {
     if (types.length === 0) return;
 
-    const before = ((await callTool(single, token, tool, {})).structuredContent as FanOutContent | undefined)?.total;
-    const afterContent = (await callTool(multi, token, tool, {})).structuredContent as FanOutContent | undefined;
+    const before = ((await callTool(single, token, tool, args)).structuredContent as FanOutContent | undefined)?.total;
+    const afterContent = (await callTool(multi, token, tool, args)).structuredContent as FanOutContent | undefined;
     const after = afterContent?.total;
 
     if (typeof before !== 'number' || typeof after !== 'number') {
@@ -218,7 +222,10 @@ const checkFanOut = async (tool: 'get_queue' | 'get_indexers', types: readonly s
 };
 
 await checkFanOut('get_queue', downloadClientTypes);
-await checkFanOut('get_indexers', Array.isArray(multiConfig.services.prowlarr) ? ['prowlarr'] : []);
+// A merged indexer list clumps by service and is limit-bounded, so the
+// default limit of 50 can hold only the first instance's indexers on a large
+// Prowlarr. 500 is the schema max.
+await checkFanOut('get_indexers', Array.isArray(multiConfig.services.prowlarr) ? ['prowlarr'] : [], { limit: 500 });
 
 // --- 3. writes refuse to guess which instance -----------------------------
 
@@ -266,9 +273,11 @@ await expectRefusal(
 // --- 3a. the write path refuses ambiguity and scopes permissions ----------
 //
 // Looped over whichever download clients are configured, one type fully at a
-// time — never Promise.all across or within a type. qBittorrent bans a client
-// that bursts two logins at it, and two doubled adapters against one URL is
-// exactly that if these ever ran concurrently.
+// time, rather than Promise.all across or within a type. This section never
+// deliberately runs two logins against the same client concurrently — unlike
+// `get_queue` above, which fans out internally via `gather` and does. That's
+// fine: qBittorrent's ban counts failed logins, and two doubled adapters
+// logging in successfully at once does not trip it.
 
 for (const type of downloadClientTypes) {
     // Guessing which client to pause is the failure resolveInstance exists to

--- a/scripts/multi-instance-check.ts
+++ b/scripts/multi-instance-check.ts
@@ -25,9 +25,11 @@ const { config: real } = await loadConfig(CONFIG_DIR, { persist: false });
 const hosts = hostsOf(real);
 
 /** The same service twice, under two names. */
+const DOUBLED_TYPES = ['radarr', 'sonarr', 'sabnzbd', 'prowlarr', 'transmission', 'qbittorrent'] as const;
+
 function doubled(config: Config): Config {
     const services = { ...config.services } as Record<string, unknown>;
-    for (const type of ['radarr', 'sonarr'] as const) {
+    for (const type of DOUBLED_TYPES) {
         const block = services[type];
         if (block === undefined || Array.isArray(block)) continue;
         services[type] = [
@@ -66,11 +68,12 @@ const multi = appFor(multiConfig);
 const token = real.auth.bearer_token;
 
 const arrTypes = (['radarr', 'sonarr'] as const).filter(t => Array.isArray(multiConfig.services[t]));
-if (arrTypes.length === 0) {
-    console.error('This config has no single-block radarr or sonarr to double. Nothing to check.');
+const doubledTypes = DOUBLED_TYPES.filter(t => Array.isArray(multiConfig.services[t]));
+if (doubledTypes.length === 0) {
+    console.error('This config has no single-block service to double. Nothing to check.');
     process.exit(1);
 }
-console.log(`Doubling: ${arrTypes.map(t => `${t}/hd + ${t}/4k`).join(', ')}\n`);
+console.log(`Doubling: ${doubledTypes.map(t => `${t}/hd + ${t}/4k`).join(', ')}\n`);
 
 const run = async (label: string, tool: string, args: Record<string, unknown>): Promise<ToolCallResult | undefined> => {
     const started = performance.now();
@@ -151,6 +154,36 @@ await run('search_media over the doubled library', 'search_media', { query: 'the
 await run('get_media_details over the doubled library', 'get_media_details', { query: 'the' });
 await run('diagnose over the doubled library', 'diagnose', { query: 'the' });
 
+// --- 2a. the queue and indexer fan-outs double ----------------------------
+//
+// Doubling one service is what makes a fan-out checkable: the same rows arrive
+// twice under two ids, so a total that did not move means an instance was
+// dropped rather than that nothing was duplicated.
+for (const [tool, type] of [['get_queue', 'sabnzbd'], ['get_indexers', 'prowlarr']] as const) {
+    if (!Array.isArray(multiConfig.services[type])) continue;
+
+    const beforeContent = (await callTool(single, token, tool, {})).structuredContent as
+        | { total?: number; items?: { service?: string }[] }
+        | undefined;
+    const afterContent = (await callTool(multi, token, tool, {})).structuredContent as
+        | { total?: number; items?: { service?: string }[] }
+        | undefined;
+    const before = beforeContent?.total;
+    const after = afterContent?.total;
+
+    if (typeof before !== 'number' || typeof after !== 'number') {
+        fail(`${tool} total`, `missing total — got ${JSON.stringify({ before, after })}`);
+    } else if (after !== before * 2) {
+        fail(`${tool} total`, `expected ${before * 2} with two instances, got ${after}`);
+    } else {
+        pass(`${tool} total`, `${before} → ${after}`);
+    }
+
+    const ids = new Set((afterContent?.items ?? []).map(i => i.service));
+    if (ids.has(`${type}/hd`) && ids.has(`${type}/4k`)) pass(`${tool} attribution`, [...ids].join(', '));
+    else fail(`${tool} attribution`, `expected both ids, saw ${[...ids].join(', ') || 'none'}`);
+}
+
 // --- 3. writes refuse to guess which instance -----------------------------
 
 const searchHits =
@@ -193,6 +226,52 @@ await expectRefusal(
     { service: 'radarr', external_id: '603', dry_run: true },
     /instances configured|does not say which/
 );
+
+// --- 3a. the write path refuses ambiguity and scopes permissions ----------
+
+if (Array.isArray(multiConfig.services.sabnzbd)) {
+    // Guessing which client to pause is the failure resolveInstance exists to
+    // prevent, and the refusal has to name the alternatives.
+    const ambiguous = await callTool(multi, token, 'pause_downloads', { service: 'sabnzbd', action: 'pause' });
+    const text = JSON.stringify(ambiguous);
+    if (/2 instances/.test(text) && /hd/.test(text) && /4k/.test(text)) pass('pause_downloads ambiguity refused');
+    else fail('pause_downloads ambiguity', `expected a refusal naming hd and 4k, got ${redactHosts(text, hosts)}`);
+}
+
+if (Array.isArray(multiConfig.services.sabnzbd)) {
+    // safe_write on `hd` and nothing on `4k` is a configuration the schema can
+    // express, so it has to be one the gate actually honours.
+    const scoped = ConfigSchema.parse({
+        ...multiConfig,
+        services: {
+            ...multiConfig.services,
+            sabnzbd: (multiConfig.services.sabnzbd as { name: string }[]).map(e => ({
+                ...e,
+                permissions: { safe_write: e.name === 'hd', destructive: false }
+            }))
+        }
+    });
+    const app = appFor(scoped);
+
+    const allowed = await callTool(app, token, 'pause_downloads', {
+        service: 'sabnzbd',
+        instance: 'hd',
+        action: 'pause'
+    });
+    const denied = await callTool(app, token, 'pause_downloads', {
+        service: 'sabnzbd',
+        instance: '4k',
+        action: 'pause'
+    });
+
+    if (/safe_write/.test(JSON.stringify(allowed))) {
+        fail('permissions scoped', 'hd was granted safe_write but the preview was refused');
+    } else if (!/safe_write/.test(JSON.stringify(denied))) {
+        fail('permissions scoped', '4k has no safe_write but was not refused');
+    } else {
+        pass('permissions scoped', 'hd allowed, 4k refused');
+    }
+}
 
 // --- 4. what search_media reports as `service` ----------------------------
 //

--- a/scripts/multi-instance-check.ts
+++ b/scripts/multi-instance-check.ts
@@ -4,9 +4,11 @@
  *
  *     ARR_MCP_CONFIG_DIR=./config node scripts/multi-instance-check.ts
  *
- * It configures the real Radarr and Sonarr twice, as `hd` and `4k`. Doubling
- * one service is what makes the library total checkable: the same ids merge, so
- * a fan-out that double-counted shows up as a changed total.
+ * It configures whichever of Radarr, Sonarr, SABnzbd, Prowlarr, Transmission
+ * and qBittorrent the live config holds twice, as `hd` and `4k`. Doubling one
+ * service is what makes its totals checkable: the same ids merge, so a
+ * fan-out that double-counted or dropped an instance shows up as a total that
+ * did not move the way doubling should have moved it.
  *
  * Reads only — the write tools it calls are dry runs or refusals.
  */
@@ -26,6 +28,9 @@ const hosts = hostsOf(real);
 
 /** The same service twice, under two names. */
 const DOUBLED_TYPES = ['radarr', 'sonarr', 'sabnzbd', 'prowlarr', 'transmission', 'qbittorrent'] as const;
+
+/** The subset of `DOUBLED_TYPES` that are download clients, not *arr apps or Prowlarr. */
+const DOWNLOAD_CLIENT_TYPES = ['sabnzbd', 'transmission', 'qbittorrent'] as const;
 
 function doubled(config: Config): Config {
     const services = { ...config.services } as Record<string, unknown>;
@@ -69,6 +74,7 @@ const token = real.auth.bearer_token;
 
 const arrTypes = (['radarr', 'sonarr'] as const).filter(t => Array.isArray(multiConfig.services[t]));
 const doubledTypes = DOUBLED_TYPES.filter(t => Array.isArray(multiConfig.services[t]));
+const downloadClientTypes = DOWNLOAD_CLIENT_TYPES.filter(t => Array.isArray(multiConfig.services[t]));
 if (doubledTypes.length === 0) {
     console.error('This config has no single-block service to double. Nothing to check.');
     process.exit(1);
@@ -158,31 +164,61 @@ await run('diagnose over the doubled library', 'diagnose', { query: 'the' });
 //
 // Doubling one service is what makes a fan-out checkable: the same rows arrive
 // twice under two ids, so a total that did not move means an instance was
-// dropped rather than that nothing was duplicated.
-for (const [tool, type] of [['get_queue', 'sabnzbd'], ['get_indexers', 'prowlarr']] as const) {
-    if (!Array.isArray(multiConfig.services[type])) continue;
+// dropped rather than that nothing was duplicated. A single-instance total of
+// zero proves nothing either way, so that's SKIP rather than a vacuous PASS
+// paired with a spurious attribution FAIL.
+//
+// Attribution prefers `counts`, keyed by adapter id and populated by `gather`
+// for every adapter that answered — including with zero items — so it tells
+// "attribution is broken" apart from "this instance's queue is idle", which
+// `items[].service` cannot: an idle instance contributes no items to inspect.
+// `get_indexers` builds its own result without `gather` and has no `counts`
+// field, so it falls back to `items[].service` — fine there, since an
+// indexer list only reads empty when nothing is configured, a state already
+// caught by the zero-total SKIP below.
+type FanOutContent = { total?: number; items?: { service?: string }[]; counts?: Record<string, number> };
 
-    const beforeContent = (await callTool(single, token, tool, {})).structuredContent as
-        | { total?: number; items?: { service?: string }[] }
-        | undefined;
-    const afterContent = (await callTool(multi, token, tool, {})).structuredContent as
-        | { total?: number; items?: { service?: string }[] }
-        | undefined;
-    const before = beforeContent?.total;
+const checkFanOut = async (tool: 'get_queue' | 'get_indexers', types: readonly string[]) => {
+    if (types.length === 0) return;
+
+    const before = ((await callTool(single, token, tool, {})).structuredContent as FanOutContent | undefined)?.total;
+    const afterContent = (await callTool(multi, token, tool, {})).structuredContent as FanOutContent | undefined;
     const after = afterContent?.total;
 
     if (typeof before !== 'number' || typeof after !== 'number') {
         fail(`${tool} total`, `missing total — got ${JSON.stringify({ before, after })}`);
-    } else if (after !== before * 2) {
-        fail(`${tool} total`, `expected ${before * 2} with two instances, got ${after}`);
-    } else {
-        pass(`${tool} total`, `${before} → ${after}`);
+        fail(`${tool} attribution`, 'no total to compare against');
+        return;
     }
+    if (before === 0) {
+        console.log(`SKIP ${tool} total — single-instance total is 0, nothing to double.`);
+        console.log(`SKIP ${tool} attribution — single-instance total is 0, nothing to double.`);
+        return;
+    }
+    if (after !== before * 2) fail(`${tool} total`, `expected ${before * 2} with two instances, got ${after}`);
+    else pass(`${tool} total`, `${before} → ${after}`);
 
-    const ids = new Set((afterContent?.items ?? []).map(i => i.service));
-    if (ids.has(`${type}/hd`) && ids.has(`${type}/4k`)) pass(`${tool} attribution`, [...ids].join(', '));
-    else fail(`${tool} attribution`, `expected both ids, saw ${[...ids].join(', ') || 'none'}`);
-}
+    const counts = afterContent?.counts;
+    const items = afterContent?.items ?? [];
+    for (const type of types) {
+        if (counts !== undefined) {
+            const hd = `${type}/hd`;
+            const k4 = `${type}/4k`;
+            if (Object.hasOwn(counts, hd) && Object.hasOwn(counts, k4)) {
+                pass(`${tool} attribution (${type})`, `${hd}: ${counts[hd]}, ${k4}: ${counts[k4]}`);
+            } else {
+                fail(`${tool} attribution (${type})`, `expected both ids in counts, saw ${Object.keys(counts).join(', ') || 'none'}`);
+            }
+        } else {
+            const ids = new Set(items.map(i => i.service));
+            if (ids.has(`${type}/hd`) && ids.has(`${type}/4k`)) pass(`${tool} attribution (${type})`, [...ids].join(', '));
+            else fail(`${tool} attribution (${type})`, `expected both ids, saw ${[...ids].join(', ') || 'none'}`);
+        }
+    }
+};
+
+await checkFanOut('get_queue', downloadClientTypes);
+await checkFanOut('get_indexers', Array.isArray(multiConfig.services.prowlarr) ? ['prowlarr'] : []);
 
 // --- 3. writes refuse to guess which instance -----------------------------
 
@@ -228,24 +264,29 @@ await expectRefusal(
 );
 
 // --- 3a. the write path refuses ambiguity and scopes permissions ----------
+//
+// Looped over whichever download clients are configured, one type fully at a
+// time — never Promise.all across or within a type. qBittorrent bans a client
+// that bursts two logins at it, and two doubled adapters against one URL is
+// exactly that if these ever ran concurrently.
 
-if (Array.isArray(multiConfig.services.sabnzbd)) {
+for (const type of downloadClientTypes) {
     // Guessing which client to pause is the failure resolveInstance exists to
     // prevent, and the refusal has to name the alternatives.
-    const ambiguous = await callTool(multi, token, 'pause_downloads', { service: 'sabnzbd', action: 'pause' });
+    const ambiguous = await callTool(multi, token, 'pause_downloads', { service: type, action: 'pause' });
     const text = JSON.stringify(ambiguous);
-    if (/2 instances/.test(text) && /hd/.test(text) && /4k/.test(text)) pass('pause_downloads ambiguity refused');
-    else fail('pause_downloads ambiguity', `expected a refusal naming hd and 4k, got ${redactHosts(text, hosts)}`);
+    if (/2 instances/.test(text) && /hd/.test(text) && /4k/.test(text)) pass(`pause_downloads ambiguity refused (${type})`);
+    else fail(`pause_downloads ambiguity (${type})`, `expected a refusal naming hd and 4k, got ${redactHosts(text, hosts)}`);
 }
 
-if (Array.isArray(multiConfig.services.sabnzbd)) {
+for (const type of downloadClientTypes) {
     // safe_write on `hd` and nothing on `4k` is a configuration the schema can
     // express, so it has to be one the gate actually honours.
     const scoped = ConfigSchema.parse({
         ...multiConfig,
         services: {
             ...multiConfig.services,
-            sabnzbd: (multiConfig.services.sabnzbd as { name: string }[]).map(e => ({
+            [type]: (multiConfig.services[type] as { name: string }[]).map(e => ({
                 ...e,
                 permissions: { safe_write: e.name === 'hd', destructive: false }
             }))
@@ -253,23 +294,15 @@ if (Array.isArray(multiConfig.services.sabnzbd)) {
     });
     const app = appFor(scoped);
 
-    const allowed = await callTool(app, token, 'pause_downloads', {
-        service: 'sabnzbd',
-        instance: 'hd',
-        action: 'pause'
-    });
-    const denied = await callTool(app, token, 'pause_downloads', {
-        service: 'sabnzbd',
-        instance: '4k',
-        action: 'pause'
-    });
+    const allowed = await callTool(app, token, 'pause_downloads', { service: type, instance: 'hd', action: 'pause' });
+    const denied = await callTool(app, token, 'pause_downloads', { service: type, instance: '4k', action: 'pause' });
 
     if (/safe_write/.test(JSON.stringify(allowed))) {
-        fail('permissions scoped', 'hd was granted safe_write but the preview was refused');
+        fail(`permissions scoped (${type})`, 'hd was granted safe_write but the preview was refused');
     } else if (!/safe_write/.test(JSON.stringify(denied))) {
-        fail('permissions scoped', '4k has no safe_write but was not refused');
+        fail(`permissions scoped (${type})`, '4k has no safe_write but was not refused');
     } else {
-        pass('permissions scoped', 'hd allowed, 4k refused');
+        pass(`permissions scoped (${type})`, 'hd allowed, 4k refused');
     }
 }
 

--- a/src/config/instances.ts
+++ b/src/config/instances.ts
@@ -45,7 +45,7 @@ export function listInstances(config: Config): ServiceInstance[] {
         if (value === undefined) continue;
         const type = key as ServiceId;
 
-        // Only the three in MULTI_INSTANCE can be a list, and the schema has
+        // Only the types in MULTI_INSTANCE can be a list, and the schema has
         // already refused one anywhere else — so this is a shape check, not a
         // policy decision being made twice.
         const entries: readonly unknown[] = Array.isArray(value) ? value : [value];

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -48,15 +48,28 @@ const KeyedServiceSchema = z.strictObject({ ...BaseServiceShape, ...ApiKeyShape 
 export type KeyedServiceConfig = z.infer<typeof KeyedServiceSchema>;
 
 /**
- * Which services may appear more than once. Quality tiers are the reason anyone
- * runs two — an HD and a 4K Radarr, their Sonarrs, and a Bazarr per stack
- * because Bazarr connects to exactly one of each.
+ * Which services may appear more than once.
  *
- * The other five are deliberately single: a second Prowlarr or Seerr is not a
- * tier, and `register.ts` selects those with a `.find`. Admitting a shape the
- * code then degrades on is worse than refusing it.
+ * Quality tiers are the reason anyone runs two *arrs, and a Bazarr follows each
+ * pair because it connects to exactly one of each. The download clients and
+ * Prowlarr are here for a different reason: nothing selects them by anything but
+ * capability, so a second one is merged into reads and named on writes with no
+ * special case.
+ *
+ * The three left out are refusals, not omissions. `get_library`'s `presence`
+ * asks whether the media server can see a file, which has no answer with two of
+ * them; and a Seerr request carries a user identity that a second instance
+ * makes ambiguous.
  */
-export const MULTI_INSTANCE: readonly ServiceId[] = ['bazarr', 'radarr', 'sonarr'];
+export const MULTI_INSTANCE: readonly ServiceId[] = [
+    'bazarr',
+    'prowlarr',
+    'qbittorrent',
+    'radarr',
+    'sabnzbd',
+    'sonarr',
+    'transmission'
+];
 
 /**
  * Goes into the qualified id (`radarr/4k`), which reaches audit rows, log
@@ -75,28 +88,35 @@ const NamedKeyedServiceSchema = z.strictObject({
 });
 
 /**
- * The list form. Names are compared case-insensitively because `4K` and `4k`
- * naming two different Radarrs is a typo every time, never an intention.
+ * Names are compared case-insensitively because `4K` and `4k` naming two
+ * different Radarrs is a typo every time, never an intention.
+ *
+ * Shared by the keyed and credential lists rather than pasted into both: two
+ * copies is two chances to disagree about whether `Main` and `main` are one
+ * instance.
  */
+const uniqueNames = (list: readonly { name: string }[], ctx: z.RefinementCtx): void => {
+    const seen = new Map<string, number>();
+    list.forEach((entry, index) => {
+        const key = entry.name.toLowerCase();
+        const first = seen.get(key);
+        if (first !== undefined) {
+            ctx.addIssue({
+                code: 'custom',
+                message: `duplicate instance name "${entry.name}" — already used by entry ${first + 1}`,
+                path: [index, 'name']
+            });
+            return;
+        }
+        seen.set(key, index);
+    });
+};
+
+/** The list form, for services taking an api_key. */
 const InstanceListSchema = z
     .array(NamedKeyedServiceSchema)
     .min(1, 'list at least one instance, or use a single block instead of a list')
-    .superRefine((list, ctx) => {
-        const seen = new Map<string, number>();
-        list.forEach((entry, index) => {
-            const key = entry.name.toLowerCase();
-            const first = seen.get(key);
-            if (first !== undefined) {
-                ctx.addIssue({
-                    code: 'custom',
-                    message: `duplicate instance name "${entry.name}" — already used by entry ${first + 1}`,
-                    path: [index, 'name']
-                });
-                return;
-            }
-            seen.set(key, index);
-        });
-    });
+    .superRefine(uniqueNames);
 
 /**
  * One block, as before, or a list of named ones. A union rather than a new key,
@@ -152,6 +172,20 @@ const CredentialServiceSchema = z.strictObject({
 });
 export type CredentialServiceConfig = z.infer<typeof CredentialServiceSchema>;
 
+const NamedCredentialServiceSchema = z.strictObject({
+    ...BaseServiceShape,
+    username: z.string().min(1).optional(),
+    password: z.string().optional(),
+    name: InstanceNameSchema
+});
+
+const CredentialInstanceListSchema = z
+    .array(NamedCredentialServiceSchema)
+    .min(1, 'list at least one instance, or use a single block instead of a list')
+    .superRefine(uniqueNames);
+
+const MultiInstanceCredentialSchema = z.union([CredentialServiceSchema, CredentialInstanceListSchema]);
+
 export type AnyServiceConfig = KeyedServiceConfig | MultiUserServiceConfig | CredentialServiceConfig;
 
 /**
@@ -183,12 +217,12 @@ const ServicesSchema = z
         radarr: MultiInstanceServiceSchema.optional(),
         sonarr: MultiInstanceServiceSchema.optional(),
         bazarr: MultiInstanceServiceSchema.optional(),
-        prowlarr: singleOnly(KeyedServiceSchema).optional(),
-        sabnzbd: singleOnly(KeyedServiceSchema).optional(),
+        prowlarr: MultiInstanceServiceSchema.optional(),
+        sabnzbd: MultiInstanceServiceSchema.optional(),
         jellyfin: singleOnly(MultiUserServiceSchema).optional(),
         seerr: singleOnly(MultiUserServiceSchema).optional(),
-        transmission: singleOnly(CredentialServiceSchema).optional(),
-        qbittorrent: singleOnly(CredentialServiceSchema).optional(),
+        transmission: MultiInstanceCredentialSchema.optional(),
+        qbittorrent: MultiInstanceCredentialSchema.optional(),
         plex: singleOnly(MultiUserServiceSchema).optional()
     })
     .superRefine((services, ctx) => {

--- a/src/core/auth.ts
+++ b/src/core/auth.ts
@@ -127,6 +127,7 @@ const QB_LOGIN_PATH = '/api/v2/auth/login';
  * clients on localhost" enabled therefore never logs in at all.
  */
 export function qbittorrentSession(creds: {
+    id: string;
     url: string;
     username?: string;
     password?: string;
@@ -172,7 +173,7 @@ interface SessionCookie {
 }
 
 async function qbittorrentLogin(
-    creds: { url: string; username?: string; password?: string; timeoutMs: number },
+    creds: { id: string; url: string; username?: string; password?: string; timeoutMs: number },
     doFetch: typeof fetch
 ): Promise<SessionCookie> {
     const base = new URL(creds.url);
@@ -190,7 +191,7 @@ async function qbittorrentLogin(
             signal: AbortSignal.timeout(creds.timeoutMs)
         });
     } catch (err) {
-        throw new ServiceError('AuthFailed', 'qbittorrent', 'the login request failed', { cause: err });
+        throw new ServiceError('AuthFailed', creds.id, 'the login request failed', { cause: err });
     }
 
     // Read before the status check, not after: a banned client sees 403 on
@@ -199,7 +200,7 @@ async function qbittorrentLogin(
     const body = (await response.text()).trim();
 
     if (response.status === 403) {
-        throw new ServiceError('AuthFailed', 'qbittorrent', 'login refused', {
+        throw new ServiceError('AuthFailed', creds.id, 'login refused', {
             remedy: 'qBittorrent bans a client after repeated failed logins. Wait, or clear the ban in Options → Web UI.'
         });
     }
@@ -209,14 +210,14 @@ async function qbittorrentLogin(
     // a wrong password is also a 200, with the body "Fails." (5.2 uses 401).
     const accepted = response.status === 204 ? body === '' : response.status === 200 && body === 'Ok.';
     if (!accepted) {
-        throw new ServiceError('AuthFailed', 'qbittorrent', `login returned "${body || response.status}"`, {
+        throw new ServiceError('AuthFailed', creds.id, `login returned "${body || response.status}"`, {
             remedy: 'Check username and password against Options → Web UI in qBittorrent.'
         });
     }
 
     const offered = readSessionCookie(response);
     if (offered === undefined) {
-        throw new ServiceError('AuthFailed', 'qbittorrent', 'login succeeded but set no session cookie');
+        throw new ServiceError('AuthFailed', creds.id, 'login succeeded but set no session cookie');
     }
     return offered;
 }

--- a/src/services/prowlarr.ts
+++ b/src/services/prowlarr.ts
@@ -213,6 +213,7 @@ export class ProwlarrAdapter
                         .filter(Boolean)
                         .join(', ');
                 return {
+                    service: this.id,
                     indexer: nameOf(r.indexerId),
                     at: r.date,
                     reason: fenceText(described === '' ? 'failed, no reason recorded' : described, {

--- a/src/services/prowlarr.ts
+++ b/src/services/prowlarr.ts
@@ -1,4 +1,5 @@
-import type { KeyedServiceConfig, ServiceId } from '../config/schema.ts';
+import { instanceId } from '../config/instances.ts';
+import type { Instanced, KeyedServiceConfig, ServiceId } from '../config/schema.ts';
 import { apiKeyHeader } from '../core/auth.ts';
 import { ServiceError } from '../core/errors.ts';
 import { fenceText } from '../core/fence.ts';
@@ -68,11 +69,14 @@ export class ProwlarrAdapter
     implements ServiceAdapter, HealthCheckCapable, IndexerCapable, SearchCapable, LibraryScanCapable
 {
     readonly type: ServiceId = 'prowlarr';
-    readonly id: string = 'prowlarr';
+    readonly instance: string | undefined;
+    readonly id: string;
     readonly #http: ServiceHttp;
 
-    constructor(config: KeyedServiceConfig, fetchImpl: typeof fetch = fetch) {
-        this.#http = new ServiceHttp('prowlarr', config, apiKeyHeader('X-Api-Key', config.api_key), fetchImpl);
+    constructor(config: Instanced<KeyedServiceConfig>, fetchImpl: typeof fetch = fetch) {
+        this.instance = config.name;
+        this.id = instanceId('prowlarr', config.name);
+        this.#http = new ServiceHttp(this.id, config, apiKeyHeader('X-Api-Key', config.api_key), fetchImpl);
     }
 
     async getVersion(): Promise<string> {

--- a/src/services/qbittorrent.ts
+++ b/src/services/qbittorrent.ts
@@ -1,4 +1,5 @@
-import type { CredentialServiceConfig, ServiceId } from '../config/schema.ts';
+import { instanceId } from '../config/instances.ts';
+import type { CredentialServiceConfig, Instanced, ServiceId } from '../config/schema.ts';
 import { qbittorrentSession } from '../core/auth.ts';
 import { ServiceError } from '../core/errors.ts';
 import { fenceText } from '../core/fence.ts';
@@ -86,12 +87,15 @@ export class QbittorrentAdapter
         MagnetAddCapable
 {
     readonly type: ServiceId = 'qbittorrent';
-    readonly id: string = 'qbittorrent';
+    readonly instance: string | undefined;
+    readonly id: string;
     readonly #http: ServiceHttp;
 
-    constructor(config: CredentialServiceConfig, fetchImpl: typeof fetch = fetch) {
+    constructor(config: Instanced<CredentialServiceConfig>, fetchImpl: typeof fetch = fetch) {
+        this.instance = config.name;
+        this.id = instanceId('qbittorrent', config.name);
         this.#http = new ServiceHttp(
-            'qbittorrent',
+            this.id,
             config,
             qbittorrentSession({
                 url: config.url,

--- a/src/services/qbittorrent.ts
+++ b/src/services/qbittorrent.ts
@@ -98,6 +98,7 @@ export class QbittorrentAdapter
             this.id,
             config,
             qbittorrentSession({
+                id: this.id,
                 url: config.url,
                 timeoutMs: config.timeout_ms,
                 ...(config.username === undefined ? {} : { username: config.username }),

--- a/src/services/registry.ts
+++ b/src/services/registry.ts
@@ -1,6 +1,7 @@
 import { listInstances, type ServiceInstance } from '../config/instances.ts';
 import type {
     Config,
+    Instanced,
     KeyedServiceConfig,
     MultiUserServiceConfig
 } from '../config/schema.ts';
@@ -33,7 +34,7 @@ export function buildAdapters(config: Config): ServiceAdapter[] {
 }
 
 function buildAdapter(instance: ServiceInstance): ServiceAdapter {
-    const keyed = instance.config as KeyedServiceConfig;
+    const keyed = instance.config as Instanced<KeyedServiceConfig>;
 
     switch (instance.type) {
         case 'bazarr':

--- a/src/services/sabnzbd.ts
+++ b/src/services/sabnzbd.ts
@@ -1,4 +1,5 @@
-import type { KeyedServiceConfig, ServiceId } from '../config/schema.ts';
+import { instanceId } from '../config/instances.ts';
+import type { Instanced, KeyedServiceConfig, ServiceId } from '../config/schema.ts';
 import { queryParamKey } from '../core/auth.ts';
 import { ServiceError } from '../core/errors.ts';
 import { ServiceHttp } from '../core/http.ts';
@@ -102,11 +103,14 @@ export class SabnzbdAdapter
         HistoryCapable
 {
     readonly type: ServiceId = 'sabnzbd';
-    readonly id: string = 'sabnzbd';
+    readonly instance: string | undefined;
+    readonly id: string;
     readonly #http: ServiceHttp;
 
-    constructor(config: KeyedServiceConfig, fetchImpl: typeof fetch = fetch) {
-        this.#http = new ServiceHttp('sabnzbd', config, queryParamKey('apikey', config.api_key), fetchImpl);
+    constructor(config: Instanced<KeyedServiceConfig>, fetchImpl: typeof fetch = fetch) {
+        this.instance = config.name;
+        this.id = instanceId('sabnzbd', config.name);
+        this.#http = new ServiceHttp(this.id, config, queryParamKey('apikey', config.api_key), fetchImpl);
     }
 
     async getVersion(): Promise<string> {

--- a/src/services/transmission.ts
+++ b/src/services/transmission.ts
@@ -1,4 +1,5 @@
-import type { ServiceId, CredentialServiceConfig } from '../config/schema.ts';
+import { instanceId } from '../config/instances.ts';
+import type { ServiceId, CredentialServiceConfig, Instanced } from '../config/schema.ts';
 import { transmissionRpc } from '../core/auth.ts';
 import { ServiceError } from '../core/errors.ts';
 import { ServiceHttp } from '../core/http.ts';
@@ -70,12 +71,15 @@ export class TransmissionAdapter
         MagnetAddCapable
 {
     readonly type: ServiceId = 'transmission';
-    readonly id: string = 'transmission';
+    readonly instance: string | undefined;
+    readonly id: string;
     readonly #http: ServiceHttp;
 
-    constructor(config: CredentialServiceConfig, fetchImpl: typeof fetch = fetch) {
+    constructor(config: Instanced<CredentialServiceConfig>, fetchImpl: typeof fetch = fetch) {
+        this.instance = config.name;
+        this.id = instanceId('transmission', config.name);
         this.#http = new ServiceHttp(
-            'transmission',
+            this.id,
             config,
             transmissionRpc({
                 ...(config.username === undefined ? {} : { username: config.username }),

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -96,8 +96,9 @@ export type IndexerSummary = {
     rejectedGrabs?: number;
 };
 
-/** A query an indexer refused, with the reason it gave. */
-export type IndexerRejection = { indexer: string; at: string; reason: string; query?: string };
+/** A query an indexer refused, with the reason it gave. `service` is the
+ *  Prowlarr that reported it — a merged list cannot be read without it. */
+export type IndexerRejection = { service: string; indexer: string; at: string; reason: string; query?: string };
 
 export interface IndexerCapable {
     getIndexers(): Promise<IndexerSummary[]>;

--- a/src/tools/diagnose/chain.ts
+++ b/src/tools/diagnose/chain.ts
@@ -30,6 +30,9 @@ export type Evidence = {
     rejections: IndexerRejection[] | undefined;
     /** Analogue of `mediaServer !== undefined`: no Prowlarr configured, not merely unreachable. */
     prowlarrConfigured: boolean;
+    /** The Prowlarr instances whose rejection read failed. Named rather than a
+     *  boolean: the stage has to say which half of the answer is missing. */
+    prowlarrDegraded: string[];
     scan: ScanState | undefined;
     /**
      * A third state beyond looked/could-not-look: **never configured**. Without
@@ -313,26 +316,43 @@ function queueStep(ev: Evidence, item: MergedItem): QueueResult {
 
 function indexerStep(ev: Evidence, item: MergedItem): Step {
     if (!ev.prowlarrConfigured) return SKIPPED('indexers', 'No indexer manager is configured.');
-    if (ev.degraded.includes('prowlarr')) {
-        // `degraded` is probe reachability — the same array `scanStep` and
-        // `queueStep` read, and right here too: Prowlarr contributes no
-        // library-read half, so there is no `libraryDegraded` for it to consult
-        // instead. A service's own probe failing must count even when
-        // `rejections` happens to be defined from a stale read.
-        return { stage: 'indexers', service: 'prowlarr', status: 'unknown', detail: 'Prowlarr could not be reached.' };
+
+    const down = ev.prowlarrDegraded;
+
+    // Every instance failed. `rejections` being defined from a stale read must
+    // not outvote the probes.
+    if (ev.rejections === undefined) {
+        return {
+            stage: 'indexers',
+            status: 'unknown',
+            ...(down[0] === undefined ? {} : { service: down[0] }),
+            detail: `${down.length > 0 ? down.join(', ') : 'Prowlarr'} could not be reached.`
+        };
     }
-    if (ev.rejections === undefined) return { stage: 'indexers', service: 'prowlarr', status: 'unknown', detail: 'Prowlarr could not be reached.' };
 
     const mine = ev.rejections.filter(r => (r.query === undefined ? false : mentions(r.query, item)));
-    if (mine.length === 0) return SKIPPED('indexers', 'No recent indexer failures mention it.');
+    if (mine.length > 0) {
+        const first = mine[0] as IndexerRejection;
+        return {
+            stage: 'indexers',
+            service: first.service,
+            status: 'blocked',
+            detail: `${mine.length} recent indexer failure(s), most recently ${first.indexer} on ${first.service}: ${first.reason}.`
+        };
+    }
 
-    const first = mine[0] as IndexerRejection;
-    return {
-        stage: 'indexers',
-        service: 'prowlarr',
-        status: 'blocked',
-        detail: `${mine.length} recent indexer failure(s), most recently ${first.indexer}: ${first.reason}.`
-    };
+    // Nothing matched, but part of the answer is missing — the rejection that
+    // explains this grab may be in the half that did not answer.
+    if (down.length > 0) {
+        return {
+            stage: 'indexers',
+            service: down[0] as string,
+            status: 'unknown',
+            detail: `${down.join(', ')} could not be reached, so the indexers cannot be ruled out. The rest reported no failures mentioning it.`
+        };
+    }
+
+    return SKIPPED('indexers', 'No recent indexer failures mention it.');
 }
 
 function libraryStep(ev: Evidence, item: MergedItem): Step {

--- a/src/tools/diagnose/evidence.ts
+++ b/src/tools/diagnose/evidence.ts
@@ -180,8 +180,8 @@ export async function collectEvidence(deps: DiagnoseDeps, target: DiagnoseTarget
     const seerr = deps.adapters.find(hasRequests);
     const queueAdapters = deps.adapters.filter(hasQueue);
     const queueConfigured = queueAdapters.length > 0;
-    const prowlarr = deps.adapters.find(hasIndexers);
-    const prowlarrConfigured = prowlarr !== undefined;
+    const prowlarrs = deps.adapters.filter(hasIndexers);
+    const prowlarrConfigured = prowlarrs.length > 0;
     // `hasUserLibrary`, matching what `LibraryLoader` itself selects on, so this
     // stage's "configured" cannot disagree with whether the library was gathered.
     const mediaServerAdapter = deps.adapters.find(hasUserLibrary);
@@ -205,10 +205,20 @@ export async function collectEvidence(deps: DiagnoseDeps, target: DiagnoseTarget
         ? gather(queueAdapters.map(a => ({ id: a.id, fetch: () => a.getQueue() })))
         : Promise.resolve(undefined);
 
-    const rejectionsP: Promise<IndexerRejection[] | undefined> =
-        prowlarr === undefined
-            ? Promise.resolve(undefined)
-            : probe(prowlarr.id, degraded, () => prowlarr.getRecentRejections(RECENT_REJECTION_LIMIT));
+    // Each instance probed separately so one unreachable Prowlarr degrades by
+    // name instead of erasing the rejections another returned.
+    const prowlarrDegraded: string[] = [];
+    const rejectionsP: Promise<IndexerRejection[] | undefined> = !prowlarrConfigured
+        ? Promise.resolve(undefined)
+        : Promise.all(
+              prowlarrs.map(async p => {
+                  const rows = await probe(p.id, degraded, () => p.getRecentRejections(RECENT_REJECTION_LIMIT));
+                  if (rows === undefined) prowlarrDegraded.push(p.id);
+                  return rows ?? [];
+              })
+              // `undefined` keeps meaning every instance failed, which is what
+              // the stage's total-failure branch reads.
+          ).then(lists => (prowlarrDegraded.length === prowlarrs.length ? undefined : lists.flat()));
 
     const scanP: Promise<ScanState | undefined> =
         scanAdapter === undefined
@@ -277,6 +287,7 @@ export async function collectEvidence(deps: DiagnoseDeps, target: DiagnoseTarget
         queueConfigured,
         rejections,
         prowlarrConfigured,
+        prowlarrDegraded: prowlarrDegraded.sort(),
         scan,
         ...(mediaServer === undefined ? {} : { mediaServer }),
         scanCapable: scanAdapter !== undefined,

--- a/src/tools/diagnose/evidence.ts
+++ b/src/tools/diagnose/evidence.ts
@@ -208,6 +208,11 @@ export async function collectEvidence(deps: DiagnoseDeps, target: DiagnoseTarget
     // Each instance probed separately so one unreachable Prowlarr degrades by
     // name instead of erasing the rejections another returned.
     const prowlarrDegraded: string[] = [];
+    // `undefined` keeps meaning every instance failed, which is what the
+    // stage's total-failure branch reads. Flattened lists are re-sorted
+    // newest-first: each instance answers in its own order, but the merge
+    // settles in whatever order the promises resolve, and `mine[0]` below is
+    // read as the most recent rejection overall.
     const rejectionsP: Promise<IndexerRejection[] | undefined> = !prowlarrConfigured
         ? Promise.resolve(undefined)
         : Promise.all(
@@ -216,9 +221,11 @@ export async function collectEvidence(deps: DiagnoseDeps, target: DiagnoseTarget
                   if (rows === undefined) prowlarrDegraded.push(p.id);
                   return rows ?? [];
               })
-              // `undefined` keeps meaning every instance failed, which is what
-              // the stage's total-failure branch reads.
-          ).then(lists => (prowlarrDegraded.length === prowlarrs.length ? undefined : lists.flat()));
+          ).then(lists =>
+              prowlarrDegraded.length === prowlarrs.length
+                  ? undefined
+                  : lists.flat().sort((a, b) => Date.parse(b.at) - Date.parse(a.at))
+          );
 
     const scanP: Promise<ScanState | undefined> =
         scanAdapter === undefined

--- a/src/tools/getIndexers.ts
+++ b/src/tools/getIndexers.ts
@@ -26,34 +26,56 @@ const project = (i: IndexerSummary, detail: DetailLevel): IndexerSummary => {
     return rest;
 };
 
+/**
+ * Every configured Prowlarr, merged.
+ *
+ * A merged indexer list is the reason to run a second one, so this is a read
+ * that spans instances rather than one that asks which to look in. One failing
+ * degrades by name and the others still answer.
+ */
 export async function buildGetIndexers(
-    adapter: (ServiceAdapter & IndexerCapable) | undefined,
+    adapters: readonly (ServiceAdapter & IndexerCapable)[],
     opts: { detail: DetailLevel; limit: number; offset?: number }
 ): Promise<GetIndexersResult> {
-    if (adapter === undefined) {
+    if (adapters.length === 0) {
         return { items: [], total: 0, returned: 0, offset: 0, truncated: false, degraded: [], disabledCount: 0 };
     }
 
-    let indexers: IndexerSummary[];
-    try {
-        indexers = await adapter.getIndexers();
-    } catch (err) {
-        logger.warn({ service: adapter.id, err }, 'indexer read failed; degrading');
-        return { items: [], total: 0, returned: 0, offset: 0, truncated: false, degraded: [adapter.id], disabledCount: 0 };
-    }
+    const indexers: IndexerSummary[] = [];
+    const rejections: IndexerRejection[] = [];
+    const degraded: string[] = [];
+    let sawRejections = false;
 
-    // Rejections only at full detail, and never allowed to fail the call: a
-    // Prowlarr without a history endpoint still has indexers worth reporting.
-    let recentRejections: IndexerRejection[] | undefined;
-    if (opts.detail === 'full') {
-        try {
-            recentRejections = await adapter.getRecentRejections(opts.limit);
-        } catch (err) {
-            logger.warn({ service: adapter.id, err }, 'rejection history unavailable; omitting');
-        }
-    }
+    await Promise.all(
+        adapters.map(async adapter => {
+            try {
+                indexers.push(...(await adapter.getIndexers()));
+            } catch (err) {
+                logger.warn({ service: adapter.id, err }, 'indexer read failed; degrading');
+                degraded.push(adapter.id);
+                return;
+            }
 
-    const shaped = applyLimit(indexers, opts.limit, opts.offset);
+            // Rejections only at full detail, and never allowed to fail the
+            // call: a Prowlarr without a history endpoint still has indexers
+            // worth reporting.
+            if (opts.detail !== 'full') return;
+            try {
+                rejections.push(...(await adapter.getRecentRejections(opts.limit)));
+                sawRejections = true;
+            } catch (err) {
+                logger.warn({ service: adapter.id, err }, 'rejection history unavailable; omitting');
+            }
+        })
+    );
+
+    // Sorted so two instances produce a stable order rather than whichever
+    // answered first, which would make the output differ run to run.
+    const shaped = applyLimit(
+        indexers.sort((a, b) => a.service.localeCompare(b.service) || a.name.localeCompare(b.name)),
+        opts.limit,
+        opts.offset
+    );
 
     // Counted before projecting: `minimal` strips `disabledUntil`, so counting
     // the projected items reported none disabled however many were.
@@ -63,12 +85,15 @@ export async function buildGetIndexers(
         ...shaped,
         items: shaped.items.map(i => project(i, opts.detail)),
         disabledCount,
-        degraded: [],
-        ...(recentRejections === undefined ? {} : { recentRejections })
+        degraded: degraded.sort(),
+        ...(sawRejections ? { recentRejections: rejections } : {})
     };
 }
 
-export function registerGetIndexers(server: McpServer, adapter: (ServiceAdapter & IndexerCapable) | undefined): void {
+export function registerGetIndexers(
+    server: McpServer,
+    adapters: readonly (ServiceAdapter & IndexerCapable)[]
+): void {
     server.registerTool(
         'get_indexers',
         {
@@ -86,12 +111,12 @@ export function registerGetIndexers(server: McpServer, adapter: (ServiceAdapter 
             inputSchema: toolInput({ detail: DetailSchema, limit: LimitSchema, offset: OffsetSchema })
         },
         async ({ detail, limit, offset }) => {
-            const result = await buildGetIndexers(adapter, { detail, limit, offset });
+            const result = await buildGetIndexers(adapters, { detail, limit, offset });
             const disabled = result.disabledCount;
             const summary =
-                result.degraded.length > 0
-                    ? 'Prowlarr could not be reached; no indexer information available.'
-                    : `${result.returned} of ${result.total} indexer(s)${disabled > 0 ? `, ${disabled} temporarily disabled` : ''}.`;
+                result.degraded.length > 0 && result.total === 0
+                    ? `${result.degraded.join(', ')} could not be reached; no indexer information available.`
+                    : `${result.returned} of ${result.total} indexer(s)${disabled > 0 ? `, ${disabled} temporarily disabled` : ''}${result.degraded.length > 0 ? `. ${result.degraded.join(', ')} could not be reached` : ''}.`;
 
             return { content: [{ type: 'text', text: summary }], structuredContent: result };
         }

--- a/src/tools/getIndexers.ts
+++ b/src/tools/getIndexers.ts
@@ -90,6 +90,19 @@ export async function buildGetIndexers(
     };
 }
 
+/**
+ * Total failure is claimed only when every configured instance degraded —
+ * `degraded.length === instanceCount`, not `result.total === 0`. A healthy
+ * instance with no indexers configured also has `total === 0`, and pairing it
+ * with one degraded instance must not read as "nothing could be reached."
+ */
+export const summarizeIndexers = (result: GetIndexersResult, instanceCount: number): string => {
+    const disabled = result.disabledCount;
+    if (result.degraded.length > 0 && result.degraded.length === instanceCount)
+        return `${result.degraded.join(', ')} could not be reached; no indexer information available.`;
+    return `${result.returned} of ${result.total} indexer(s)${disabled > 0 ? `, ${disabled} temporarily disabled` : ''}${result.degraded.length > 0 ? `. ${result.degraded.join(', ')} could not be reached` : ''}.`;
+};
+
 export function registerGetIndexers(
     server: McpServer,
     adapters: readonly (ServiceAdapter & IndexerCapable)[]
@@ -112,11 +125,7 @@ export function registerGetIndexers(
         },
         async ({ detail, limit, offset }) => {
             const result = await buildGetIndexers(adapters, { detail, limit, offset });
-            const disabled = result.disabledCount;
-            const summary =
-                result.degraded.length > 0 && result.total === 0
-                    ? `${result.degraded.join(', ')} could not be reached; no indexer information available.`
-                    : `${result.returned} of ${result.total} indexer(s)${disabled > 0 ? `, ${disabled} temporarily disabled` : ''}${result.degraded.length > 0 ? `. ${result.degraded.join(', ')} could not be reached` : ''}.`;
+            const summary = summarizeIndexers(result, adapters.length);
 
             return { content: [{ type: 'text', text: summary }], structuredContent: result };
         }

--- a/src/tools/getIndexers.ts
+++ b/src/tools/getIndexers.ts
@@ -81,12 +81,19 @@ export async function buildGetIndexers(
     // the projected items reported none disabled however many were.
     const disabledCount = shaped.items.filter(i => i.disabledUntil !== undefined).length;
 
+    // Rejections are time-ordered; each instance answers its own newest-first,
+    // but as they settle in whatever order the promises resolve. Re-sort the
+    // merge, and re-apply the limit that bounded each instance alone.
+    const mergedRejections = rejections
+        .sort((a, b) => Date.parse(b.at) - Date.parse(a.at))
+        .slice(0, opts.limit);
+
     return {
         ...shaped,
         items: shaped.items.map(i => project(i, opts.detail)),
         disabledCount,
         degraded: degraded.sort(),
-        ...(sawRejections ? { recentRejections: rejections } : {})
+        ...(sawRejections ? { recentRejections: mergedRejections } : {})
     };
 }
 

--- a/src/tools/pauseDownloads.ts
+++ b/src/tools/pauseDownloads.ts
@@ -89,15 +89,15 @@ export function registerPauseDownloads(
                 const client = findLimitAdapter(adapters, service, instance);
                 const current = await client.readSpeedLimit();
                 const wanted = speed_limit_kbps === 0 ? undefined : speed_limit_kbps;
-                const target = `${service}:limit`;
+                const target = `${client.id}:limit`;
 
                 if (current.kbps === wanted) {
                     return {
                         target,
                         summary:
                             wanted === undefined
-                                ? `${service} already has no download limit.`
-                                : `${service} is already limited to ${wanted} KB/s.`,
+                                ? `${client.id} already has no download limit.`
+                                : `${client.id} is already limited to ${wanted} KB/s.`,
                         effects: [],
                         noop: true
                     };
@@ -107,12 +107,12 @@ export function registerPauseDownloads(
                     target,
                     summary:
                         wanted === undefined
-                            ? `Remove the download limit on ${service}.`
-                            : `Limit ${service} to ${wanted} KB/s.`,
+                            ? `Remove the download limit on ${client.id}.`
+                            : `Limit ${client.id} to ${wanted} KB/s.`,
                     effects: [
                         wanted === undefined
-                            ? `${service} will download as fast as the line allows${current.kbps === undefined ? '' : `, instead of the current ${current.kbps} KB/s`}.`
-                            : `Caps ${service} at ${wanted} KB/s${current.kbps === undefined ? ', which currently has no limit' : `, from ${current.kbps} KB/s`}. Client-wide, not per item.`,
+                            ? `${client.id} will download as fast as the line allows${current.kbps === undefined ? '' : `, instead of the current ${current.kbps} KB/s`}.`
+                            : `Caps ${client.id} at ${wanted} KB/s${current.kbps === undefined ? ', which currently has no limit' : `, from ${current.kbps} KB/s`}. Client-wide, not per item.`,
                         'Does NOT stop Radarr or Sonarr grabbing. They keep sending releases; they just arrive more slowly.',
                         'Undo it by calling this tool again with action: "limit" and a different value — 0 removes the cap.'
                     ],
@@ -124,14 +124,14 @@ export function registerPauseDownloads(
             const paused = action === 'pause';
             const state = await adapter.readPauseState(id);
 
-            const target = `${service}:${id ?? 'all'}`;
+            const target = `${adapter.id}:${id ?? 'all'}`;
 
             // Asking someone to confirm a no-op teaches them to confirm
             // without reading.
             if (state.paused === paused) {
                 return {
                     target,
-                    summary: `${state.scope} on ${service} ${paused ? 'is already paused' : 'is already running'}.`,
+                    summary: `${state.scope} on ${adapter.id} ${paused ? 'is already paused' : 'is already running'}.`,
                     effects: [],
                     noop: true
                 };
@@ -139,19 +139,19 @@ export function registerPauseDownloads(
 
             const effects = paused
                 ? [
-                      `Stops ${state.scope} on ${service}. Nothing already downloaded is lost, and partial downloads resume where they left off.`,
+                      `Stops ${state.scope} on ${adapter.id}. Nothing already downloaded is lost, and partial downloads resume where they left off.`,
                       // The thing a bare "paused" would let someone believe.
                       'Does NOT stop Radarr or Sonarr searching and grabbing. They keep sending releases, which pile up in this client until it is resumed.',
                       `Undo it by calling this tool again with action: "resume".`
                   ]
                 : [
-                      `Restarts ${state.scope} on ${service}. Downloading resumes immediately and uses bandwidth.`,
+                      `Restarts ${state.scope} on ${adapter.id}. Downloading resumes immediately and uses bandwidth.`,
                       'Anything Radarr or Sonarr grabbed while it was paused starts downloading too.'
                   ];
 
             return {
                 target,
-                summary: `${paused ? 'Pause' : 'Resume'} ${state.scope} on ${service}.`,
+                summary: `${paused ? 'Pause' : 'Resume'} ${state.scope} on ${adapter.id}.`,
                 effects,
                 args: { action, ...(id === undefined ? {} : { id }) }
             };
@@ -160,12 +160,14 @@ export function registerPauseDownloads(
         async apply(_plan, { service, instance, action, id, speed_limit_kbps }) {
             if (action === 'limit') {
                 const kbps = speed_limit_kbps === undefined || speed_limit_kbps === 0 ? undefined : speed_limit_kbps;
-                await findLimitAdapter(adapters, service, instance).setSpeedLimit(kbps);
-                return { limitKbps: kbps ?? null, service };
+                const client = findLimitAdapter(adapters, service, instance);
+                await client.setSpeedLimit(kbps);
+                return { limitKbps: kbps ?? null, service: client.id };
             }
 
-            await findAdapter(adapters, service, instance).setPaused(action === 'pause', id);
-            return { [action === 'pause' ? 'paused' : 'resumed']: `${service}:${id ?? 'all'}` };
+            const adapter = findAdapter(adapters, service, instance);
+            await adapter.setPaused(action === 'pause', id);
+            return { [action === 'pause' ? 'paused' : 'resumed']: `${adapter.id}:${id ?? 'all'}` };
         }
     });
 }

--- a/src/tools/register.ts
+++ b/src/tools/register.ts
@@ -212,7 +212,7 @@ export function registerAllTools(server: McpServer, context: ToolContext): void 
 
     registerDiagnose(server, { adapters, library });
     registerStackHealth(server, adapters, instances);
-    registerGetIndexers(server, adapters.find(hasIndexers));
+    registerGetIndexers(server, adapters.filter(hasIndexers));
     registerGetSubtitles(server, adapters.filter(hasSubtitles));
     registerGetQueue(server, adapters);
     registerGetHistory(server, adapters);

--- a/src/tools/removeQueueItem.ts
+++ b/src/tools/removeQueueItem.ts
@@ -68,7 +68,7 @@ export function registerRemoveQueueItem(
             // an opaque id, and so an id that has already finished downloading
             // fails here instead of as a confusing 404 from a delete.
             if (!hasQueue(adapter)) {
-                throw new ServiceError('NotFound', service, `${service} cannot list its own queue`);
+                throw new ServiceError('NotFound', service, `${adapter.id} cannot list its own queue`);
             }
             const item = (await adapter.getQueue()).find(q => q.id === id);
             if (item === undefined) {

--- a/src/tools/removeQueueItem.ts
+++ b/src/tools/removeQueueItem.ts
@@ -68,11 +68,11 @@ export function registerRemoveQueueItem(
             // an opaque id, and so an id that has already finished downloading
             // fails here instead of as a confusing 404 from a delete.
             if (!hasQueue(adapter)) {
-                throw new ServiceError('NotFound', service, `${adapter.id} cannot list its own queue`);
+                throw new ServiceError('NotFound', adapter.id, `${adapter.id} cannot list its own queue`);
             }
             const item = (await adapter.getQueue()).find(q => q.id === id);
             if (item === undefined) {
-                throw new ServiceError('NotFound', service, `nothing in ${adapter.id}'s queue has id "${id}"`, {
+                throw new ServiceError('NotFound', adapter.id, `nothing in ${adapter.id}'s queue has id "${id}"`, {
                     remedy:
                         'It may have finished or already been removed. Call get_queue for a current list — queue ids are not stable once an item leaves the queue.'
                 });

--- a/src/tools/removeQueueItem.ts
+++ b/src/tools/removeQueueItem.ts
@@ -72,7 +72,7 @@ export function registerRemoveQueueItem(
             }
             const item = (await adapter.getQueue()).find(q => q.id === id);
             if (item === undefined) {
-                throw new ServiceError('NotFound', service, `nothing in ${service}'s queue has id "${id}"`, {
+                throw new ServiceError('NotFound', service, `nothing in ${adapter.id}'s queue has id "${id}"`, {
                     remedy:
                         'It may have finished or already been removed. Call get_queue for a current list — queue ids are not stable once an item leaves the queue.'
                 });
@@ -80,8 +80,8 @@ export function registerRemoveQueueItem(
 
             const effects = [
                 remove_from_client
-                    ? `Removes it from ${service} and deletes any partial data already downloaded.`
-                    : `Removes it from ${service}'s queue but leaves the download itself alone.`
+                    ? `Removes it from ${adapter.id} and deletes any partial data already downloaded.`
+                    : `Removes it from ${adapter.id}'s queue but leaves the download itself alone.`
             ];
 
             // Accepting a flag that silently does nothing is how someone
@@ -90,16 +90,16 @@ export function registerRemoveQueueItem(
                 effects.push(
                     adapter.supportsBlocklist
                         ? 'Blocklists this release, so it will not be grabbed again. Undoing this means finding it in the service\'s blocklist by hand.'
-                        : `Ignored: ${service} has no blocklist of its own. To blocklist a release, remove it from the Radarr or Sonarr queue instead.`
+                        : `Ignored: ${adapter.id} has no blocklist of its own. To blocklist a release, remove it from the Radarr or Sonarr queue instead.`
                 );
             }
 
             return {
-                target: `${service}:${id}`,
-                summary: `Remove ${item.title} from ${service}'s queue (currently ${item.status}).`,
+                target: `${adapter.id}:${id}`,
+                summary: `Remove ${item.title} from ${adapter.id}'s queue (currently ${item.status}).`,
                 effects,
                 args: {
-                    service,
+                    service: adapter.id,
                     id,
                     removeFromClient: remove_from_client,
                     // The *effective* value, not the requested one, so the
@@ -117,7 +117,7 @@ export function registerRemoveQueueItem(
                 removeFromClient: remove_from_client,
                 blocklist: blocklist && adapter.supportsBlocklist
             });
-            return { removed: `${service}:${id}` };
+            return { removed: `${adapter.id}:${id}` };
         }
     });
 }

--- a/src/web/configPage.ts
+++ b/src/web/configPage.ts
@@ -307,7 +307,7 @@ function addDialog(
 
     /** A service that cannot have a second instance and already has one is not
      *  a choice — offering it only to answer "already configured" wastes the
-     *  click. The three multi-instance types are always here, so this list is
+     *  click. The multi-instance types are always here, so this list is
      *  never empty. */
     const offerable = SERVICE_IDS_ALPHABETICAL.filter(
         id => id !== rivalMediaServer && (MULTI_INSTANCE.includes(id) || !configured.has(id))

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -101,6 +101,7 @@ describe('qbittorrentSession', () => {
 
     const session = (over: Partial<Parameters<typeof qbittorrentSession>[0]> = {}, impl?: typeof fetch) =>
         qbittorrentSession({
+            id: 'qbittorrent',
             url: BASE,
             timeoutMs: 1000,
             username: 'u',
@@ -182,7 +183,7 @@ describe('qbittorrentSession', () => {
             return loggedIn();
         }) as unknown as typeof fetch;
 
-        const auth = qbittorrentSession({ url: BASE, timeoutMs: 1000, fetchImpl: impl });
+        const auth = qbittorrentSession({ id: 'qbittorrent', url: BASE, timeoutMs: 1000, fetchImpl: impl });
         expect(await auth.recover?.(forbidden())).toBe(false);
         expect(called).toBe(false);
     });
@@ -235,5 +236,12 @@ describe('qbittorrentSession', () => {
     it('fails when a 204 login sets no cookie', async () => {
         const impl = (async () => new Response(null, { status: 204 })) as unknown as typeof fetch;
         await expect(session({}, impl).recover?.(forbidden())).rejects.toThrow(/no session cookie/i);
+    });
+
+    it('names the qualified instance id, not the bare service, in a login failure', async () => {
+        const impl = (async () => new Response('', { status: 403 })) as unknown as typeof fetch;
+        await expect(session({ id: 'qbittorrent/vpn' }, impl).recover?.(forbidden())).rejects.toThrow(
+            /qbittorrent\/vpn/
+        );
     });
 });

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,4 +1,4 @@
-import type { KeyedServiceConfig } from '../src/config/schema.ts';
+import type { CredentialServiceConfig, KeyedServiceConfig } from '../src/config/schema.ts';
 import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -10,6 +10,8 @@ import { saveConfig, writeConfigAtomic } from '../src/config/save.ts';
 /** The list form makes each service key a union; every assertion here is
  *  about the single form, so this narrows once rather than at each call. */
 const single = (value: unknown): KeyedServiceConfig | undefined => value as KeyedServiceConfig | undefined;
+const singleCredential = (value: unknown): CredentialServiceConfig | undefined =>
+    value as CredentialServiceConfig | undefined;
 
 const freshDir = () => mkdtemp(join(tmpdir(), 'arr-mcp-cfg-'));
 /**
@@ -257,7 +259,7 @@ describe('per-service config shapes', () => {
             auth: AUTH,
             services: { transmission: { url: 'http://h:9091', username: 'u', password: 'p' } }
         });
-        expect(parsed.services.transmission?.username).toBe('u');
+        expect(singleCredential(parsed.services.transmission)?.username).toBe('u');
     });
 
     it('accepts transmission with no credentials at all — LAN RPC is often unauthenticated', () => {

--- a/test/configUi.test.ts
+++ b/test/configUi.test.ts
@@ -468,12 +468,12 @@ describe('adding an instance', () => {
     });
 
     it('refuses a second instance of a service that may only have one', async () => {
-        await seed('  prowlarr:\n    url: http://192.0.2.10:9696\n    api_key: k\n');
+        await seed('  seerr:\n    url: http://192.0.2.10:5055\n    api_key: k\n');
         await signIn();
 
         const res = await call(
             '/ui/config/add',
-            form({ csrf: await csrfFrom(), ...addForm({ type: 'prowlarr', name: 'second' }) })
+            form({ csrf: await csrfFrom(), ...addForm({ type: 'seerr', name: 'second' }) })
         );
         expect(res.status).toBe(400);
     });
@@ -548,14 +548,14 @@ describe('the add dialog', () => {
      *  one, is a click whose only outcome is "already configured". */
     it('drops a configured single-instance service from the picker', async () => {
         await seed(
-            '  prowlarr:\n    url: http://192.0.2.10:9696\n    api_key: k\n' +
+            '  seerr:\n    url: http://192.0.2.10:5055\n    api_key: k\n' +
                 '  radarr:\n    url: http://192.0.2.10:7878\n    api_key: k\n'
         );
         await signIn();
         const page = await (await call('/ui/config')).text();
 
         const offered = [...page.matchAll(/<option value="([^"]+)"/g)].map(m => m[1]);
-        expect(offered).not.toContain('prowlarr');
+        expect(offered).not.toContain('seerr');
         // Radarr takes more than one, so it stays.
         expect(offered).toContain('radarr');
         expect(page).toContain('Already configured, and limited to one instance');

--- a/test/destructiveWrites.test.ts
+++ b/test/destructiveWrites.test.ts
@@ -1,6 +1,6 @@
-import { instancesOf } from './helpers/instances.ts';
 import { describe, expect, it, vi } from 'vitest';
 import * as z from 'zod/v4';
+import { instanceId, type ServiceInstance } from '../src/config/instances.ts';
 import type { AnyServiceConfig, KeyedServiceConfig, ServiceId, CredentialServiceConfig } from '../src/config/schema.ts';
 import { WriteAudit } from '../src/core/audit.ts';
 import { ConfirmTokens } from '../src/core/confirm.ts';
@@ -418,6 +418,25 @@ type Call = (args: Record<string, unknown>) => Promise<{
     structuredContent: WriteToolResult;
 }>;
 
+// `instancesOf` (test/helpers/instances.ts) deliberately ignores `name` — this
+// file's tests are almost all a single unnamed instance per service. This
+// reads it when present, so a config built as `{ ...keyed(port), name: 'spare' }`
+// produces the qualified id its adapter actually carries, without growing that
+// shared helper to cover a case it was written to skip.
+const instancesWithNames = (map: Partial<Record<ServiceId, AnyServiceConfig>>): ServiceInstance[] =>
+    Object.entries(map).flatMap(([type, config]) => {
+        if (config === undefined) return [];
+        const name = (config as { name?: string }).name;
+        return [
+            {
+                id: instanceId(type as ServiceId, name),
+                type: type as ServiceId,
+                ...(name === undefined ? {} : { name }),
+                config
+            }
+        ];
+    });
+
 function harness(
     register: typeof registerDeleteMedia,
     opts: { permissions?: Partial<Record<ServiceId, AnyServiceConfig>>; adapters?: ServiceAdapter[] } = {}
@@ -443,7 +462,7 @@ function harness(
         server as never,
         {
             permissions: permissionSourceFrom(
-                instancesOf(opts.permissions ?? { radarr: tiered(false, true), sonarr: tiered(false, true) })
+                instancesWithNames(opts.permissions ?? { radarr: tiered(false, true), sonarr: tiered(false, true) })
             ),
             confirm: new ConfirmTokens(),
             audit,
@@ -597,6 +616,33 @@ describe('remove_queue_item', () => {
         });
 
         expect(structuredContent.effects.join(' ')).toContain('has no blocklist of its own');
+    });
+
+    it('records the instance in the audit target, not the bare service', async () => {
+        const spare = { ...tiered(false, true), name: 'spare' } as never;
+        const sabQueue = {
+            queue: { slots: [{ nzo_id: 'SABnzbd_nzo_ab12', filename: 'Alien.1979-GROUP', status: 'Downloading' }] }
+        };
+        const impl = (async (input: string | URL | Request) => {
+            const url = new URL(input instanceof Request ? input.url : String(input));
+            if (url.search.includes('name=delete')) return jsonResponse({ status: true });
+            return jsonResponse(sabQueue);
+        }) as unknown as typeof fetch;
+
+        const h = harness(registerRemoveQueueItem, {
+            adapters: [new SabnzbdAdapter(spare, impl)],
+            permissions: { sabnzbd: spare }
+        });
+
+        const first = await h.call({ service: 'sabnzbd', instance: 'spare', id: 'SABnzbd_nzo_ab12' });
+        await h.call({
+            service: 'sabnzbd',
+            instance: 'spare',
+            id: 'SABnzbd_nzo_ab12',
+            confirm: first.structuredContent.confirm_token
+        });
+
+        expect(h.audit.recent(10)[0]?.target).toBe('sabnzbd/spare:SABnzbd_nzo_ab12');
     });
 
     it('is refused by safe_write alone', async () => {

--- a/test/diagnoseChain.test.ts
+++ b/test/diagnoseChain.test.ts
@@ -58,6 +58,7 @@ const healthy = (over: EvidenceOverride = {}): Evidence => {
         queueConfigured: true,
         rejections: [],
         prowlarrConfigured: true,
+        prowlarrDegraded: [],
         scan: { service: 'jellyfin', lastCompleted: '2026-08-05T02:00:00Z' },
         mediaServer: 'jellyfin',
         scanCapable: true,
@@ -383,6 +384,7 @@ describe('buildChain — certainty', () => {
             queueConfigured: true,
             rejections: [],
             prowlarrConfigured: true,
+            prowlarrDegraded: [],
             scan: { service: 'jellyfin', lastCompleted: '2026-08-05T02:00:00Z' },
             mediaServer: 'jellyfin',
             scanCapable: true,
@@ -477,6 +479,7 @@ describe('buildChain — certainty', () => {
             queueConfigured: true,
             rejections: [],
             prowlarrConfigured: true,
+            prowlarrDegraded: [],
             scan: undefined,
             mediaServer: 'jellyfin',
             scanCapable: true,
@@ -1167,16 +1170,16 @@ describe('buildChain — a queue fault does not outrank an already-playable file
 });
 
 describe('buildChain — degraded is read the same way for every stage (N8)', () => {
-    it('reports indexers as unreachable when Prowlarr is named in degraded, even if rejections happens to be present', () => {
+    it('reports indexers as unreachable when Prowlarr is named in prowlarrDegraded, even if rejections happens to be present', () => {
         // `scanStep`/`queueStep` already treat `degraded` (probe reachability
         // — item 2 keeps it separate from `libraryStep`'s `libraryDegraded`)
-        // as authoritative over their own dedicated field; `indexerStep` used
-        // to only ever consult `ev.rejections === undefined`.
+        // as authoritative over their own dedicated field; `indexerStep`
+        // reads its own `prowlarrDegraded` the same way.
         const d = buildChain('some film', {
             ...healthy(),
             item: item({ acquisition: { service: 'radarr', monitored: true, hasFile: false } }),
             rejections: [],
-            degraded: ['prowlarr']
+            prowlarrDegraded: ['prowlarr']
         });
         expect(stepFor(d, 'indexers')?.status).toBe('unknown');
     });
@@ -1190,6 +1193,68 @@ describe('buildChain — degraded is read the same way for every stage (N8)', ()
         });
         expect(stepFor(d, 'queue')?.status).toBe('unknown');
         expect(d.verdict.certain).toBe(false);
+    });
+});
+
+describe('buildChain — the indexer stage with several Prowlarrs', () => {
+    const rejection = (service: string, query: string) => ({
+        service,
+        indexer: 'NZBgeek',
+        at: '2026-09-01T10:00:00Z',
+        reason: 'Query rate limit exceeded',
+        query
+    });
+
+    it('names the instance that reported the blocking rejection', () => {
+        const d = buildChain('some film', {
+            ...healthy(),
+            prowlarrDegraded: [],
+            rejections: [rejection('prowlarr/private', 'some film 2026')]
+        });
+        expect(stepFor(d, 'indexers')).toMatchObject({ status: 'blocked', service: 'prowlarr/private' });
+    });
+
+    // The blocking rejection may be in the half that did not answer, so the
+    // stage says it cannot tell rather than that the indexers are fine.
+    it('answers unknown when one instance is unreachable and the rest found nothing', () => {
+        const d = buildChain('some film', {
+            ...healthy(),
+            prowlarrDegraded: ['prowlarr/private'],
+            rejections: []
+        });
+        const step = stepFor(d, 'indexers');
+        expect(step?.status).toBe('unknown');
+        expect(step?.detail).toContain('prowlarr/private');
+    });
+
+    it('still skips when every instance answered and none mentions it', () => {
+        const d = buildChain('some film', {
+            ...healthy(),
+            prowlarrDegraded: [],
+            rejections: []
+        });
+        expect(stepFor(d, 'indexers')?.status).toBe('skipped');
+    });
+
+    it('answers unknown when every instance is unreachable', () => {
+        const d = buildChain('some film', {
+            ...healthy(),
+            prowlarrDegraded: ['prowlarr/private', 'prowlarr/public'],
+            rejections: undefined
+        });
+        const step = stepFor(d, 'indexers');
+        expect(step?.status).toBe('unknown');
+        expect(step?.detail).toContain('prowlarr/public');
+    });
+
+    it('skips when none is configured', () => {
+        const d = buildChain('some film', {
+            ...healthy(),
+            prowlarrConfigured: false,
+            prowlarrDegraded: [],
+            rejections: undefined
+        });
+        expect(stepFor(d, 'indexers')?.status).toBe('skipped');
     });
 });
 

--- a/test/diagnoseChain.test.ts
+++ b/test/diagnoseChain.test.ts
@@ -275,7 +275,7 @@ describe('buildChain — a symptom never outranks its cause', () => {
         const d = buildChain('some film', {
             ...healthy(),
             item: noFile,
-            rejections: [{ indexer: 'Indexer 1', at: '2026-08-05T09:00:00Z', reason: 'query failed', query: 'Some Film' }]
+            rejections: [{ service: 'prowlarr', indexer: 'Indexer 1', at: '2026-08-05T09:00:00Z', reason: 'query failed', query: 'Some Film' }]
         });
         expect(d.verdict.stage).toBe('indexers');
     });
@@ -303,7 +303,7 @@ describe('buildChain — a symptom does not outrank a chain that is not actually
     it('does not let a stale indexer rejection outrank a file already on disk', () => {
         const d = buildChain('some film', {
             ...healthy(),
-            rejections: [{ indexer: 'Indexer 1', at: '2020-01-01T00:00:00Z', reason: 'query failed', query: 'Some Film' }]
+            rejections: [{ service: 'prowlarr', indexer: 'Indexer 1', at: '2020-01-01T00:00:00Z', reason: 'query failed', query: 'Some Film' }]
         });
         expect(d.verdict).toMatchObject({ stage: 'playable', certain: true });
     });
@@ -567,7 +567,7 @@ describe('buildChain — verdict order is pinned, not incidental (I7)', () => {
             ...healthy(),
             item: item({ acquisition: { service: 'radarr', monitored: true, hasFile: false } }),
             queue: { items: [{ service: 'sabnzbd', id: '1', title: queueTitle('sabnzbd', 'Some.Film.2026'), status: 'stalled', errorMessage: 'x' }], partial: [] },
-            rejections: [{ indexer: 'Indexer 1', at: '2026-08-05T09:00:00Z', reason: 'query failed', query: 'Some Film' }]
+            rejections: [{ service: 'prowlarr', indexer: 'Indexer 1', at: '2026-08-05T09:00:00Z', reason: 'query failed', query: 'Some Film' }]
         });
         expect(d.verdict.stage).toBe('queue');
     });
@@ -576,7 +576,7 @@ describe('buildChain — verdict order is pinned, not incidental (I7)', () => {
         const d = buildChain('some film', {
             ...healthy(),
             item: item({ acquisition: { service: 'radarr', monitored: true, hasFile: false } }),
-            rejections: [{ indexer: 'Indexer 1', at: '2026-08-05T09:00:00Z', reason: 'query failed', query: 'Some Film' }]
+            rejections: [{ service: 'prowlarr', indexer: 'Indexer 1', at: '2026-08-05T09:00:00Z', reason: 'query failed', query: 'Some Film' }]
         });
         expect(d.verdict.stage).toBe('indexers');
     });

--- a/test/diagnoseChain.test.ts
+++ b/test/diagnoseChain.test.ts
@@ -805,7 +805,8 @@ describe('buildChain — the file remedy matches what was actually checked (N2)'
             item: item({ acquisition: { service: 'radarr', monitored: true, hasFile: false } }),
             queue: undefined,
             rejections: undefined,
-            degraded: ['sabnzbd', 'prowlarr']
+            degraded: ['sabnzbd', 'prowlarr'],
+            prowlarrDegraded: ['prowlarr']
         });
         expect(d.verdict.stage).toBe('file');
         expect(d.verdict.certain).toBe(false);

--- a/test/getIndexers.test.ts
+++ b/test/getIndexers.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { KeyedServiceConfig } from '../src/config/schema.ts';
 import { ProwlarrAdapter } from '../src/services/prowlarr.ts';
-import { buildGetIndexers } from '../src/tools/getIndexers.ts';
+import { buildGetIndexers, summarizeIndexers } from '../src/tools/getIndexers.ts';
 import { repeat } from './helpers/bigFixture.ts';
 import { expectWithinBudget } from './helpers/budget.ts';
 import { serving } from './helpers/serve.ts';
@@ -304,5 +304,41 @@ describe('several Prowlarrs', () => {
 
     it('answers empty when none is configured', async () => {
         expect(await buildGetIndexers([], { detail: 'standard', limit: 50 })).toMatchObject({ total: 0, degraded: [] });
+    });
+
+    // A healthy Prowlarr with nothing configured also has total === 0. Only
+    // the fraction of instances actually degraded may claim total failure.
+    it('does not claim total failure when a healthy instance simply has no indexers', async () => {
+        const broken = new ProwlarrAdapter({ ...config, name: 'private' }, refuse);
+        const empty = named('public', { ...routes, '/api/v1/indexer': [] });
+        const result = await buildGetIndexers([empty, broken], { detail: 'standard', limit: 50 });
+
+        expect(result.total).toBe(0);
+        expect(result.degraded).toEqual(['prowlarr/private']);
+
+        const summary = summarizeIndexers(result, 2);
+        expect(summary).not.toContain('no indexer information available');
+        expect(summary).toContain('prowlarr/private could not be reached');
+    });
+});
+
+describe('summarizeIndexers', () => {
+    const base = { items: [], returned: 0, offset: 0, truncated: false, disabledCount: 0 };
+
+    it('claims total failure only when every configured instance degraded', () => {
+        const result = { ...base, total: 0, degraded: ['prowlarr/a', 'prowlarr/b'] };
+        expect(summarizeIndexers(result, 2)).toBe('prowlarr/a, prowlarr/b could not be reached; no indexer information available.');
+    });
+
+    it('names the degraded instance alongside the count when the others answered', () => {
+        const result = { ...base, total: 3, returned: 3, degraded: ['prowlarr/b'] };
+        expect(summarizeIndexers(result, 2)).toBe('3 of 3 indexer(s). prowlarr/b could not be reached.');
+    });
+
+    it('does not claim total failure when a healthy instance has zero indexers and another degraded', () => {
+        const result = { ...base, total: 0, degraded: ['prowlarr/b'] };
+        const summary = summarizeIndexers(result, 2);
+        expect(summary).not.toMatch(/no indexer information available/);
+        expect(summary).toContain('prowlarr/b could not be reached');
     });
 });

--- a/test/getIndexers.test.ts
+++ b/test/getIndexers.test.ts
@@ -295,6 +295,44 @@ describe('several Prowlarrs', () => {
         );
     });
 
+    it('merges rejections newest-first, not in whichever order the instances answered', async () => {
+        const withRejection = (date: string) => ({
+            ...routes,
+            '/api/v1/history': {
+                records: [{ indexerId: 1, date, successful: false, data: { query: 'q', reason: 'r' } }]
+            }
+        });
+
+        // The older rejection belongs to the instance listed first, so a merge
+        // that trusted arrival order over `at` would put it first too.
+        const result = await buildGetIndexers(
+            [named('public', withRejection('2020-01-01T00:00:00Z')), named('private', withRejection('2025-01-01T00:00:00Z'))],
+            { detail: 'full', limit: 50 }
+        );
+
+        expect(result.recentRejections?.map(r => r.at)).toEqual(['2025-01-01T00:00:00Z', '2020-01-01T00:00:00Z']);
+    });
+
+    it('bounds the merged rejection list to the requested limit', async () => {
+        const withRejections = (dates: string[]) => ({
+            ...routes,
+            '/api/v1/history': {
+                records: dates.map(date => ({ indexerId: 1, date, successful: false, data: { query: 'q', reason: 'r' } }))
+            }
+        });
+
+        const result = await buildGetIndexers(
+            [
+                named('public', withRejections(['2025-01-03T00:00:00Z', '2025-01-01T00:00:00Z'])),
+                named('private', withRejections(['2025-01-04T00:00:00Z', '2025-01-02T00:00:00Z']))
+            ],
+            { detail: 'full', limit: 2 }
+        );
+
+        expect(result.recentRejections).toHaveLength(2);
+        expect(result.recentRejections?.map(r => r.at)).toEqual(['2025-01-04T00:00:00Z', '2025-01-03T00:00:00Z']);
+    });
+
     it('sorts by instance so two of them produce a stable order', async () => {
         const first = await buildGetIndexers([named('public'), named('private')], { detail: 'minimal', limit: 50 });
         const second = await buildGetIndexers([named('private'), named('public')], { detail: 'minimal', limit: 50 });

--- a/test/getIndexers.test.ts
+++ b/test/getIndexers.test.ts
@@ -57,7 +57,7 @@ const adapter = (r: Record<string, unknown> = routes) => new ProwlarrAdapter(con
 
 describe('get_indexers', () => {
     it('joins indexers with their status and statistics', async () => {
-        const result = await buildGetIndexers(adapter(), { detail: 'full', limit: 50 });
+        const result = await buildGetIndexers([adapter()], { detail: 'full', limit: 50 });
         expect(result.items.find(i => i.name === 'NZBgeek')).toMatchObject({
             service: 'prowlarr',
             id: 1,
@@ -71,34 +71,34 @@ describe('get_indexers', () => {
     });
 
     it('fences the failure message, which is text the indexer chose', async () => {
-        const result = await buildGetIndexers(adapter(), { detail: 'full', limit: 50 });
+        const result = await buildGetIndexers([adapter()], { detail: 'full', limit: 50 });
         expect(result.items.find(i => i.name === 'NZBgeek')?.lastFailure).toBe(
             '<<untrusted:prowlarr.mostRecentFailure>>Request limit reached<</untrusted>>'
         );
     });
 
     it('reports an indexer with no status row as not disabled rather than omitting it', async () => {
-        const result = await buildGetIndexers(adapter(), { detail: 'full', limit: 50 });
+        const result = await buildGetIndexers([adapter()], { detail: 'full', limit: 50 });
         const torrentio = result.items.find(i => i.name === 'Torrentio');
         expect(torrentio?.enabled).toBe(false);
         expect(torrentio?.disabledUntil).toBeUndefined();
     });
 
     it('drops statistics at detail: standard but keeps health', async () => {
-        const result = await buildGetIndexers(adapter(), { detail: 'standard', limit: 50 });
+        const result = await buildGetIndexers([adapter()], { detail: 'standard', limit: 50 });
         const geek = result.items.find(i => i.name === 'NZBgeek');
         expect(geek?.queries).toBeUndefined();
         expect(geek?.disabledUntil).toBe('2026-08-05T12:00:00Z');
     });
 
     it('returns name and enabled only at detail: minimal', async () => {
-        const result = await buildGetIndexers(adapter(), { detail: 'minimal', limit: 50 });
+        const result = await buildGetIndexers([adapter()], { detail: 'minimal', limit: 50 });
         expect(Object.keys(result.items[0] ?? {}).sort()).toEqual(['enabled', 'id', 'name', 'service']);
     });
 
     it('reports truncation honestly', async () => {
         const many = repeat(INDEXERS[0]!, 120).map((i, n) => ({ ...i, id: n }));
-        const result = await buildGetIndexers(adapter({ ...routes, '/api/v1/indexer': many }), {
+        const result = await buildGetIndexers([adapter({ ...routes, '/api/v1/indexer': many })], {
             detail: 'standard',
             limit: 50
         });
@@ -107,7 +107,7 @@ describe('get_indexers', () => {
 
     it('still returns indexers when the statistics endpoint is down', async () => {
         const result = await buildGetIndexers(
-            adapter({ '/api/v1/indexer': INDEXERS, '/api/v1/indexerstatus': STATUS }),
+            [adapter({ '/api/v1/indexer': INDEXERS, '/api/v1/indexerstatus': STATUS })],
             { detail: 'full', limit: 50 }
         );
         expect(result.items).toHaveLength(2);
@@ -120,13 +120,13 @@ describe('get_indexers', () => {
             throw Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' });
         }) as unknown as typeof fetch;
 
-        const result = await buildGetIndexers(new ProwlarrAdapter(config, refuse), { detail: 'standard', limit: 50 });
+        const result = await buildGetIndexers([new ProwlarrAdapter(config, refuse)], { detail: 'standard', limit: 50 });
         expect(result.items).toEqual([]);
         expect(result.degraded).toEqual(['prowlarr']);
     });
 
     it('returns an empty result rather than throwing when Prowlarr is not configured', async () => {
-        expect(await buildGetIndexers(undefined, { detail: 'standard', limit: 50 })).toMatchObject({
+        expect(await buildGetIndexers([], { detail: 'standard', limit: 50 })).toMatchObject({
             items: [],
             total: 0,
             degraded: []
@@ -134,9 +134,10 @@ describe('get_indexers', () => {
     });
 
     it('returns the actual recent rejections, not just a count of them', async () => {
-        const result = await buildGetIndexers(adapter(), { detail: 'full', limit: 50 });
+        const result = await buildGetIndexers([adapter()], { detail: 'full', limit: 50 });
         expect(result.recentRejections).toEqual([
             {
+                service: 'prowlarr',
                 indexer: 'NZBgeek',
                 at: '2026-08-04T22:10:00Z',
                 reason: '<<untrusted:prowlarr.reason>>Query rate limit exceeded<</untrusted>>',
@@ -146,19 +147,19 @@ describe('get_indexers', () => {
     });
 
     it('ignores successful history rows — those are not rejections', async () => {
-        const result = await buildGetIndexers(adapter(), { detail: 'full', limit: 50 });
+        const result = await buildGetIndexers([adapter()], { detail: 'full', limit: 50 });
         expect(result.recentRejections).toHaveLength(1);
     });
 
     it('omits rejections below detail: full, where they are noise', async () => {
         for (const detail of ['minimal', 'standard'] as const) {
-            const result = await buildGetIndexers(adapter(), { detail, limit: 50 });
+            const result = await buildGetIndexers([adapter()], { detail, limit: 50 });
             expect(result.recentRejections).toBeUndefined();
         }
     });
 
     it('reports an empty rejection list rather than omitting it when nothing was rejected', async () => {
-        const result = await buildGetIndexers(adapter({ ...routes, '/api/v1/history': { records: [] } }), {
+        const result = await buildGetIndexers([adapter({ ...routes, '/api/v1/history': { records: [] } })], {
             detail: 'full',
             limit: 50
         });
@@ -171,7 +172,7 @@ describe('get_indexers', () => {
             '/api/v1/indexerstatus': STATUS,
             '/api/v1/indexerstats': STATS
         };
-        const result = await buildGetIndexers(adapter(noHistory), { detail: 'full', limit: 50 });
+        const result = await buildGetIndexers([adapter(noHistory)], { detail: 'full', limit: 50 });
         expect(result.items).toHaveLength(2);
         expect(result.recentRejections).toBeUndefined();
         expect(result.degraded).toEqual([]);
@@ -181,7 +182,7 @@ describe('get_indexers', () => {
         // A busy Prowlarr has tens of indexers, not hundreds. This is the
         // number that matters in practice, and it should be cheap.
         const fifty = repeat(INDEXERS[0]!, 50).map((i, n) => ({ ...i, id: n, name: `Indexer number ${n}` }));
-        const result = await buildGetIndexers(adapter({ ...routes, '/api/v1/indexer': fifty }), {
+        const result = await buildGetIndexers([adapter({ ...routes, '/api/v1/indexer': fifty })], {
             detail: 'full',
             limit: 500
         });
@@ -193,7 +194,7 @@ describe('get_indexers', () => {
         // The ceiling exists so a shaping regression — an extra field, an
         // unfenced blob — shows up as a jump rather than silently.
         const many = repeat(INDEXERS[0]!, 500).map((i, n) => ({ ...i, id: n, name: `Indexer number ${n}` }));
-        const result = await buildGetIndexers(adapter({ ...routes, '/api/v1/indexer': many }), {
+        const result = await buildGetIndexers([adapter({ ...routes, '/api/v1/indexer': many })], {
             detail: 'full',
             limit: 500
         });
@@ -245,16 +246,63 @@ describe('counting disabled indexers at minimal detail', () => {
     };
 
     it('counts the disabled ones even when the projection drops the field', async () => {
-        const result = await buildGetIndexers(adapter(rows), { detail: 'minimal', limit: 50 });
+        const result = await buildGetIndexers([adapter(rows)], { detail: 'minimal', limit: 50 });
 
         expect(result.items[0]?.disabledUntil).toBeUndefined(); // the premise
         expect(result.disabledCount).toBe(2);
     });
 
     it('agrees with the full-detail count', async () => {
-        const minimal = await buildGetIndexers(adapter(rows), { detail: 'minimal', limit: 50 });
-        const full = await buildGetIndexers(adapter(rows), { detail: 'full', limit: 50 });
+        const minimal = await buildGetIndexers([adapter(rows)], { detail: 'minimal', limit: 50 });
+        const full = await buildGetIndexers([adapter(rows)], { detail: 'full', limit: 50 });
 
         expect(minimal.disabledCount).toBe(full.disabledCount);
+    });
+});
+
+describe('several Prowlarrs', () => {
+    const named = (name: string, r: Record<string, unknown> = routes) =>
+        new ProwlarrAdapter({ ...config, name }, serving(r));
+
+    const refuse = (async () => {
+        throw new Error('connection refused');
+    }) as unknown as typeof fetch;
+
+    it('merges the indexers of every instance, attributed to each', async () => {
+        const result = await buildGetIndexers([named('public'), named('private')], { detail: 'standard', limit: 50 });
+
+        expect(result.total).toBe(4);
+        expect(new Set(result.items.map(i => i.service))).toEqual(new Set(['prowlarr/public', 'prowlarr/private']));
+    });
+
+    // A partial list that says which Prowlarr is missing is useful; one that
+    // silently drops half is not.
+    it('degrades one by name while the other still answers', async () => {
+        const broken = new ProwlarrAdapter({ ...config, name: 'private' }, refuse);
+        const result = await buildGetIndexers([named('public'), broken], { detail: 'standard', limit: 50 });
+
+        expect(result.degraded).toEqual(['prowlarr/private']);
+        expect(result.total).toBe(2);
+        expect(result.items.every(i => i.service === 'prowlarr/public')).toBe(true);
+    });
+
+    it('attributes a merged rejection to the instance that reported it', async () => {
+        const result = await buildGetIndexers([named('public'), named('private')], { detail: 'full', limit: 50 });
+
+        expect(result.recentRejections?.length).toBeGreaterThan(0);
+        expect(new Set(result.recentRejections?.map(r => r.service))).toEqual(
+            new Set(['prowlarr/public', 'prowlarr/private'])
+        );
+    });
+
+    it('sorts by instance so two of them produce a stable order', async () => {
+        const first = await buildGetIndexers([named('public'), named('private')], { detail: 'minimal', limit: 50 });
+        const second = await buildGetIndexers([named('private'), named('public')], { detail: 'minimal', limit: 50 });
+
+        expect(first.items.map(i => `${i.service}:${i.name}`)).toEqual(second.items.map(i => `${i.service}:${i.name}`));
+    });
+
+    it('answers empty when none is configured', async () => {
+        expect(await buildGetIndexers([], { detail: 'standard', limit: 50 })).toMatchObject({ total: 0, degraded: [] });
     });
 });

--- a/test/instances.test.ts
+++ b/test/instances.test.ts
@@ -103,9 +103,10 @@ describe('what the list form refuses', () => {
     /**
      * The boundary is the design, so it is tested rather than commented.
      *
-     * `register.ts` selects Jellyfin, Seerr and Plex with a `.find`, and the
-     * identity resolver is built from *the* Jellyfin config. Admitting a list
-     * there would produce configurations the code silently degrades on.
+     * `register.ts` selects Seerr with a `.find`; Jellyfin and Plex go through
+     * `theMediaServer`, which `.filter`s and throws on more than one. Either
+     * way, admitting a list here would produce configurations the code
+     * silently degrades on or rejects at request time instead of at parse time.
      */
     it('refuses a list under a service that may not repeat, and names the ones that may', () => {
         for (const type of ['jellyfin', 'seerr', 'plex']) {
@@ -236,11 +237,10 @@ describe('the download clients and Prowlarr take a list', () => {
         const config = parse({
             sabnzbd: entry(undefined, 8080),
             prowlarr: entry(undefined, 9696),
-            // A single-element list, not a bare block — a bare credential block
-            // has no `name` field, same as the keyed single form.
-            qbittorrent: [credential('x', 8081)]
+            qbittorrent: { url: 'http://192.0.2.10:8081', permissions: {} },
+            transmission: { url: 'http://192.0.2.10:9091', permissions: {} }
         });
-        expect(listInstances(config).map(i => i.id)).toEqual(['prowlarr', 'qbittorrent/x', 'sabnzbd']);
+        expect(listInstances(config).map(i => i.id)).toEqual(['prowlarr', 'qbittorrent', 'sabnzbd', 'transmission']);
     });
 
     it('reports the new types as multi-instance', () => {

--- a/test/instances.test.ts
+++ b/test/instances.test.ts
@@ -44,10 +44,16 @@ describe('the single form is untouched', () => {
     });
 });
 
+// Transmission and qBittorrent take credentials rather than an api_key, so a
+// loop over every multi-instance type needs to build the right shape for each.
+const CREDENTIAL_TYPES = new Set(['transmission', 'qbittorrent']);
+const instanceOf = (type: string, name: string, port: number) =>
+    CREDENTIAL_TYPES.has(type) ? { name, url: `http://192.0.2.10:${port}`, permissions: {} } : entry(name, port);
+
 describe('the list form', () => {
     it('parses under each service that may repeat', () => {
         for (const type of MULTI_INSTANCE) {
-            const config = parse({ [type]: [entry('hd', 7878), entry('4k', 7879)] });
+            const config = parse({ [type]: [instanceOf(type, 'hd', 7878), instanceOf(type, '4k', 7879)] });
             expect(listInstances(config).map(i => i.id)).toEqual([`${type}/4k`, `${type}/hd`]);
         }
     });
@@ -97,14 +103,16 @@ describe('what the list form refuses', () => {
     /**
      * The boundary is the design, so it is tested rather than commented.
      *
-     * `register.ts` selects Prowlarr, Jellyfin and Seerr with a `.find`, and the
+     * `register.ts` selects Jellyfin, Seerr and Plex with a `.find`, and the
      * identity resolver is built from *the* Jellyfin config. Admitting a list
      * there would produce configurations the code silently degrades on.
      */
     it('refuses a list under a service that may not repeat, and names the ones that may', () => {
-        for (const type of ['prowlarr', 'sabnzbd', 'jellyfin', 'seerr', 'transmission']) {
+        for (const type of ['jellyfin', 'seerr', 'plex']) {
             expect(isMultiInstance(type as never)).toBe(false);
-            expect(() => parse({ [type]: [entry('a', 9999)] })).toThrow(/only bazarr, radarr, sonarr/i);
+            expect(() => parse({ [type]: [entry('a', 9999)] })).toThrow(
+                /only bazarr, prowlarr, qbittorrent, radarr, sabnzbd, sonarr, transmission/i
+            );
         }
     });
 });
@@ -178,5 +186,67 @@ describe('the audit trail', () => {
         } finally {
             audit.close();
         }
+    });
+});
+
+describe('the download clients and Prowlarr take a list', () => {
+    const credential = (name: string, port: number) => ({
+        name,
+        url: `http://192.0.2.10:${port}`,
+        permissions: {}
+    });
+
+    it('accepts two SABnzbds and gives each a qualified id', () => {
+        const config = parse({ sabnzbd: [entry('main', 8080), entry('spare', 8081)] });
+        expect(listInstances(config).map(i => i.id)).toEqual(['sabnzbd/main', 'sabnzbd/spare']);
+    });
+
+    it('accepts two Prowlarrs', () => {
+        const config = parse({ prowlarr: [entry('public', 9696), entry('private', 9697)] });
+        expect(listInstances(config).map(i => i.id)).toEqual(['prowlarr/private', 'prowlarr/public']);
+    });
+
+    // The credential shape has no api_key, so it needs its own named variant —
+    // the keyed one would reject it for a missing field.
+    it('accepts two qBittorrents, which carry credentials rather than a key', () => {
+        const config = parse({ qbittorrent: [credential('vpn', 8081), credential('direct', 8082)] });
+        expect(listInstances(config).map(i => i.id)).toEqual(['qbittorrent/direct', 'qbittorrent/vpn']);
+    });
+
+    it('accepts two Transmissions', () => {
+        const config = parse({ transmission: [credential('vpn', 9091), credential('direct', 9092)] });
+        expect(listInstances(config).map(i => i.id)).toEqual(['transmission/direct', 'transmission/vpn']);
+    });
+
+    it('refuses two instances sharing a name, whatever the case', () => {
+        expect(() => parse({ sabnzbd: [entry('Main', 8080), entry('main', 8081)] })).toThrow(/duplicate instance name/);
+        expect(() => parse({ qbittorrent: [credential('VPN', 8081), credential('vpn', 8082)] })).toThrow(
+            /duplicate instance name/
+        );
+    });
+
+    it('still refuses a list for the three that stay single, naming the seven that do not', () => {
+        for (const type of ['jellyfin', 'plex', 'seerr'] as const) {
+            expect(() => parse({ [type]: [entry('a', 8096), entry('b', 8097)] })).toThrow(/can be a list of instances/);
+        }
+        expect(() => parse({ seerr: [entry('a', 5055)] })).toThrow(/prowlarr/);
+    });
+
+    it('keeps every single block parsing unchanged, with a bare id', () => {
+        const config = parse({
+            sabnzbd: entry(undefined, 8080),
+            prowlarr: entry(undefined, 9696),
+            // A single-element list, not a bare block — a bare credential block
+            // has no `name` field, same as the keyed single form.
+            qbittorrent: [credential('x', 8081)]
+        });
+        expect(listInstances(config).map(i => i.id)).toEqual(['prowlarr', 'qbittorrent/x', 'sabnzbd']);
+    });
+
+    it('reports the new types as multi-instance', () => {
+        for (const type of ['sabnzbd', 'prowlarr', 'transmission', 'qbittorrent'] as const) {
+            expect(isMultiInstance(type)).toBe(true);
+        }
+        expect(MULTI_INSTANCE).toHaveLength(7);
     });
 });

--- a/test/mutate.test.ts
+++ b/test/mutate.test.ts
@@ -78,6 +78,26 @@ describe('adding an instance', () => {
         expect(() => addInstance(two, { type: 'radarr', name: '4K', fields: KEYED })).toThrow(/already has an instance/);
     });
 
+    /**
+     * qBittorrent and Transmission are credential-shaped, not keyed: `applyFields`
+     * takes a different branch for them (username/password, no `api_key`), and
+     * this is the only place that path is exercised through `addInstance` at all.
+     */
+    it('adds a second qBittorrent, forcing the rename of the unnamed one', () => {
+        const one = base({ qbittorrent: { url: 'http://192.0.2.10:8081', username: 'u', password: 'p' } });
+        const two = addInstance(one, {
+            type: 'qbittorrent',
+            name: 'vpn',
+            renameExistingTo: 'direct',
+            fields: { url: 'http://192.0.2.11:8081', username: 'u2', password: 'p2' }
+        });
+
+        expect(ids(two)).toEqual(['qbittorrent/direct', 'qbittorrent/vpn']);
+        const vpn = listInstances(two).find(i => i.id === 'qbittorrent/vpn');
+        expect((vpn?.config as { username?: string }).username).toBe('u2');
+        expect((vpn?.config as { api_key?: string }).api_key).toBeUndefined();
+    });
+
     it('refuses an edit that would produce an invalid config, before it reaches disk', () => {
         expect(() => addInstance(base(), { type: 'radarr', fields: { url: 'not-a-url', api_key: 'k' } })).toThrow(
             ConfigEditError

--- a/test/mutate.test.ts
+++ b/test/mutate.test.ts
@@ -24,8 +24,8 @@ describe('adding an instance', () => {
     });
 
     it('refuses a second instance of a service that may only have one', () => {
-        const one = base({ prowlarr: KEYED });
-        expect(() => addInstance(one, { type: 'prowlarr', name: 'b', fields: KEYED })).toThrow(ConfigEditError);
+        const one = base({ seerr: KEYED });
+        expect(() => addInstance(one, { type: 'seerr', name: 'b', fields: KEYED })).toThrow(ConfigEditError);
     });
 
     /**

--- a/test/pauseDownloads.test.ts
+++ b/test/pauseDownloads.test.ts
@@ -175,6 +175,21 @@ describe('qbittorrent pause', () => {
             jsonResponse([{ hash: 'a', state: 'pausedDL' }, { hash: 'b', state: 'stoppedUP' }])) as unknown as typeof fetch;
         expect((await adapterWith(impl).readPauseState()).paused).toBe(true);
     });
+
+    it('names the qualified instance, not the bare service, when login is refused', async () => {
+        const impl = (async (input: string | URL | Request) => {
+            const url = new URL(input instanceof Request ? input.url : String(input));
+            if (url.pathname.endsWith('/torrents/info')) return jsonResponse([{ hash: 'abc', state: 'downloading' }]);
+            if (url.pathname.endsWith('/auth/login')) return new Response('', { status: 403 });
+            return new Response('Forbidden', { status: 403 });
+        }) as unknown as typeof fetch;
+
+        const named = new QbittorrentAdapter(
+            { ...credential(8081), name: 'vpn', username: 'u', password: 'p' },
+            impl
+        );
+        await expect(named.setPaused(true, 'abc')).rejects.toThrow(/qbittorrent\/vpn/);
+    });
 });
 
 // --- the tool ------------------------------------------------------------

--- a/test/pauseDownloads.test.ts
+++ b/test/pauseDownloads.test.ts
@@ -1,6 +1,6 @@
-import { instancesOf } from './helpers/instances.ts';
 import { describe, expect, it, vi } from 'vitest';
 import type * as z from 'zod/v4';
+import { instanceId, type ServiceInstance } from '../src/config/instances.ts';
 import type { AnyServiceConfig, CredentialServiceConfig, KeyedServiceConfig, ServiceId } from '../src/config/schema.ts';
 import { WriteAudit } from '../src/core/audit.ts';
 import { ConfirmTokens } from '../src/core/confirm.ts';
@@ -184,17 +184,40 @@ type Call = (args: Record<string, unknown>) => Promise<{
     structuredContent: WriteToolResult;
 }>;
 
+/** Shared by `harness`'s default SABnzbd and any test that needs a second,
+ *  independently-named one against the same fake queue behaviour. */
+function sabFetch(paused: { value: boolean } = { value: false }): typeof fetch {
+    return (async (input: string | URL | Request) => {
+        const url = new URL(input instanceof Request ? input.url : String(input));
+        if (url.search.includes('mode=queue')) return jsonResponse({ queue: { paused: paused.value, slots: [] } });
+        return jsonResponse({ status: true });
+    }) as unknown as typeof fetch;
+}
+
+// `instancesOf` deliberately ignores `name` — almost every test here wants a
+// single unnamed instance. This reads it when present, so a config built as
+// `{ ...keyed(port), name: 'spare' }` produces the qualified id its adapter
+// actually carries, without growing that shared helper to cover a case it was
+// written to skip.
+const instancesWithNames = (map: Partial<Record<ServiceId, AnyServiceConfig>>): ServiceInstance[] =>
+    Object.entries(map).flatMap(([type, config]) => {
+        if (config === undefined) return [];
+        const name = (config as { name?: string }).name;
+        return [
+            {
+                id: instanceId(type as ServiceId, name),
+                type: type as ServiceId,
+                ...(name === undefined ? {} : { name }),
+                config
+            }
+        ];
+    });
+
 function harness(
     opts: { adapters?: ServiceAdapter[]; permissions?: Partial<Record<ServiceId, AnyServiceConfig>> } = {}
 ) {
     const sabPaused = { value: false };
-    const sabImpl = (async (input: string | URL | Request) => {
-        const url = new URL(input instanceof Request ? input.url : String(input));
-        if (url.search.includes('mode=queue')) return jsonResponse({ queue: { paused: sabPaused.value, slots: [] } });
-        return jsonResponse({ status: true });
-    }) as unknown as typeof fetch;
-
-    const adapters = opts.adapters ?? [new SabnzbdAdapter(keyed(8080), sabImpl)];
+    const adapters = opts.adapters ?? [new SabnzbdAdapter(keyed(8080), sabFetch(sabPaused))];
 
     let call: Call = () => Promise.reject(new Error('not registered'));
     const server = {
@@ -208,7 +231,7 @@ function harness(
         server as never,
         {
             permissions: permissionSourceFrom(
-                instancesOf(opts.permissions ?? { sabnzbd: keyed(8080) as unknown as AnyServiceConfig })
+                instancesWithNames(opts.permissions ?? { sabnzbd: keyed(8080) as unknown as AnyServiceConfig })
             ),
             confirm: new ConfirmTokens(),
             audit,
@@ -301,5 +324,23 @@ describe('pause_downloads', () => {
         });
 
         expect(applied.structuredContent.applied).toBe(true);
+    });
+
+    it('records the instance in the audit target, not the bare service', async () => {
+        const spare = { ...keyed(8081), name: 'spare' } as never;
+        const h = harness({
+            adapters: [new SabnzbdAdapter(spare, sabFetch())],
+            permissions: { sabnzbd: spare }
+        });
+
+        const preview = await h.call({ service: 'sabnzbd', instance: 'spare', action: 'pause' });
+        await h.call({
+            service: 'sabnzbd',
+            instance: 'spare',
+            action: 'pause',
+            confirm: preview.structuredContent.confirm_token
+        });
+
+        expect(h.audit.recent(10)[0]?.target).toBe('sabnzbd/spare:all');
     });
 });

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { ConfigSchema } from '../src/config/schema.ts';
 import { buildAdapters } from '../src/services/registry.ts';
+import { SabnzbdAdapter } from '../src/services/sabnzbd.ts';
 
 const AUTH = { bearer_token: 'a'.repeat(64), password_hash: 'scrypt$00$11' };
 const keyed = (port: number) => ({ url: `http://h:${port}`, api_key: 'k' });
@@ -64,5 +65,65 @@ describe('buildAdapters', () => {
             services: { transmission: { url: 'http://h:9091' } }
         });
         expect(buildAdapters(config).map(a => a.id)).toEqual(['transmission']);
+    });
+});
+
+describe('multi-instance download clients and Prowlarr', () => {
+    const keyed = (name: string | undefined, port: number) => ({
+        ...(name === undefined ? {} : { name }),
+        url: `http://192.0.2.10:${port}`,
+        api_key: 'k',
+        permissions: {}
+    });
+
+    const credential = (name: string, port: number) => ({
+        name,
+        url: `http://192.0.2.10:${port}`,
+        permissions: {}
+    });
+
+    const build = (services: unknown) =>
+        buildAdapters(ConfigSchema.parse({ auth: AUTH, services }));
+
+    it('gives two SABnzbds distinct ids and names', () => {
+        const adapters = build({ sabnzbd: [keyed('main', 8080), keyed('spare', 8081)] });
+        expect(adapters.map(a => a.id)).toEqual(['sabnzbd/main', 'sabnzbd/spare']);
+        expect(adapters.map(a => a.instance)).toEqual(['main', 'spare']);
+        // Capability dispatch keys on this, so both must still say what they are.
+        expect(adapters.every(a => a.type === 'sabnzbd')).toBe(true);
+    });
+
+    it('gives two Prowlarrs distinct ids', () => {
+        expect(build({ prowlarr: [keyed('public', 9696), keyed('private', 9697)] }).map(a => a.id)).toEqual([
+            'prowlarr/private',
+            'prowlarr/public'
+        ]);
+    });
+
+    it('gives the credential clients distinct ids', () => {
+        expect(build({ qbittorrent: [credential('vpn', 8081), credential('direct', 8082)] }).map(a => a.id)).toEqual([
+            'qbittorrent/direct',
+            'qbittorrent/vpn'
+        ]);
+        expect(build({ transmission: [credential('vpn', 9091), credential('direct', 9092)] }).map(a => a.id)).toEqual([
+            'transmission/direct',
+            'transmission/vpn'
+        ]);
+    });
+
+    it('keeps the bare id for a single block', () => {
+        expect(build({ sabnzbd: keyed(undefined, 8080) })[0]?.id).toBe('sabnzbd');
+        expect(build({ sabnzbd: keyed(undefined, 8080) })[0]?.instance).toBeUndefined();
+    });
+
+    // ServiceHttp's first argument is what reaches error messages and log rows.
+    // Left as the literal, two clients produce failures nothing can tell apart.
+    it('carries the qualified id into the errors the transport raises', async () => {
+        const refuse = (async () => {
+            throw new Error('connection refused');
+        }) as unknown as typeof fetch;
+
+        const adapter = new SabnzbdAdapter({ ...keyed('spare', 8081), timeout_ms: 10_000 } as never, refuse);
+        await expect(adapter.getVersion()).rejects.toMatchObject({ service: 'sabnzbd/spare' });
     });
 });


### PR DESCRIPTION
Closes #196.

`radarr`, `sonarr` and `bazarr` have taken a list of named instances since 0.7. This widens that to **`prowlarr`, `sabnzbd`, `transmission` and `qbittorrent`**, so seven services now, three deliberately still single.

## Why these four, and not the other three

The original multi-instance spec refused all five remaining services with one argument: allowing a list everywhere would permit configurations the code then degrades on. That reasoning has aged unevenly.

It is still exactly right for **Jellyfin/Plex** (`get_library`'s `presence` asks whether the media server can see a file, which has no answer with two of them, and it is also why the schema already refuses both together) and for **Seerr** (a request carries the identity of whoever made it, so a second Seerr makes "which one do I ask" a guess with an approver on the other end).

It is no longer right for the download clients or Prowlarr, because the tool surface built since then already resolves instances on every path they use:

| Path | Already generic before this PR |
| --- | --- |
| `get_queue`, `diagnose`'s queue stage | `filter(hasQueue)` through `gather`, rows tagged `adapter.id` |
| `pause_downloads`, `remove_queue_item` | take `instance`, resolve via `resolveInstance`, gate on `adapter.id` |
| `trigger_scan` (Prowlarr's only write) | same |
| `search_media` (Prowlarr's `SearchCapable`) | `filter(hasSearch)` |
| Config UI, `mutate.ts`, `permissions.ts`, `arr://instances` | driven off `MULTI_INSTANCE`, no per-service code |

So the actual work was the adapters' own identity, one read tool, one diagnose stage, and two audit targets.

## What changed

- **Schema.** `MULTI_INSTANCE` grows to seven. Transmission and qBittorrent needed a named variant of the credential shape, and the duplicate-name check is now shared rather than pasted twice. The single-block form parses exactly as before and keeps its bare id, so **no existing config needs editing**.
- **Adapters.** The four derive `instance` and a qualified `id` the way `RadarrAdapter` does, and hand `this.id` to `ServiceHttp` so two clients raise errors that can be told apart.
- **`get_indexers`.** Merges every configured Prowlarr, mirroring `buildGetSubtitles`. Rejections carry the instance that reported them, one unreachable instance degrades by name while the others still answer, and total failure is claimed only when every instance is unreachable.
- **`diagnose`.** Fixes a trap that would have arrived silently: the indexer stage tested `degraded.includes('prowlarr')` against a bare literal, which a qualified id never matches, so an unreachable Prowlarr was reported as "no recent indexer failures mention it", an absence nothing had verified. It now answers `unknown` naming the unreachable instances.
- **Audit targets.** `pause_downloads` and `remove_queue_item` built targets from the bare service type, so `sabnzbd:all` no longer says which client was paused. Both now use `adapter.id`, as `clean_queue` already did.
- **Docs.** The seven/three split, plus a worked example of the setup people actually have: one torrent client behind a VPN and one not.

## Verification

- 2458 unit tests passing, typecheck and lint clean.
- `npm run multi-instance` (the live maintainer check) extended to the new types, and it **exits 0 against a real stack**: 29 PASS, 2 SKIP, 0 FAIL, exercising SABnzbd, Transmission, Prowlarr, Radarr and Sonarr. qBittorrent is not configured on that stack and skipped.
- The live check found two defects fixtures could not. Its own queue assertion failed on an idle queue while its neighbour passed vacuously in the same state. Both now key on `gather`'s `counts`, which is populated per instance even at zero, and SKIP when there is nothing to compare.

## Two fixes worth calling out

Both came from review and both sit on seams:

- **qBittorrent login errors** hardcoded the bare type. qBittorrent authenticates outside `ServiceHttp`, so passing `this.id` there never reached the login path, and two clients with different credentials produced identical auth failures. That is precisely the configuration these docs now advertise.
- **Merged rejections** were pushed in settle order, unsorted and unbounded. Rejections are time-ordered, so `diagnose`'s "most recently X" could name the newest rejection of whichever Prowlarr answered first rather than the newest overall.

## Follow-ups

Tracked in #201, deliberately not in this PR. The largest is not from this change at all: seven write tools still build `${service}:${id}` audit targets, which has been ambiguous for `radarr/4k` since the first widening. This PR fixed that defect twice, and the untouched half is bigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
