### PR TITLE
fix: name the instance in audit targets, and say when a merged list is partial

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,7 +124,7 @@ why `stack_health` reports per-instance permissions.
 
 ## Adding a service adapter
 
-The highest-value contribution, and deliberately self-contained. Seven steps,
+The highest-value contribution, and deliberately self-contained. Eight steps,
 each with a worked example already in the tree.
 
 ### Which services qualify
@@ -298,10 +298,30 @@ around them.
    `UserDirectoryCapable` — together `MediaServerAdapter` — and exactly one may
    be configured, because `get_library`'s `presence` join needs a single
    counterparty.
-5. **Declare its contract** in `test/contract.test.ts` — the response fields your
+5. **Decide whether it can be configured twice**, and say so in the adapter.
+   Seven of the ten services can be, so this is the common case rather than the
+   exotic one — but copying `jellyfin.ts` gets you `readonly id: string =
+   '<type>'`, which is the *single*-instance shape. That is the safe default
+   (a service that simply cannot be configured twice, rather than two adapters
+   with colliding ids), so getting it wrong fails closed. Making it
+   multi-instance is four moves:
+
+   - accept `Instanced<…>` rather than the bare config type,
+   - set `readonly instance` from `config.name`,
+   - derive `readonly id` with `instanceId()` rather than a type literal,
+   - **pass `this.id` into `ServiceHttp`, not the type literal.**
+
+   That last one is the trap. `ServiceHttp` puts the id it was given into every
+   error it raises, so a hardcoded literal there produces errors blaming
+   `qbittorrent` when the failure was `qbittorrent/vpn` — and a service that
+   authenticates *outside* `ServiceHttp` needs the same care in its own login
+   path. qBittorrent does exactly that, and its login errors had to be fixed
+   separately from the rest of the adapter for precisely this reason.
+
+6. **Declare its contract** in `test/contract.test.ts` — the response fields your
    adapter reads. Omit the `spec` when the service publishes no OpenAPI document.
-6. **Register it** in `src/services/registry.ts`.
-7. **Draw it an icon** in `src/web/icons.ts` — stroke-only, `currentColor`, on
+7. **Register it** in `src/services/registry.ts`.
+8. **Draw it an icon** in `src/web/icons.ts` — stroke-only, `currentColor`, on
    the same 24×24 grid as the rest, saying what kind of thing the service is
    rather than which one. The UI uses one drawn set rather than per-service
    artwork, so a new icon is drawn to match the others instead of sourced. A

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -169,6 +169,14 @@ services:
 `qbittorrent/vpn`. `pause_downloads` needs `instance` to say which one to stop —
 with two configured, omitting it is refused rather than guessed.
 
+**Two Prowlarrs with overlapping indexers return the same release twice.**
+`search_media` fans out across every configured Prowlarr and labels each row
+with the instance it came from, so a release both of them index comes back once
+per instance. That is the intended behaviour rather than a bug — de-duplicating
+would mean deciding which instance's copy to discard, and the two may differ in
+priority or in what they will actually grab — but it is worth knowing before
+you set up a public plus private split and wonder why the list looks doubled.
+
 ## Access
 
 ```yaml

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -64,9 +64,19 @@ rather than accepting their ten-row default, and `get_requests` and
 `get_indexers` push a status filter upstream where the service supports one, so
 a filtered answer is not a filtered slice of an arbitrary window.
 
-Tools spanning several services also report which ones they could not reach, and
-how many results each contributed, so a long answer from one service can never
-silently hide another.
+Tools spanning several services also report which ones they could not reach, so
+a long answer from one service can never silently hide another being down. Most
+of them carry `counts` as well, saying how many results each contributed;
+`get_indexers` and `get_subtitles` do not, and every row there names its own
+service instead.
+
+Two of those tools carry a second kind of gap. `get_indexers` reads rejection
+history alongside the indexers themselves, and `get_subtitles` reads provider
+state alongside the gaps; either can fail while the main read succeeds. That is
+**not** `degraded` — the instance did answer — so it is reported separately as
+`rejectionsUnavailable` and `providersUnavailable`, naming the instances whose
+half is missing. Without it, one of two Prowlarrs failing leaves a rejection
+list that is present, plausible and missing half the stack.
 
 `get_indexers` does the same across instances of one service: it merges every
 configured Prowlarr, each row naming the instance it came from, and one

--- a/src/services/registry.ts
+++ b/src/services/registry.ts
@@ -28,6 +28,18 @@ import type { ServiceAdapter } from './types.ts';
  * The casts are narrowing a union the schema has already discriminated by key:
  * `services.jellyfin` cannot be a Transmission block. A `switch` cannot see
  * that, so each case restates the type its constructor needs.
+ *
+ * With two exceptions, and they are worth knowing about rather than tidying
+ * away. `qbittorrent` and `transmission` carry no cast because they need none:
+ * every `AnyServiceConfig` member structurally satisfies
+ * `Instanced<CredentialServiceConfig>`, so the compiler accepts any of them
+ * there. Adding a cast is rejected as unnecessary, which is the compiler
+ * confirming the gap rather than closing it.
+ *
+ * The consequence: swapping those two case bodies would hand the wrong config
+ * to the wrong constructor and still compile. Closing it properly means a
+ * type-level map from service id to config type, which is a change to the
+ * schema rather than to this file (#201).
  */
 export function buildAdapters(config: Config): ServiceAdapter[] {
     return listInstances(config).map(buildAdapter);

--- a/src/tools/addMedia.ts
+++ b/src/tools/addMedia.ts
@@ -145,7 +145,7 @@ export function registerAddMedia(server: McpServer, context: WriteContext, adapt
             // be a duplicate entry rather than a second copy of the film.
             if (candidate.existingId !== undefined) {
                 return {
-                    target: `${service}:${external_id}`,
+                    target: `${adapter.id}:${external_id}`,
                     summary: `${label} is already in ${service} (id ${candidate.existingId}).`,
                     effects: [],
                     noop: true
@@ -205,7 +205,7 @@ export function registerAddMedia(server: McpServer, context: WriteContext, adapt
             );
 
             return {
-                target: `${service}:${external_id}`,
+                target: `${adapter.id}:${external_id}`,
                 summary: `Add ${label} to ${service}.`,
                 effects,
                 // The resolved profile and folder, not the strings asked for:

--- a/src/tools/deleteEpisodeFiles.ts
+++ b/src/tools/deleteEpisodeFiles.ts
@@ -141,7 +141,7 @@ export function registerDeleteEpisodeFiles(
 
             if (fileIds.length === 0) {
                 return {
-                    target: `${service}:${id}:${season !== undefined ? `s${season}` : 'e'}`,
+                    target: `${adapter.id}:${id}:${season !== undefined ? `s${season}` : 'e'}`,
                     summary: `${scope} has no files on disk.`,
                     effects: [],
                     noop: true
@@ -206,7 +206,7 @@ export function registerDeleteEpisodeFiles(
             );
 
             return {
-                target: `${service}:${id}:${season !== undefined ? `s${season}` : `e${fileIds.join(',')}`}`,
+                target: `${adapter.id}:${id}:${season !== undefined ? `s${season}` : `e${fileIds.join(',')}`}`,
                 summary: `Delete ${fileIds.length} episode file(s) from ${scope}${size === undefined ? '' : `, ${size}`} from disk.`,
                 effects,
                 // The ids, not the season: a file imported between preview and

--- a/src/tools/deleteMedia.ts
+++ b/src/tools/deleteMedia.ts
@@ -104,7 +104,7 @@ export function registerDeleteMedia(
             }
 
             return {
-                target: `${service}:${id}`,
+                target: `${adapter.id}:${id}`,
                 summary:
                     `Delete ${label} from ${service}` +
                     (delete_files

--- a/src/tools/getIndexers.ts
+++ b/src/tools/getIndexers.ts
@@ -16,6 +16,20 @@ export type GetIndexersResult = {
     disabledCount: number;
     /** the "recent rejections". Present only at detail: full. */
     recentRejections?: IndexerRejection[];
+    /**
+     * Instances whose rejection history could not be read, while their
+     * indexers could.
+     *
+     * Not `degraded`: the indexers themselves answered, so the instance is not
+     * degraded. But with two Prowlarrs, one failing here leaves
+     * `recentRejections` present, plausible and missing half the stack, which
+     * reads exactly like a complete history. #200 put `service` on every
+     * rejection so a merged list could say which Prowlarr refused a query; this
+     * is the same argument for saying which one never answered.
+     *
+     * Present only at detail: full, and only when something actually failed.
+     */
+    rejectionsUnavailable?: string[];
 };
 
 const project = (i: IndexerSummary, detail: DetailLevel): IndexerSummary => {
@@ -44,6 +58,7 @@ export async function buildGetIndexers(
     const indexers: IndexerSummary[] = [];
     const rejections: IndexerRejection[] = [];
     const degraded: string[] = [];
+    const rejectionsUnavailable: string[] = [];
     let sawRejections = false;
 
     await Promise.all(
@@ -65,6 +80,7 @@ export async function buildGetIndexers(
                 sawRejections = true;
             } catch (err) {
                 logger.warn({ service: adapter.id, err }, 'rejection history unavailable; omitting');
+                rejectionsUnavailable.push(adapter.id);
             }
         })
     );
@@ -93,7 +109,8 @@ export async function buildGetIndexers(
         items: shaped.items.map(i => project(i, opts.detail)),
         disabledCount,
         degraded: degraded.sort(),
-        ...(sawRejections ? { recentRejections: mergedRejections } : {})
+        ...(sawRejections ? { recentRejections: mergedRejections } : {}),
+        ...(rejectionsUnavailable.length === 0 ? {} : { rejectionsUnavailable: rejectionsUnavailable.sort() })
     };
 }
 
@@ -107,7 +124,14 @@ export const summarizeIndexers = (result: GetIndexersResult, instanceCount: numb
     const disabled = result.disabledCount;
     if (result.degraded.length > 0 && result.degraded.length === instanceCount)
         return `${result.degraded.join(', ')} could not be reached; no indexer information available.`;
-    return `${result.returned} of ${result.total} indexer(s)${disabled > 0 ? `, ${disabled} temporarily disabled` : ''}${result.degraded.length > 0 ? `. ${result.degraded.join(', ')} could not be reached` : ''}.`;
+    // The unavailable-history note rides on the sentence rather than only in
+    // the structure, because the failure it describes is invisible: a short
+    // rejection list looks like a quiet week.
+    const partial =
+        result.rejectionsUnavailable === undefined
+            ? ''
+            : ` Rejection history is missing for ${result.rejectionsUnavailable.join(', ')}, so the list below is partial.`;
+    return `${result.returned} of ${result.total} indexer(s)${disabled > 0 ? `, ${disabled} temporarily disabled` : ''}${result.degraded.length > 0 ? `. ${result.degraded.join(', ')} could not be reached` : ''}.${partial}`;
 };
 
 export function registerGetIndexers(

--- a/src/tools/getSubtitles.ts
+++ b/src/tools/getSubtitles.ts
@@ -16,6 +16,14 @@ export type GetSubtitlesResult = {
      * is noise in every response.
      */
     providers?: SubtitleProvider[];
+    /**
+     * Instances whose provider state could not be read, while their gaps
+     * could. The same hole `rejectionsUnavailable` closes in `get_indexers`,
+     * decided once for both (#201): with two Bazarrs, one failing here leaves
+     * `providers` present and missing half the stack, which reads as a
+     * complete answer.
+     */
+    providersUnavailable?: string[];
 };
 
 const project = (gap: SubtitleGap, detail: DetailLevel): SubtitleGap => {
@@ -61,6 +69,7 @@ export async function buildGetSubtitles(
     const gaps: SubtitleGap[] = [];
     const providers: SubtitleProvider[] = [];
     const degraded: string[] = [];
+    const providersUnavailable: string[] = [];
     let sawProviders = false;
 
     await Promise.all(
@@ -81,6 +90,7 @@ export async function buildGetSubtitles(
                 sawProviders = true;
             } catch (err) {
                 logger.warn({ service: adapter.id, err }, 'provider state unavailable; omitting');
+                providersUnavailable.push(adapter.id);
             }
         })
     );
@@ -96,7 +106,8 @@ export async function buildGetSubtitles(
         ...shaped,
         items: shaped.items.map(g => project(g, opts.detail)),
         degraded: degraded.sort(),
-        ...(sawProviders ? { providers } : {})
+        ...(sawProviders ? { providers } : {}),
+        ...(providersUnavailable.length === 0 ? {} : { providersUnavailable: providersUnavailable.sort() })
     };
 }
 
@@ -118,7 +129,13 @@ export function registerGetSubtitles(server: McpServer, adapters: readonly (Serv
                 result.degraded.length > 0
                     ? `Bazarr could not be reached (${result.degraded.join(', ')}); subtitle information may be incomplete.`
                     : `${result.returned} of ${result.total} item(s) missing subtitles` +
-                      (unhealthy > 0 ? `; ${unhealthy} provider(s) unavailable.` : '.');
+                      (unhealthy > 0 ? `; ${unhealthy} provider(s) unavailable.` : '.') +
+                      // Said out loud for the same reason get_indexers says it:
+                      // a provider list missing half the stack looks exactly
+                      // like a healthy one.
+                      (result.providersUnavailable === undefined
+                          ? ''
+                          : ` Provider state is missing for ${result.providersUnavailable.join(', ')}, so that list is partial.`);
 
             return { content: [{ type: 'text', text: summary }], structuredContent: result };
         }

--- a/src/tools/grabRelease.ts
+++ b/src/tools/grabRelease.ts
@@ -157,7 +157,7 @@ export function registerGrabRelease(
             }
 
             return {
-                target: `${service}:${guid}`,
+                target: `${adapter.id}:${guid}`,
                 summary: `Grab ${match.title} from ${match.indexer} for ${service}.`,
                 effects,
                 // Both, because both decide what apply() sends. A token that

--- a/src/tools/removeBlocklistItem.ts
+++ b/src/tools/removeBlocklistItem.ts
@@ -58,7 +58,7 @@ export function registerRemoveBlocklistItem(
             }
 
             return {
-                target: `${service}:${id}`,
+                target: `${adapter.id}:${id}`,
                 summary: `Un-blocklist ${entry.title} on ${service}.`,
                 effects: [
                     `${service} may grab this release again the next time it searches.`,

--- a/src/tools/setMonitoring.ts
+++ b/src/tools/setMonitoring.ts
@@ -139,7 +139,7 @@ export function registerSetMonitoring(
             ];
 
             return {
-                target: `${service}:${id}`,
+                target: `${adapter.id}:${id}`,
                 summary: `${verb} ${scope} in ${service}.`,
                 effects,
                 args: {
@@ -154,12 +154,13 @@ export function registerSetMonitoring(
         },
 
         async apply(_plan, { service, instance, id, monitored, season, episodes }) {
-            await findAdapter(adapters, service, instance).setMonitoring(id, {
+            const adapter = findAdapter(adapters, service, instance);
+            await adapter.setMonitoring(id, {
                 monitored,
                 ...(season === undefined ? {} : { season }),
                 ...(episodes === undefined ? {} : { episodeIds: episodes })
             });
-            return { monitored, target: `${service}:${id}` };
+            return { monitored, target: `${adapter.id}:${id}` };
         }
     });
 }

--- a/src/tools/triggerSearch.ts
+++ b/src/tools/triggerSearch.ts
@@ -140,7 +140,7 @@ export function registerTriggerSearch(
             }
 
             return {
-                target: `${service}:${id}`,
+                target: `${adapter.id}:${id}`,
                 summary: `Ask ${service} to search for releases for ${scope}.`,
                 effects,
                 args: {

--- a/test/destructiveWrites.test.ts
+++ b/test/destructiveWrites.test.ts
@@ -1,6 +1,6 @@
+import { instancesOf } from './helpers/instances.ts';
 import { describe, expect, it, vi } from 'vitest';
 import * as z from 'zod/v4';
-import { instanceId, type ServiceInstance } from '../src/config/instances.ts';
 import type { AnyServiceConfig, KeyedServiceConfig, ServiceId, CredentialServiceConfig } from '../src/config/schema.ts';
 import { WriteAudit } from '../src/core/audit.ts';
 import { ConfirmTokens } from '../src/core/confirm.ts';
@@ -423,20 +423,6 @@ type Call = (args: Record<string, unknown>) => Promise<{
 // reads it when present, so a config built as `{ ...keyed(port), name: 'spare' }`
 // produces the qualified id its adapter actually carries, without growing that
 // shared helper to cover a case it was written to skip.
-const instancesWithNames = (map: Partial<Record<ServiceId, AnyServiceConfig>>): ServiceInstance[] =>
-    Object.entries(map).flatMap(([type, config]) => {
-        if (config === undefined) return [];
-        const name = (config as { name?: string }).name;
-        return [
-            {
-                id: instanceId(type as ServiceId, name),
-                type: type as ServiceId,
-                ...(name === undefined ? {} : { name }),
-                config
-            }
-        ];
-    });
-
 function harness(
     register: typeof registerDeleteMedia,
     opts: { permissions?: Partial<Record<ServiceId, AnyServiceConfig>>; adapters?: ServiceAdapter[] } = {}
@@ -462,7 +448,7 @@ function harness(
         server as never,
         {
             permissions: permissionSourceFrom(
-                instancesWithNames(opts.permissions ?? { radarr: tiered(false, true), sonarr: tiered(false, true) })
+                instancesOf(opts.permissions ?? { radarr: tiered(false, true), sonarr: tiered(false, true) })
             ),
             confirm: new ConfirmTokens(),
             audit,
@@ -1240,5 +1226,57 @@ describe('qBittorrent queue removal', () => {
             })
         ).rejects.toThrow(/not found/i);
         expect(sent.some(s => s.method === 'POST')).toBe(false);
+    });
+});
+
+/**
+ * #201 item 1. Seven write tools built their audit target from the bare
+ * `service` string the caller passed rather than the resolved adapter, so with
+ * a `radarr/hd` plus `radarr/4k` pair an audit row said `radarr:412` and could
+ * not say which library was written to. That had been true since the first
+ * multi-instance release, and no test covered it — which is why it survived
+ * the fix that corrected the same defect in the queue tools.
+ */
+describe('audit targets name the instance', () => {
+    const namedRadarr = { ...tiered(false, true), name: '4k' } as never;
+
+    const withNamedRadarr = (register: Parameters<typeof harness>[0]) =>
+        harness(register, {
+            adapters: [
+                new RadarrAdapter(
+                    namedRadarr,
+                    recordingFetch({ '/api/v3/movie/412': MOVIE, '/api/v3/queue': ARR_QUEUE }).impl
+                )
+            ],
+            permissions: { radarr: namedRadarr }
+        });
+
+    const applied = async (h: ReturnType<typeof harness>, args: Record<string, unknown>) => {
+        const first = await h.call({ ...args, instance: '4k' });
+        await h.call({ ...args, instance: '4k', confirm: first.structuredContent.confirm_token });
+        return h.audit.recent(10);
+    };
+
+    it('delete_media records radarr/4k, not radarr', async () => {
+        const h = withNamedRadarr(registerDeleteMedia);
+        const rows = await applied(h, { service: 'radarr', id: '412', delete_files: false });
+
+        expect(rows[0]?.target).toBe('radarr/4k:412');
+    });
+
+    /** The preview carries the same target, because the confirmation token
+     *  binds to it — a token issued against one instance must not spend on
+     *  another. */
+    it('binds the preview target to the instance too', async () => {
+        const h = withNamedRadarr(registerDeleteMedia);
+        const { structuredContent } = await h.call({
+            service: 'radarr',
+            instance: '4k',
+            id: '412',
+            delete_files: false,
+            dry_run: true
+        });
+
+        expect(structuredContent.target).toBe('radarr/4k:412');
     });
 });

--- a/test/getIndexers.test.ts
+++ b/test/getIndexers.test.ts
@@ -380,3 +380,80 @@ describe('summarizeIndexers', () => {
         expect(summary).toContain('prowlarr/b could not be reached');
     });
 });
+
+/**
+ * #201 item 2. With one Prowlarr, a failed rejection history left
+ * `recentRejections` absent, which a caller can see. With two, one failing and
+ * one succeeding gave a list that was present, plausible, and missing half the
+ * stack — indistinguishable from a quiet week.
+ */
+describe('a partial rejection history says so', () => {
+    const working = {
+        id: 'prowlarr/main',
+        type: 'prowlarr' as const,
+        getIndexers: async () => [
+            {
+                service: 'prowlarr/main',
+                id: 1,
+                name: 'Alpha',
+                enabled: true,
+                protocol: 'usenet',
+                priority: 25
+            }
+        ],
+        getRecentRejections: async () => [
+            { service: 'prowlarr/main', indexer: 'Alpha', at: '2026-09-01T10:00:00Z', reason: 'no results' }
+        ]
+    };
+
+    const brokenHistory = {
+        ...working,
+        id: 'prowlarr/spare',
+        type: 'prowlarr' as const,
+        getIndexers: async () => [
+            {
+                service: 'prowlarr/spare',
+                id: 2,
+                name: 'Beta',
+                enabled: true,
+                protocol: 'torrent',
+                priority: 25
+            }
+        ],
+        getRecentRejections: async () => {
+            throw new Error('history endpoint gone');
+        }
+    };
+
+    const build = () =>
+        buildGetIndexers([working, brokenHistory] as never, { detail: 'full', limit: 50, offset: 0 });
+
+    it('names the instance whose history could not be read', async () => {
+        const result = await build();
+        expect(result.rejectionsUnavailable).toEqual(['prowlarr/spare']);
+    });
+
+    /** The instance answered its indexers, so it is not degraded — the two
+     *  fields describe different failures and must not be merged. */
+    it('does not call that instance degraded, because its indexers answered', async () => {
+        const result = await build();
+        expect(result.degraded).toEqual([]);
+        expect(result.total).toBe(2);
+    });
+
+    it('still returns what the working instance rejected', async () => {
+        const result = await build();
+        expect(result.recentRejections).toHaveLength(1);
+    });
+
+    it('says the list is partial in the sentence, not only the structure', async () => {
+        const result = await build();
+        expect(summarizeIndexers(result, 2)).toContain('partial');
+    });
+
+    it('stays absent when every instance answered', async () => {
+        const result = await buildGetIndexers([working] as never, { detail: 'full', limit: 50, offset: 0 });
+        expect(result.rejectionsUnavailable).toBeUndefined();
+        expect(summarizeIndexers(result, 1)).not.toContain('partial');
+    });
+});

--- a/test/helpers/instances.ts
+++ b/test/helpers/instances.ts
@@ -10,12 +10,39 @@ import type { AnyServiceConfig, ServiceId } from '../../src/config/schema.ts';
  * so this keeps those tests saying what they mean instead of restating the
  * instance shape a dozen times.
  *
- * Named instances are built explicitly in the tests that are actually about
- * naming; this deliberately does not grow an options bag to cover them.
+ * A config carrying a `name` becomes a named instance, so a test about naming
+ * says so in the config it already writes rather than in a second helper. That
+ * is behaviour-preserving for every caller that passes no name, which is what
+ * `instanceId` does with an undefined one.
+ *
+ * This replaced two verbatim copies of a `instancesWithNames` helper (#201).
+ * A map is still the shape here because a `Partial<Record<ServiceId, …>>` holds
+ * one config per service type; tests needing *two* of the same type build the
+ * instance list directly.
  */
 export const instancesOf = (map: Partial<Record<ServiceId, AnyServiceConfig>>): ServiceInstance[] =>
-    Object.entries(map).flatMap(([type, config]) =>
-        config === undefined
-            ? []
-            : [{ id: instanceId(type as ServiceId), type: type as ServiceId, config }]
-    );
+    Object.entries(map).flatMap(([type, config]) => {
+        if (config === undefined) return [];
+        const name = (config as { name?: string }).name;
+        return [
+            {
+                id: instanceId(type as ServiceId, name),
+                type: type as ServiceId,
+                ...(name === undefined ? {} : { name }),
+                config
+            }
+        ];
+    });
+
+/** Two or more instances of the *same* service, which the map shape cannot
+ *  express. Named, because that is the only way two of one type differ. */
+export const namedInstances = (type: ServiceId, configs: readonly AnyServiceConfig[]): ServiceInstance[] =>
+    configs.map(config => {
+        const name = (config as { name?: string }).name;
+        return {
+            id: instanceId(type, name),
+            type,
+            ...(name === undefined ? {} : { name }),
+            config
+        };
+    });

--- a/test/pauseDownloads.test.ts
+++ b/test/pauseDownloads.test.ts
@@ -1,6 +1,6 @@
+import { instancesOf } from './helpers/instances.ts';
 import { describe, expect, it, vi } from 'vitest';
 import type * as z from 'zod/v4';
-import { instanceId, type ServiceInstance } from '../src/config/instances.ts';
 import type { AnyServiceConfig, CredentialServiceConfig, KeyedServiceConfig, ServiceId } from '../src/config/schema.ts';
 import { WriteAudit } from '../src/core/audit.ts';
 import { ConfirmTokens } from '../src/core/confirm.ts';
@@ -214,20 +214,6 @@ function sabFetch(paused: { value: boolean } = { value: false }): typeof fetch {
 // `{ ...keyed(port), name: 'spare' }` produces the qualified id its adapter
 // actually carries, without growing that shared helper to cover a case it was
 // written to skip.
-const instancesWithNames = (map: Partial<Record<ServiceId, AnyServiceConfig>>): ServiceInstance[] =>
-    Object.entries(map).flatMap(([type, config]) => {
-        if (config === undefined) return [];
-        const name = (config as { name?: string }).name;
-        return [
-            {
-                id: instanceId(type as ServiceId, name),
-                type: type as ServiceId,
-                ...(name === undefined ? {} : { name }),
-                config
-            }
-        ];
-    });
-
 function harness(
     opts: { adapters?: ServiceAdapter[]; permissions?: Partial<Record<ServiceId, AnyServiceConfig>> } = {}
 ) {
@@ -246,7 +232,7 @@ function harness(
         server as never,
         {
             permissions: permissionSourceFrom(
-                instancesWithNames(opts.permissions ?? { sabnzbd: keyed(8080) as unknown as AnyServiceConfig })
+                instancesOf(opts.permissions ?? { sabnzbd: keyed(8080) as unknown as AnyServiceConfig })
             ),
             confirm: new ConfirmTokens(),
             audit,

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -69,7 +69,10 @@ describe('buildAdapters', () => {
 });
 
 describe('multi-instance download clients and Prowlarr', () => {
-    const keyed = (name: string | undefined, port: number) => ({
+    // Named rather than a second `keyed`: the file-level one takes a port
+    // alone, and two same-named helpers with different arities twenty lines
+    // apart compile fine and read as a trap (#201).
+    const namedKeyed = (name: string | undefined, port: number) => ({
         ...(name === undefined ? {} : { name }),
         url: `http://192.0.2.10:${port}`,
         api_key: 'k',
@@ -86,7 +89,7 @@ describe('multi-instance download clients and Prowlarr', () => {
         buildAdapters(ConfigSchema.parse({ auth: AUTH, services }));
 
     it('gives two SABnzbds distinct ids and names', () => {
-        const adapters = build({ sabnzbd: [keyed('main', 8080), keyed('spare', 8081)] });
+        const adapters = build({ sabnzbd: [namedKeyed('main', 8080), namedKeyed('spare', 8081)] });
         expect(adapters.map(a => a.id)).toEqual(['sabnzbd/main', 'sabnzbd/spare']);
         expect(adapters.map(a => a.instance)).toEqual(['main', 'spare']);
         // Capability dispatch keys on this, so both must still say what they are.
@@ -94,7 +97,7 @@ describe('multi-instance download clients and Prowlarr', () => {
     });
 
     it('gives two Prowlarrs distinct ids', () => {
-        expect(build({ prowlarr: [keyed('public', 9696), keyed('private', 9697)] }).map(a => a.id)).toEqual([
+        expect(build({ prowlarr: [namedKeyed('public', 9696), namedKeyed('private', 9697)] }).map(a => a.id)).toEqual([
             'prowlarr/private',
             'prowlarr/public'
         ]);
@@ -112,8 +115,8 @@ describe('multi-instance download clients and Prowlarr', () => {
     });
 
     it('keeps the bare id for a single block', () => {
-        expect(build({ sabnzbd: keyed(undefined, 8080) })[0]?.id).toBe('sabnzbd');
-        expect(build({ sabnzbd: keyed(undefined, 8080) })[0]?.instance).toBeUndefined();
+        expect(build({ sabnzbd: namedKeyed(undefined, 8080) })[0]?.id).toBe('sabnzbd');
+        expect(build({ sabnzbd: namedKeyed(undefined, 8080) })[0]?.instance).toBeUndefined();
     });
 
     // ServiceHttp's first argument is what reaches error messages and log rows.
@@ -123,7 +126,7 @@ describe('multi-instance download clients and Prowlarr', () => {
             throw new Error('connection refused');
         }) as unknown as typeof fetch;
 
-        const adapter = new SabnzbdAdapter({ ...keyed('spare', 8081), timeout_ms: 10_000 } as never, refuse);
+        const adapter = new SabnzbdAdapter({ ...namedKeyed('spare', 8081), timeout_ms: 10_000 } as never, refuse);
         await expect(adapter.getVersion()).rejects.toMatchObject({ service: 'sabnzbd/spare' });
     });
 });


### PR DESCRIPTION
Closes #201.

All six follow-ups from the #200 review.

## 1. Seven write tools named the service, not the instance

`add_media`, `delete_media`, `delete_episode_files`, `set_monitoring`,
`trigger_search`, `remove_blocklist_item` and `grab_release` all built their
audit target from the bare `service` string the caller passed. With a
`radarr/hd` plus `radarr/4k` pair, `radarr:412` does not say which library was
written to.

Each of them already resolved an adapter, so the fix is `adapter.id` in the
template. `set_monitoring` needed one extra line, because its `apply` called
`findAdapter(...)` inline and never bound the result.

**Now covered by a test**, which is the part that was actually missing. It
asserts `radarr/4k:412` in both the audit row and the preview target, the
latter because the confirmation token binds to it. Verified by reverting the
fix and watching both fail.

## 2. A partial merged list said nothing

`get_indexers` reads rejection history alongside the indexers, `get_subtitles`
reads provider state alongside the gaps. Either can fail while the main read
succeeds, and with one instance that left the field absent, which a caller can
see. With two, one failing left a list that was present, plausible and missing
half the stack.

Both now carry `rejectionsUnavailable` / `providersUnavailable`, naming the
instances whose half is missing, and say it in the summary sentence too, since
the failure is otherwise invisible: a short rejection list looks like a quiet
week. Not `degraded`, because those instances did answer.

Decided the same way for both, as the issue asked.

## 3 to 5. Docs

- Two Prowlarrs with overlapping indexers return the same release twice.
  Intended, now written down in `docs/configuration.md` with why
  de-duplicating would be worse.
- CONTRIBUTING gains a step on single versus multi instance adapters, naming
  the four moves and calling out the one that bit qBittorrent: passing the type
  literal into `ServiceHttp` instead of `this.id`, and the same care needed in
  a login path that sits outside it.
- `docs/tools.md` no longer claims every multi-service tool reports per-service
  counts. `get_indexers` and `get_subtitles` do not, and every row there names
  its own service instead.

## 6. Test hygiene

- `instancesOf` now reads a `name` off the config, which **replaced** two
  verbatim copies of `instancesWithNames` rather than adding a third, exactly
  as the issue proposed. Behaviour-preserving for every existing caller.
- `registry.test.ts` no longer shadows `keyed` with a different arity twenty
  lines from the original.
- The two un-cast `registry.ts` cases **keep no cast**, because the cast is
  provably unnecessary: eslint rejects it, since every `AnyServiceConfig`
  member structurally satisfies `Instanced<CredentialServiceConfig>`. That is
  the compiler confirming the gap rather than closing it. The comment now says
  so, and says that closing it properly means a type-level map from service id
  to config type, which is a schema change rather than a registry one. I would
  rather leave the gap documented than add a line that reads like a fix and is
  not one.

2534 tests, lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
