### PR TITLE
fix: correct the metadata detector's false positives and its remedy rule

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -678,7 +678,7 @@ enough to be certain — treat it as the likely fix rather than a verdict:
 - Dragon Ball Kai, where a refresh changed nothing twice.
 
 Rows are worst-first: `numbering` findings outrank title ones, then sheer count.
-`seriesScanned` is the denominator — without it, "0 problems" and "0 series
+`itemsScanned` is the denominator — without it, "0 problems" and "0 series
 looked at" read identically.
 
 ## `fix_metadata`
@@ -808,8 +808,9 @@ a read that asks for it and only for a user who may see it.
 ### The result does not claim the repair finished
 
 Jellyfin refreshes in the background, so the re-read that follows the write is
-a snapshot taken while the work is very likely still running. A non-zero
-`remaining` immediately afterwards is not evidence the repair failed. Check
+a snapshot taken while the work is very likely still running. A
+`mismatchesAfter` still equal to `mismatchesBefore` immediately afterwards is
+not evidence the repair failed, which is what `verified: false` says. Check
 `stack_health` for the running task, then re-run with `dry_run` to see the
 settled result.
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -714,10 +714,17 @@ to be able to see what the tool believes is wrong.
 
 ### What it actually does
 
-On confirm, two calls in order. The identity is pinned first
-(`/Items/RemoteSearch/Apply/{id}` with the TVDB id, TMDB as fallback), then a
-full refresh with `replaceAllMetadata`. Both are needed: a refresh on its own
-asks the agent to match the item again and it matches it the same wrong way.
+On confirm, **one** call. `/Items/RemoteSearch/Apply/{id}` with the TVDB id for
+a series or TMDB for a film is not just a pin: checked against the server
+source, it sets the provider ids and then awaits a full refresh itself, with
+`ReplaceAllMetadata` and `RemoveOldMetadata`, before answering. A second
+`/Refresh` would be another full provider fetch of the same item for nothing.
+
+That call is **synchronous**, so when it returns the metadata is settled and
+the before/after comparison is a final answer. With no provider id to pin there
+is nothing to identify against, so the fallback is a plain `/Refresh`, which the
+server *queues* — there the comparison is a snapshot mid-flight, and the result
+says which of the two happened rather than hedging over both.
 TVDB is preferred because Sonarr is the source of truth for a series and its
 id is what the file layout was built from. When no provider id is known the
 identify step is **skipped rather than guessed** — applying an empty match

--- a/src/core/episodeMismatch.ts
+++ b/src/core/episodeMismatch.ts
@@ -91,8 +91,40 @@ export type Mismatch = {
  *  parsed with these removed. */
 const BRACKETED = /\[[^\]]*\]|\([^)]*\)/g;
 
-const SEASON_EPISODE = /[Ss](\d{1,3})[Ee](\d{1,3})/;
-const SEASON_X_EPISODE = /\b(\d{1,3})x(\d{1,3})\b/;
+/**
+ * Four digits for the episode, not three, and a right boundary so the fourth
+ * is not silently dropped. Sonarr's default `{episode:00}` emits `E1000` past
+ * episode 999, and `\d{1,3}` read that as episode 100 — a *confident* numbering
+ * finding on every long-running anime, pointing at a rename that would change
+ * nothing. `EPISODE_WORD` already allowed four; this did not.
+ *
+ * The left boundary stops a series title ending in a letter or digit from
+ * contributing its tail to the match.
+ */
+const SEASON_EPISODE = /(?<![A-Za-z0-9])[Ss](\d{1,3})[Ee](\d{1,4})(?!\d)/;
+
+/**
+ * The `1x02` form, narrowed to what that convention actually looks like: a
+ * two- or three-digit episode, space-delimited. Anything looser reads a series
+ * title as numbering — `2x2 Shinobuden` (a real series) parsed as season 2
+ * episode 2, `4x4 Adventures` as season 4 episode 4, and a `640x480` resolution
+ * tag as season 640.
+ */
+const SEASON_X_EPISODE = /(?:^|\s)(\d{1,2})x(\d{2,3})(?=\s|$)/;
+
+/**
+ * The *last* numbering match in a filename, not the first.
+ *
+ * A series whose own title contains one — `The S1E1 Podcast - S02E03 - …` —
+ * puts a decoy to the left of the real thing, and every naming convention in
+ * use puts the real numbering after the series name.
+ */
+const lastMatch = (re: RegExp, value: string): RegExpExecArray | null => {
+    const global = new RegExp(re.source, `${re.flags.replace('g', '')}g`);
+    let found: RegExpExecArray | null = null;
+    for (let m = global.exec(value); m !== null; m = global.exec(value)) found = m;
+    return found;
+};
 const EPISODE_WORD = /\bepisode\s*(\d{1,4})\b/i;
 const SEASON_FOLDER = /^season\s*(\d{1,3})$/i;
 const SPECIALS_FOLDER = /^specials?$/i;
@@ -127,7 +159,7 @@ export function parseFileNumbering(path: string): { season?: number; episode?: n
         if (folder?.[1] !== undefined) season = Number(folder[1]);
     }
 
-    const sxe = SEASON_EPISODE.exec(base) ?? SEASON_X_EPISODE.exec(base);
+    const sxe = lastMatch(SEASON_EPISODE, base) ?? lastMatch(SEASON_X_EPISODE, base);
     if (sxe?.[1] !== undefined && sxe[2] !== undefined) {
         season = Number(sxe[1]);
         episode = Number(sxe[2]);
@@ -158,7 +190,7 @@ export function extractFileTitle(path: string): string | undefined {
         .replace(BRACKETED, ' ')
         .replace(/\./g, ' ');
 
-    const numbered = SEASON_EPISODE.exec(base) ?? SEASON_X_EPISODE.exec(base);
+    const numbered = lastMatch(SEASON_EPISODE, base) ?? lastMatch(SEASON_X_EPISODE, base);
     const worded = numbered === null ? EPISODE_WORD.exec(base) : null;
     const marker = numbered ?? worded;
     if (marker === null) return undefined;
@@ -191,9 +223,12 @@ export function extractFileTitle(path: string): string | undefined {
         .map(part => part.replace(/-[A-Za-z0-9_.]+$/, '').trim())
         .filter(part => part !== '' && !/^\d+$/.test(part));
 
-    // The absolute episode number sits in its own ` - 001 - ` field between the
-    // numbering and the title, so take the longest field rather than the first.
-    const candidate = fields.sort((a, b) => b.length - a.length)[0];
+    // The first surviving field, not the longest. The absolute episode number
+    // that sits in its own ` - 001 - ` field is already gone (the numeric
+    // filter above), and "longest" preferred a trailing release-tag blob:
+    // `… - Pilot - AMZN WEB-DL DDP5.1 H.264-NTb` extracted the tags as the
+    // title, whose surviving words then matched nothing.
+    const candidate = fields[0];
     return candidate === undefined || candidate === '' ? undefined : candidate;
 }
 
@@ -256,7 +291,21 @@ const MIN_WORDS = 2;
  * punctuation, transliteration and part-numbering differ constantly on
  * correct libraries.
  */
+/**
+ * Anything outside the Latin script, which the word comparison cannot read.
+ *
+ * A Jellyfin set to a non-English `PreferredMetadataLanguage` holds titles in
+ * that language while Sonarr and Radarr name files in English, so every pinned
+ * episode in such a library disagrees by word overlap while both sides are
+ * correct. Script is only the half of that this can detect cheaply — English
+ * against Dutch is invisible here — which is why the remedy for a title-only
+ * finding is `inspect` rather than an instruction.
+ */
+const NON_LATIN = /[^\p{Script=Latin}\p{Script=Common}\p{Script=Inherited}]/u;
+
 function titlesDisagree(serverTitle: string, fileTitle: string): boolean {
+    if (NON_LATIN.test(unfenced(serverTitle)) || NON_LATIN.test(unfenced(fileTitle))) return false;
+
     const server = contentWords(serverTitle);
     const file = contentWords(fileTitle);
     if (server.size < MIN_WORDS || file.size < MIN_WORDS) return false;
@@ -290,7 +339,7 @@ function titlesDisagree(serverTitle: string, fileTitle: string): boolean {
  * enough to be certain. Callers should present it as the likely fix, not a
  * verdict.
  */
-export type Remedy = 'refresh_metadata' | 'rename_files';
+export type Remedy = 'refresh_metadata' | 'rename_files' | 'inspect';
 
 export type SeriesVerdict = {
     /** How many episodes had a file to compare at all. */
@@ -301,6 +350,40 @@ export type SeriesVerdict = {
     /** Of the mismatching episodes, how many the server had already matched. */
     pinned: number;
     remedy: Remedy;
+};
+
+/**
+ * Which way a *series* disagreement points.
+ *
+ *  is the only signal confident enough to name a fix on its own: an
+ * episode's season and number are stored on the item at scan time and no
+ * refresh re-derives them, so the file has to change. Measured.
+ *
+ * A title-only disagreement says the two sides differ, not which is wrong, and
+ * the honest answer depends on something not in the comparison. An episode the
+ * server never matched holds no title of its own, so filling it in is safe. An
+ * episode it *did* match could be either a wrong match or a correct title in
+ * another language, and this cannot tell those apart — so it says 
+ * rather than sending a destructive write at a coin flip. That is narrower
+ * than the rule three series originally suggested, and deliberately so.
+ */
+const seriesRemedy = (numbering: number, pinned: number, mismatches: number): Remedy => {
+    if (numbering > 0) return 'rename_files';
+    return pinned === mismatches ? 'inspect' : 'refresh_metadata';
+};
+
+/**
+ * And a *film*.
+ *
+ * A film has no scan-time numbering, so the episode rule does not carry over:
+ * its year and title both come from the provider match, and re-identifying it
+ * re-derives both. A wrong year therefore means the wrong film was matched and
+ *  is exactly the repair — the opposite of what the episode rule
+ * would have said, since every matched film carries provider ids.
+ */
+export const movieRemedy = (reasons: readonly MismatchReason[], pinned: boolean): Remedy => {
+    if (reasons.includes('year')) return 'refresh_metadata';
+    return pinned ? 'inspect' : 'refresh_metadata';
 };
 
 export function summariseSeries(items: readonly EpisodeRecord[]): SeriesVerdict | undefined {
@@ -321,9 +404,7 @@ export function summariseSeries(items: readonly EpisodeRecord[]): SeriesVerdict 
         numbering,
         titleOnly: mismatches.length - numbering,
         pinned,
-        // A mixed series still goes to `fix_metadata`: it is the tool that can
-        // help the unpinned half, and it refuses to pretend about the rest.
-        remedy: numbering > 0 || pinned === mismatches.length ? 'rename_files' : 'refresh_metadata'
+        remedy: seriesRemedy(numbering, pinned, mismatches.length)
     };
 }
 
@@ -355,7 +436,7 @@ export function parseMovieFile(path: string): { title?: string; year?: number } 
     // `Blade Runner 2049 (2017)` parse as year 2049.
     const raw = withoutExtension(segments(path).at(-1) ?? '');
 
-    const found = MOVIE_YEAR.exec(raw);
+    const found = lastMatch(MOVIE_YEAR, raw);
     if (found === null) return {};
 
     const year = Number(found[0].slice(1, -1));
@@ -383,7 +464,11 @@ export function findMovieMismatches(items: readonly MovieRecord[]): Mismatch[] {
         const { title: fileTitle, year: fileYear } = parseMovieFile(path);
         const reasons: MismatchReason[] = [];
 
-        if (fileYear !== undefined && item.year !== undefined && fileYear !== item.year) reasons.push('year');
+        // Two years apart, not one. Radarr names a file with the release year
+        // it held at import and TMDB moves festival and limited dates across a
+        // year boundary afterwards, so a drift of one is ordinary rather than
+        // evidence the wrong film was matched.
+        if (fileYear !== undefined && item.year !== undefined && Math.abs(fileYear - item.year) > 1) reasons.push('year');
         if (fileTitle !== undefined && titlesDisagree(item.name, fileTitle)) reasons.push('title');
         if (reasons.length === 0) continue;
 

--- a/src/services/jellyfin.ts
+++ b/src/services/jellyfin.ts
@@ -597,17 +597,31 @@ export class JellyfinAdapter
     }
 
     /**
-     * Identify, then replace. Two calls, and both are needed: a refresh on its
-     * own asks the agent to match the item again and it matches it the same
-     * wrong way, so the provider id has to be pinned first.
+     * One call, not two, and which one depends on whether an identity can be
+     * pinned.
      *
-     * The query names are camelCase because that is what the vendored spec
-     * says (`RefreshItem`), not the capitalised spelling issue #199 quoted.
+     * `ApplySearchCriteria` is not just a pin. Checked against the server
+     * source rather than assumed: it sets the item's `ProviderIds` and then
+     * **awaits `RefreshFullItem` itself**, with `MetadataRefreshMode.FullRefresh`,
+     * `ReplaceAllMetadata = true` and `RemoveOldMetadata = true`, before
+     * answering 204. So a following `/Refresh` is a second full provider fetch
+     * of the same item for no gain, and the comment that used to sit here
+     * claiming "two calls, and both are needed" was wrong.
+     *
+     * The difference matters beyond the wasted work: Apply is **synchronous**,
+     * so when it returns the metadata is settled and a caller comparing before
+     * and after is reading a final answer. The standalone refresh is queued, so
+     * a caller reading straight after it is reading a snapshot mid-flight.
+     * `settled` says which of the two happened rather than making the caller
+     * guess.
+     *
+     * The refresh query names are camelCase because that is what the vendored
+     * spec says (`RefreshItem`), not the capitalised spelling issue #199 quoted.
      * Jellyfin ignores parameters it does not recognise, so a wrong spelling
      * here would return 204 and change nothing — the failure this whole tool
      * exists to stop being reported as success.
      */
-    async repairMetadata(itemId: string, opts: { tvdbId?: number; tmdbId?: number }): Promise<void> {
+    async repairMetadata(itemId: string, opts: { tvdbId?: number; tmdbId?: number }): Promise<{ settled: boolean }> {
         const id = this.#itemId(itemId);
         const slow = { timeoutMs: METADATA_REPAIR_TIMEOUT_MS };
 
@@ -616,8 +630,9 @@ export class JellyfinAdapter
             ...(opts.tmdbId === undefined ? {} : { Tmdb: String(opts.tmdbId) })
         };
 
-        // Skipped rather than guessed when no provider id is known: applying an
-        // empty match would unpin whatever identity the item already had.
+        // Applying an empty match would unpin whatever identity the item
+        // already had, so with no id to pin this falls back to the plain
+        // refresh — which cannot fix a wrong match, only a missing one.
         if (Object.keys(providerIds).length > 0) {
             await this.#http.post(
                 `/Items/RemoteSearch/Apply/${id}?replaceAllImages=false`,
@@ -625,6 +640,7 @@ export class JellyfinAdapter
                 true,
                 slow
             );
+            return { settled: true };
         }
 
         await this.#http.post(
@@ -634,6 +650,7 @@ export class JellyfinAdapter
             true,
             slow
         );
+        return { settled: false };
     }
 
     async listUserSeasons(user: ServiceUser): Promise<IndexInput[]> {

--- a/src/services/jellyfin.ts
+++ b/src/services/jellyfin.ts
@@ -570,9 +570,18 @@ export class JellyfinAdapter
      * sweep of a large library costs one request here and one per series
      * there.
      */
-    async readMovieMetadata(user: ServiceUser): Promise<MovieRecord[]> {
+    async readMovieMetadata(user: ServiceUser, itemId?: string): Promise<MovieRecord[]> {
+        // One film by id when the caller wants one. `fix_metadata` reads a film
+        // four times across a preview and a confirm, and pulling the whole film
+        // library each time is a multi-megabyte response under a read timeout
+        // meant for a small one — which `get` then retries once before failing.
+        const scope =
+            itemId === undefined
+                ? '&Recursive=true&IncludeItemTypes=Movie'
+                : `&ids=${encodeURIComponent(this.#itemId(itemId))}`;
+
         const page = await this.#http.get<{ Items?: RawItemDetail[] }>(
-            `/Items?userId=${encodeURIComponent(user.id)}&Recursive=true&IncludeItemTypes=Movie` +
+            `/Items?userId=${encodeURIComponent(user.id)}${scope}` +
                 '&Fields=Path,ProviderIds&EnableImages=false'
         );
 

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -346,9 +346,10 @@ export interface MetadataInspectCapable {
      *  where it has one. */
     readEpisodeMetadata(user: ServiceUser, seriesItemId: string): Promise<EpisodeRecord[]>;
 
-    /** Every film in one call. Films need no per-title read the way episodes
-     *  need a per-series one. */
-    readMovieMetadata(user: ServiceUser): Promise<MovieRecord[]>;
+    /** Every film in one call, or just one when `itemId` is given. Films need
+     *  no per-title read the way episodes need a per-series one, but a caller
+     *  repairing a single film should not pull the whole library to find it. */
+    readMovieMetadata(user: ServiceUser, itemId?: string): Promise<MovieRecord[]>;
 }
 
 export const hasMetadataInspect = (a: ServiceAdapter): a is ServiceAdapter & MetadataInspectCapable =>

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -370,7 +370,10 @@ export interface MetadataRepairCapable {
      * Irreversible: the previous metadata is not recoverable, which is why
      * every caller is `destructive` tier.
      */
-    repairMetadata(itemId: string, opts: { tvdbId?: number; tmdbId?: number }): Promise<void>;
+    /** `settled` is true when the server finished the work before answering,
+     *  so a caller reading straight afterwards is reading a final result rather
+     *  than a snapshot mid-refresh. */
+    repairMetadata(itemId: string, opts: { tvdbId?: number; tmdbId?: number }): Promise<{ settled: boolean }>;
 }
 
 export const hasMetadataRepair = (a: ServiceAdapter): a is ServiceAdapter & MetadataRepairCapable =>

--- a/src/tools/deleteMedia.ts
+++ b/src/tools/deleteMedia.ts
@@ -119,11 +119,12 @@ export function registerDeleteMedia(
         },
 
         async apply(_plan, { service, instance, id, delete_files, add_import_exclusion }) {
-            await findAdapter(adapters, service, instance).deleteMedia(id, {
+            const adapter = findAdapter(adapters, service, instance);
+            await adapter.deleteMedia(id, {
                 deleteFiles: delete_files,
                 addImportExclusion: add_import_exclusion
             });
-            return { deleted: `${service}:${id}` };
+            return { deleted: `${adapter.id}:${id}` };
         }
     });
 }

--- a/src/tools/fixMetadata.ts
+++ b/src/tools/fixMetadata.ts
@@ -151,7 +151,7 @@ export function registerFixMetadata(
         name: 'fix_metadata',
         title: 'Repair wrong metadata',
         description:
-            'Finds and repairs episodes whose Jellyfin metadata does not describe the file on disk — the case where a file named `Episode 101 …` is shown as S1E1 with a completely different title. This is not `trigger_scan`: a scan checks whether a file is on disk and never replaces a wrong title. Give a film or series title as `query`. The preview lists the mismatching files themselves, split into `numbering` findings (the season or episode number the path states disagrees with the server, high confidence) and `title` findings (the filename and the title share no words, advisory — a romanised filename against an English title is a legitimate disagreement). A film is judged on its **year** and title rather than on episode numbering: a film file names its year almost universally, and a year that disagrees means the server matched a different film rather than the same one worded differently. **Destructive**: the repair re-identifies the item against TVDB for a series or TMDB for a film and refreshes with `replaceAllMetadata`, which overwrites everything the server held, including anything corrected by hand. There is no undo. It also has a known limit, stated in the preview rather than discovered afterwards: a refresh does not re-derive an episode\'s season, number or title from its file, so episodes that were matched to a specific provider episode will not move. When the preview says that, the repair that works is `trigger_scan` with `action: "rename"` on the Sonarr series followed by a Jellyfin rescan — not this tool. **The repair is slow**: Jellyfin holds the identify request open while it talks to the provider and rebuilds the item, and a live run on a 69-episode series took longer than a normal read timeout allows. A long wait is not a hang — do not retry, which starts a second full rematch. Previews by default — call again with the returned `confirm` token to apply it.',
+            'Finds and repairs episodes whose Jellyfin metadata does not describe the file on disk — the case where a file named `Episode 101 …` is shown as S1E1 with a completely different title. This is not `trigger_scan`: a scan checks whether a file is on disk and never replaces a wrong title. Give a film or series title as `query`. The preview lists the mismatching files themselves, split into `numbering` findings (the season or episode number the path states disagrees with the server, high confidence) and `title` findings (the filename and the title share no words, advisory — a romanised filename against an English title is a legitimate disagreement). A film is judged on its **year** and title rather than on episode numbering: a film file names its year almost universally, and a year that disagrees means the server matched a different film rather than the same one worded differently. **Destructive**: the repair re-identifies the item against TVDB for a series or TMDB for a film, which the server performs as a full refresh with `replaceAllMetadata` and `removeOldMetadata` — overwriting everything it held, including anything corrected by hand. There is no undo. It also has a known limit, stated in the preview rather than discovered afterwards: a refresh does not re-derive an episode\'s season, number or title from its file, so episodes that were matched to a specific provider episode will not move. When the preview says that, the repair that works is `trigger_scan` with `action: "rename"` on the Sonarr series followed by a Jellyfin rescan — not this tool. **The repair is slow**: Jellyfin holds the identify request open while it talks to the provider and rebuilds the item, and a live run on a 69-episode series took longer than a normal read timeout allows. A long wait is not a hang — do not retry, which starts a second full rematch. Previews by default — call again with the returned `confirm` token to apply it.',
         inputSchema: z.object({
             query: z.string().min(1).describe('A film or series title. Resolved through the library index, the same way get_media_details resolves one.'),
             user: z
@@ -321,7 +321,7 @@ export function registerFixMetadata(
             const before = await read();
 
             // Exactly the id the preview named and the token bound.
-            await adapter.repairMetadata(series.itemId, bound.providerId ?? {});
+            const { settled } = await adapter.repairMetadata(series.itemId, bound.providerId ?? {});
 
             // Jellyfin refreshes asynchronously, so this re-read is a snapshot
             // taken while the work is very likely still running. It is reported
@@ -337,10 +337,12 @@ export function registerFixMetadata(
              * the reassuring lie every other part of this file is written to
              * avoid — so the outcome is stated in its own words here.
              *
-             * `unchanged` is not the same as failure: Jellyfin refreshes in the
-             * background, so an identical count immediately afterwards may mean
-             * "not finished yet" or may mean "did nothing". Both are reported as
-             * unverified rather than one being guessed at.
+             * Whether an unchanged count is a failure depends on which call ran.
+             * The identify path finishes the refresh before it answers, so its
+             * result is final and an unchanged count means it genuinely did
+             * nothing. The plain refresh is queued, so an unchanged count there
+             * may only be too early. `settled` carries that distinction instead
+             * of hedging over both.
              */
             return {
                 mismatchesBefore: before.length,
@@ -348,8 +350,11 @@ export function registerFixMetadata(
                 verified: after.length < before.length,
                 note:
                     after.length < before.length
-                        ? `Repaired: ${before.length - after.length} of ${before.length} mismatches are gone. Jellyfin may still be refreshing, so the final count can improve further.`
-                        : `NOT VERIFIED: the calls succeeded but ${after.length} mismatches remain, the same as before. Jellyfin refreshes in the background, so this may be too early — re-run with dry_run in a minute. If the count is still identical then a refresh cannot fix this library: an episode's numbers and title are stored on the item from the original scan, not re-derived from the file. The repair that works is trigger_scan with action "rename" on the Sonarr series, then trigger_scan on Jellyfin.`
+                        ? `Repaired: ${before.length - after.length} of ${before.length} mismatches are gone.` +
+                          (settled ? '' : ' The refresh is queued, so the final count can improve further.')
+                        : settled
+                          ? `NOT FIXED: the re-identify completed and ${after.length} mismatches remain, the same as before. This is a final answer rather than an early one, because the server finished the work before replying. An episode's season and number are stored on the item from the original scan and no refresh re-derives them, so the repair that works is trigger_scan with action "rename" on the managing Radarr or Sonarr, then trigger_scan on Jellyfin.`
+                          : `NOT VERIFIED: the refresh was accepted but ${after.length} mismatches remain, the same as before. No provider id could be pinned, so this was a plain refresh, which the server queues — re-run with dry_run in a minute to see the settled result.`
             };
         }
     });

--- a/src/tools/fixMetadata.ts
+++ b/src/tools/fixMetadata.ts
@@ -83,6 +83,29 @@ type Resolved = {
     kind: 'movie' | 'series';
     tvdbId?: number;
     tmdbId?: number;
+    /** No Radarr or Sonarr manages this, so any provider id on it is the media
+     *  server's own — possibly the wrong one that caused the mismatch. */
+    unmanaged: boolean;
+};
+
+/**
+ * Which provider id the repair will actually pin, decided once.
+ *
+ * TMDB for a film because Radarr is built on it, TVDB for a series because
+ * Sonarr is, with the other as a fallback. The summary, the "not pinned"
+ * warning and the confirmation token all read this, so none of the three can
+ * describe a different id from the one `apply` sends.
+ */
+const pinnedProvider = (
+    item: Resolved
+): { label: string; id?: { tvdbId?: number; tmdbId?: number } } => {
+    const order = item.kind === 'movie' ? ([['TMDB', 'tmdbId'], ['TVDB', 'tvdbId']] as const) : ([['TVDB', 'tvdbId'], ['TMDB', 'tmdbId']] as const);
+
+    for (const [label, key] of order) {
+        const value = item[key];
+        if (value !== undefined) return { label: `${label} ${value}`, id: { [key]: value } };
+    }
+    return { label: 'no pinned provider id' };
 };
 
 /**
@@ -111,6 +134,7 @@ async function resolve(loader: LibraryLoader, query: string): Promise<Resolved> 
         itemId,
         title: best.title,
         kind: best.kind,
+        unmanaged: best.acquisition === undefined,
         ...(best.ids.tvdb === undefined ? {} : { tvdbId: best.ids.tvdb }),
         ...(best.ids.tmdb === undefined ? {} : { tmdbId: best.ids.tmdb })
     };
@@ -155,7 +179,7 @@ export function registerFixMetadata(
             let mismatches: Mismatch[];
 
             if (series.kind === 'movie') {
-                const films = (await adapter.readMovieMetadata(viewer)).filter(m => m.id === series.itemId);
+                const films = await adapter.readMovieMetadata(viewer, series.itemId);
                 parts = films;
                 mismatches = findMovieMismatches(films);
             } else {
@@ -199,27 +223,33 @@ export function registerFixMetadata(
              * 68 mismatching episodes carried their own AniDB/TVDB ids, the
              * repair applied cleanly, and every title came back identical.
              */
+            // Films are exempt. An episode pinned to a provider id keeps its
+            // scan-time numbering across a refresh, which is what makes the
+            // repair pointless there. A film has no such index: its year and
+            // title come from the match, and re-identifying re-derives both —
+            // so every matched film would otherwise be told, wrongly, that this
+            // repair achieves nothing and to rename a Sonarr series.
             const byId = new Map(parts.map(e => [e.id, e]));
-            const pinned = mismatches.filter(m => {
-                const record = byId.get(m.id);
-                return record !== undefined && pinnedToProvider(record);
-            }).length;
+            const pinned =
+                series.kind === 'movie'
+                    ? 0
+                    : mismatches.filter(m => {
+                          const record = byId.get(m.id);
+                          return record !== undefined && pinnedToProvider(record);
+                      }).length;
 
             const numbering = mismatches.filter(m => m.reasons.includes('numbering')).length;
             const titleOnly = mismatches.length - numbering;
-            const provider =
-                series.tvdbId !== undefined
-                    ? `TVDB ${series.tvdbId}`
-                    : series.tmdbId !== undefined
-                      ? `TMDB ${series.tmdbId}`
-                      : 'no pinned provider id';
+            // One decision, used by the summary, the warning and the token
+            // binding, so the three cannot disagree about which id is pinned.
+            const provider = pinnedProvider(series);
 
             return {
                 target,
                 summary:
                     pinned === mismatches.length
                         ? `${series.title} has ${mismatches.length} of ${comparable} episodes disagreeing with their files, but every one of them was matched to a specific provider episode — a refresh will not move those, and this repair is expected to change nothing.`
-                        : `Re-identify ${series.title} against ${provider} and replace all of its metadata: ${mismatches.length} of ${comparable} ${unit} disagree with their files.`,
+                        : `Re-identify ${series.title} against ${provider.label} and replace all of its metadata: ${mismatches.length} of ${comparable} ${unit} disagree with their files.`,
                 effects: [
                     ...(pinned === 0
                         ? []
@@ -229,9 +259,17 @@ export function registerFixMetadata(
                                   : `${pinned} of the ${mismatches.length} mismatching episodes were matched to a specific provider episode, and a refresh will not move those — an episode's numbers and title are stored on the item from the original scan, not re-derived from the file. For those, trigger_scan with action "rename" on the Sonarr series and then a Jellyfin rescan is the repair that works.`
                           ]),
                     'Replaces every metadata field on the series and its episodes. Anything corrected by hand in Jellyfin is overwritten, and the previous values are not recoverable.',
-                    ...(series.tvdbId === undefined
+                    ...(provider.id === undefined
                         ? [
-                              'No TVDB id is known for this series, so the identity is not pinned before the refresh — the server may re-match it the same wrong way. Consider fixing the series in Sonarr first.'
+                              'No provider id is known for this title, so the identity is not pinned before the refresh — the server may re-match it the same wrong way. Fix it in Radarr or Sonarr first.'
+                          ]
+                        : []),
+                    // m3: an id that came only from the media server is not
+                    // independent evidence — it may be the wrong id that caused
+                    // this. Say so rather than presenting it as a fix.
+                    ...(provider.id !== undefined && series.unmanaged
+                        ? [
+                              `${provider.label} is the media server's own id for this title, and no Radarr or Sonarr manages it — so re-identifying may pin exactly the id that is already wrong.`
                           ]
                         : []),
                     `${numbering} episode${numbering === 1 ? '' : 's'} where the path's own season/episode number disagrees with the server.`,
@@ -243,6 +281,11 @@ export function registerFixMetadata(
                 // changed between preview and confirm, the evidence the person
                 // agreed to no longer describes what would happen, and a fresh
                 // preview is the right outcome.
+                // No token for a write this predicts will do nothing. Issuing
+                // one asks a person to confirm a destructive, irreversible
+                // operation whose own preview says it achieves nothing, which
+                // is how confirming becomes reflexive.
+                ...(pinned > 0 && pinned === mismatches.length && numbering > 0 ? { noop: true } : {}),
                 args: {
                     itemId: series.itemId,
                     mismatches: mismatches.length,
@@ -250,39 +293,35 @@ export function registerFixMetadata(
                     // for a preview that unpinned nothing must not authorise one
                     // that unpins sixty-eight episodes.
                     pinned,
-                    ...(series.tvdbId === undefined ? {} : { tvdbId: series.tvdbId })
+                    kind: series.kind,
+                    // The id `apply` will actually pin, not just the series one:
+                    // a film pins TMDB, and binding only TVDB left a change to
+                    // the film's merged TMDB id invisible to the token.
+                    ...(provider.id === undefined ? {} : { providerId: provider.id })
                 }
             };
         },
 
-        async apply(_plan, { query, user }) {
+        async apply(plan, { user }) {
             const adapter = jellyfinAdapter(adapters);
             const viewer = await requireIdentity(adapters, identity).resolve(user);
-            const series = await resolve(loader, query);
+
+            // From the plan the token was verified against, not a second
+            // resolve. Re-resolving would let a concurrent write that
+            // invalidated the library index land this repair on a different
+            // item than the one the confirmation names.
+            const bound = plan.args as { itemId: string; kind: 'movie' | 'series'; providerId?: { tvdbId?: number; tmdbId?: number } };
+            const series = { itemId: bound.itemId, kind: bound.kind, title: plan.summary };
 
             const read = async (): Promise<Mismatch[]> =>
                 series.kind === 'movie'
-                    ? findMovieMismatches((await adapter.readMovieMetadata(viewer)).filter(m => m.id === series.itemId))
+                    ? findMovieMismatches(await adapter.readMovieMetadata(viewer, series.itemId))
                     : findMismatches(await adapter.readEpisodeMetadata(viewer, series.itemId));
 
             const before = await read();
 
-            await adapter.repairMetadata(series.itemId, {
-                // Whichever provider the managing *arr is the source of truth
-                // for: TMDB for a film, because Radarr is built on it, and TVDB
-                // for a series, because Sonarr is and its id is the one the file
-                // layout was built from. The other rides along only as a
-                // fallback when the first is unknown.
-                ...(series.kind === 'movie'
-                    ? {
-                          ...(series.tmdbId === undefined ? {} : { tmdbId: series.tmdbId }),
-                          ...(series.tmdbId === undefined && series.tvdbId !== undefined ? { tvdbId: series.tvdbId } : {})
-                      }
-                    : {
-                          ...(series.tvdbId === undefined ? {} : { tvdbId: series.tvdbId }),
-                          ...(series.tvdbId === undefined && series.tmdbId !== undefined ? { tmdbId: series.tmdbId } : {})
-                      })
-            });
+            // Exactly the id the preview named and the token bound.
+            await adapter.repairMetadata(series.itemId, bound.providerId ?? {});
 
             // Jellyfin refreshes asynchronously, so this re-read is a snapshot
             // taken while the work is very likely still running. It is reported

--- a/src/tools/getIndexers.ts
+++ b/src/tools/getIndexers.ts
@@ -130,7 +130,9 @@ export const summarizeIndexers = (result: GetIndexersResult, instanceCount: numb
     const partial =
         result.rejectionsUnavailable === undefined
             ? ''
-            : ` Rejection history is missing for ${result.rejectionsUnavailable.join(', ')}, so the list below is partial.`;
+            : result.recentRejections === undefined
+              ? ` Rejection history could not be read for ${result.rejectionsUnavailable.join(', ')}, so none is reported.`
+              : ` Rejection history is missing for ${result.rejectionsUnavailable.join(', ')}, so the list below is partial.`;
     return `${result.returned} of ${result.total} indexer(s)${disabled > 0 ? `, ${disabled} temporarily disabled` : ''}${result.degraded.length > 0 ? `. ${result.degraded.join(', ')} could not be reached` : ''}.${partial}`;
 };
 

--- a/src/tools/getMetadataIssues.ts
+++ b/src/tools/getMetadataIssues.ts
@@ -82,6 +82,9 @@ export type GetMetadataIssuesResult = {
      * is "could not look" rather than "nothing is wrong".
      */
     notComparable?: string[];
+    /** How many reads failed outright. `itemsScanned` counts successes only, so
+     *  without this the denominator silently shrinks. */
+    itemsSkipped?: number;
 };
 
 const FIX: Record<Remedy, string> = {
@@ -132,6 +135,7 @@ export async function buildGetMetadataIssues(
     const degraded: string[] = [];
     const notComparable: string[] = [];
     let scanned = 0;
+    let skipped = 0;
 
     // Films first, and in one request: they need no per-title read, so the
     // whole film half of the library costs what a single series costs.
@@ -217,6 +221,7 @@ export async function buildGetMetadataIssues(
             // One unreadable series must not turn a useful sweep into an
             // error. Named rather than swallowed, so a short list is legible.
             logger.warn({ service: adapter.id, itemId, err }, 'metadata sweep skipped a series');
+            skipped += 1;
             if (!degraded.includes(adapter.id)) degraded.push(adapter.id);
         }
     }
@@ -231,6 +236,7 @@ export async function buildGetMetadataIssues(
         items: paged.items.map(i => project(i, opts.detail)),
         degraded,
         itemsScanned: scanned,
+        ...(skipped === 0 ? {} : { itemsSkipped: skipped }),
         ...(notComparable.length === 0 ? {} : { notComparable })
     };
 }
@@ -263,7 +269,9 @@ export function registerGetMetadataIssues(
                           ? '.'
                           : `; ${rename} ${rename === 1 ? 'needs' : 'need'} a rename rather than a metadata refresh` +
                             (look === 0 ? '.' : `, and ${look} ${look === 1 ? 'needs' : 'need'} a look because this cannot tell which side is wrong.`)) +
-                      (result.degraded.length > 0 ? ` Some items could not be read (${result.degraded.join(', ')}).` : '') +
+                      (result.degraded.length > 0
+                          ? ` ${result.itemsSkipped ?? 0} could not be read at all (${result.degraded.join(', ')}), so the count above is out of fewer than the library holds.`
+                          : '') +
                       // Said out loud, because it is the difference between a
                       // quiet library and one nothing could be compared in.
                       (result.notComparable === undefined

--- a/src/tools/getMetadataIssues.ts
+++ b/src/tools/getMetadataIssues.ts
@@ -1,5 +1,12 @@
 import type { McpServer } from '@modelcontextprotocol/server';
-import { findMismatches, findMovieMismatches, pinnedToProvider, summariseSeries, type Remedy } from '../core/episodeMismatch.ts';
+import {
+    findMismatches,
+    findMovieMismatches,
+    movieRemedy,
+    pinnedToProvider,
+    summariseSeries,
+    type Remedy
+} from '../core/episodeMismatch.ts';
 import { fenceText } from '../core/fence.ts';
 import { logger } from '../core/logger.ts';
 import type { IdentityResolver } from '../core/identity.ts';
@@ -68,12 +75,25 @@ export type GetMetadataIssuesResult = {
     /** How many films and series were read, so a small `total` can be read as
      *  "few problems" rather than "few looked at". */
     itemsScanned: number;
+    /**
+     * Items whose files the server would not name, so nothing about them was
+     * compared. Reported apart from both `itemsScanned` and `degraded`: the
+     * read succeeded, so the instance is not degraded, but the answer for these
+     * is "could not look" rather than "nothing is wrong".
+     */
+    notComparable?: string[];
 };
 
 const FIX: Record<Remedy, string> = {
-    refresh_metadata: 'fix_metadata — the server never matched this, so a refresh can fill it in.',
+    refresh_metadata: 'fix_metadata — the server holds nothing of its own here, or matched the wrong thing, and re-identifying re-derives it.',
     rename_files:
-        'trigger_scan with action "rename" on the managing Radarr or Sonarr, then trigger_scan on Jellyfin — the file is the outlier here, and no metadata refresh moves it.'
+        'trigger_scan with action "rename" on the managing Radarr or Sonarr, then trigger_scan on Jellyfin. An episode\'s season and number are stored at scan time, so only the file can change.',
+    // Deliberately not an instruction. A title-only disagreement on an item the
+    // server already matched could be a wrong match or a correct title in
+    // another language, and nothing in the comparison separates those. Naming a
+    // fix here would send a destructive write at a coin flip.
+    inspect:
+        'Look before acting: the file and the server disagree on wording only, and this cannot tell which is right. A title in a different language from the filename is a legitimate disagreement. Compare against the managing Radarr or Sonarr.'
 };
 
 const project = (issue: MetadataIssue, detail: DetailLevel): MetadataIssue => {
@@ -110,6 +130,7 @@ export async function buildGetMetadataIssues(
 
     const issues: MetadataIssue[] = [];
     const degraded: string[] = [];
+    const notComparable: string[] = [];
     let scanned = 0;
 
     // Films first, and in one request: they need no per-title read, so the
@@ -120,7 +141,7 @@ export async function buildGetMetadataIssues(
         for (const mismatch of findMovieMismatches(movies)) {
             const record = movies.find(m => m.id === mismatch.id);
             const pinned = record !== undefined && pinnedToProvider(record) ? 1 : 0;
-            const remedy: Remedy = mismatch.reasons.includes('year') || pinned === 1 ? 'rename_files' : 'refresh_metadata';
+            const remedy = movieRemedy(mismatch.reasons, pinned === 1);
 
             issues.push({
                 service: adapter.id,
@@ -137,7 +158,9 @@ export async function buildGetMetadataIssues(
                 examples: [
                     fenceText(
                         `${unfenced(mismatch.path).split(/[/\\]/).at(-1) ?? ''} → ${unfenced(mismatch.serverTitle)}${mismatch.serverYear === undefined ? '' : ` (${mismatch.serverYear})`}`,
-                        { service: adapter.id, field: 'Path' }
+                        // The line is a filename and a title together, so the
+                        // label names the pair rather than claiming it is a path.
+                        { service: adapter.id, field: 'Path/Name' }
                     )
                 ]
             });
@@ -152,6 +175,18 @@ export async function buildGetMetadataIssues(
         if (itemId === undefined) continue;
         try {
             const episodes = await adapter.readEpisodeMetadata(viewer, itemId);
+
+            // "Could not look" is not "looked and found nothing". A series whose
+            // episodes came back with no file paths compared nothing, and
+            // counting it as scanned-and-clean is how a sweep of a library the
+            // token cannot see file paths for answers "0 items disagree".
+            // fix_metadata already refuses this exact state as an error; the two
+            // must not contradict each other about the same input.
+            if (episodes.length > 0 && episodes.every(e => e.path === undefined || e.path.trim() === '')) {
+                notComparable.push(item.title);
+                continue;
+            }
+
             scanned += 1;
             const verdict = summariseSeries(episodes);
             if (verdict === undefined) continue;
@@ -176,7 +211,7 @@ export async function buildGetMetadataIssues(
                 // fixMetadata's own formatter documents: the closing marker
                 // contains a slash, so splitting a fenced path on separators
                 // returns the tail of the marker instead of the filename.
-                examples: examples.map(e => fenceText(e, { service: adapter.id, field: 'Path' }))
+                examples: examples.map(e => fenceText(e, { service: adapter.id, field: 'Path/Name' }))
             });
         } catch (err) {
             // One unreadable series must not turn a useful sweep into an
@@ -195,7 +230,8 @@ export async function buildGetMetadataIssues(
         ...paged,
         items: paged.items.map(i => project(i, opts.detail)),
         degraded,
-        itemsScanned: scanned
+        itemsScanned: scanned,
+        ...(notComparable.length === 0 ? {} : { notComparable })
     };
 }
 
@@ -218,14 +254,21 @@ export function registerGetMetadataIssues(
             const result = await buildGetMetadataIssues(adapters, identity, { detail, limit, offset });
 
             const rename = result.items.filter(i => i.remedy === 'rename_files').length;
+            const look = result.items.filter(i => i.remedy === 'inspect').length;
             const summary =
                 result.itemsScanned === 0
                     ? 'No media server library could be read, so nothing was compared — this is not a clean result.'
                     : `${result.total} of ${result.itemsScanned} items have metadata that disagrees with their files` +
                       (result.total === 0
                           ? '.'
-                          : `; ${rename} need a rename rather than a metadata refresh.`) +
-                      (result.degraded.length > 0 ? ` Some series could not be read (${result.degraded.join(', ')}).` : '');
+                          : `; ${rename} ${rename === 1 ? 'needs' : 'need'} a rename rather than a metadata refresh` +
+                            (look === 0 ? '.' : `, and ${look} ${look === 1 ? 'needs' : 'need'} a look because this cannot tell which side is wrong.`)) +
+                      (result.degraded.length > 0 ? ` Some items could not be read (${result.degraded.join(', ')}).` : '') +
+                      // Said out loud, because it is the difference between a
+                      // quiet library and one nothing could be compared in.
+                      (result.notComparable === undefined
+                          ? ''
+                          : ` ${result.notComparable.length} series had no file paths to compare, so nothing is claimed about them.`);
 
             return { content: [{ type: 'text', text: summary }], structuredContent: result };
         }

--- a/src/tools/getSubtitles.ts
+++ b/src/tools/getSubtitles.ts
@@ -127,7 +127,13 @@ export function registerGetSubtitles(server: McpServer, adapters: readonly (Serv
             const unhealthy = (result.providers ?? []).filter(p => !p.healthy).length;
             const summary =
                 result.degraded.length > 0
-                    ? `Bazarr could not be reached (${result.degraded.join(', ')}); subtitle information may be incomplete.`
+                    ? `Bazarr could not be reached (${result.degraded.join(', ')}); subtitle information may be incomplete.` +
+                      // Kept on this branch too: one instance down and another
+                      // half-answering are different holes, and naming only the
+                      // first hides the second.
+                      (result.providersUnavailable === undefined
+                          ? ''
+                          : ` Provider state is also missing for ${result.providersUnavailable.join(', ')}.`)
                     : `${result.returned} of ${result.total} item(s) missing subtitles` +
                       (unhealthy > 0 ? `; ${unhealthy} provider(s) unavailable.` : '.') +
                       // Said out loud for the same reason get_indexers says it:

--- a/src/tools/grabRelease.ts
+++ b/src/tools/grabRelease.ts
@@ -180,8 +180,9 @@ export function registerGrabRelease(
                 throw new Error('`guid` and `indexer_id` are both required to grab a release.');
             }
 
-            await findAdapter(adapters, service, instance).grabRelease({ guid, indexerId: indexer_id });
-            return { grabbed: `${service}:${guid}` };
+            const adapter = findAdapter(adapters, service, instance);
+            await adapter.grabRelease({ guid, indexerId: indexer_id });
+            return { grabbed: `${adapter.id}:${guid}` };
         }
     });
 }

--- a/src/tools/removeBlocklistItem.ts
+++ b/src/tools/removeBlocklistItem.ts
@@ -70,8 +70,9 @@ export function registerRemoveBlocklistItem(
         },
 
         async apply(_plan, { service, instance, id }) {
-            await findAdapter(adapters, service, instance).removeBlocklistItem(id);
-            return { removed: `${service}:${id}` };
+            const adapter = findAdapter(adapters, service, instance);
+            await adapter.removeBlocklistItem(id);
+            return { removed: `${adapter.id}:${id}` };
         }
     });
 }

--- a/src/tools/updateMedia.ts
+++ b/src/tools/updateMedia.ts
@@ -209,7 +209,7 @@ export function registerUpdateMedia(
                 changes.push('tags');
             }
 
-            const target = `${service}:${id}`;
+            const target = `${adapter.id}:${id}`;
 
             // A folder change is never a no-op even when the path looks the
             // same: `root_folder` is matched loosely, and the service decides

--- a/test/destructiveWrites.test.ts
+++ b/test/destructiveWrites.test.ts
@@ -17,6 +17,7 @@ import { registerDeleteMedia } from '../src/tools/deleteMedia.ts';
 import type { LibraryLoader } from '../src/tools/library.ts';
 import { registerRemoveQueueItem } from '../src/tools/removeQueueItem.ts';
 import { registerSetMonitoring } from '../src/tools/setMonitoring.ts';
+import { registerUpdateMedia } from '../src/tools/updateMedia.ts';
 import type { WriteToolResult } from '../src/tools/write.ts';
 import { jsonResponse } from './helpers/serve.ts';
 
@@ -1274,6 +1275,36 @@ describe('audit targets name the instance', () => {
             instance: '4k',
             id: '412',
             delete_files: false,
+            dry_run: true
+        });
+
+        expect(structuredContent.target).toBe('radarr/4k:412');
+    });
+});
+
+/**
+ * M9. `update_media` builds its target the same way the seven tools #201 named
+ * did, and the issue's own list missed it. Found by review, not by the sweep
+ * that produced the list.
+ */
+describe('update_media names the instance too', () => {
+    it('records radarr/4k, not radarr', async () => {
+        const namedRadarr = { ...tiered(false, true), name: '4k' } as never;
+        const h = harness(registerUpdateMedia, {
+            adapters: [
+                new RadarrAdapter(
+                    namedRadarr,
+                    recordingFetch({ '/api/v3/movie/412': MOVIE, '/api/v3/queue': ARR_QUEUE }).impl
+                )
+            ],
+            permissions: { radarr: namedRadarr }
+        });
+
+        const { structuredContent } = await h.call({
+            service: 'radarr',
+            instance: '4k',
+            id: '412',
+            monitored: false,
             dry_run: true
         });
 

--- a/test/episodeMismatch.test.ts
+++ b/test/episodeMismatch.test.ts
@@ -4,6 +4,8 @@ import {
     findMismatches,
     findMovieMismatches,
     parseFileNumbering,
+    extractFileTitle,
+    movieRemedy,
     parseMovieFile,
     summariseSeries,
     type EpisodeRecord
@@ -330,13 +332,17 @@ describe('summariseSeries', () => {
         expect(verdict).toMatchObject({ mismatches: 1, numbering: 0, titleOnly: 1, pinned: 0, remedy: 'refresh_metadata' });
     });
 
-    /** The Furious shape: the server matched it and is right, the filename is
-     *  the outlier — refreshing would rewrite correct metadata. */
-    it('sends a matched title mismatch to a rename', () => {
+    /**
+     * The Furious shape. This used to be sent to a rename on the strength of one
+     * series where the filenames were the outlier — but the identical finding is
+     * produced by a server holding correct titles in another language, and
+     * nothing here separates the two. It says "look" rather than naming a fix.
+     */
+    it('refuses to name a fix for a matched title mismatch', () => {
         const verdict = summariseSeries([
             withIds({ id: 'p', name: 'My Life Had Stood a Loaded Gun', season: 1, episode: 2, path: '/tv/F/Season 01/F - S01E02 - Flash Flood.mkv' })
         ]);
-        expect(verdict).toMatchObject({ mismatches: 1, titleOnly: 1, pinned: 1, remedy: 'rename_files' });
+        expect(verdict).toMatchObject({ mismatches: 1, titleOnly: 1, pinned: 1, remedy: 'inspect' });
     });
 
     /** The Dragon Ball Kai shape. Numbering is stored at scan time and no
@@ -421,5 +427,102 @@ describe('findMovieMismatches', () => {
 
     it('says nothing about a film with no file', () => {
         expect(findMovieMismatches([film({ id: 'n', name: 'Alien', year: 1979 })])).toEqual([]);
+    });
+});
+
+/**
+ * Every one of these was a false positive found by review rather than by the
+ * suite, on a library shaped unlike the one this was developed against. The
+ * detector feeds an irreversible write, so each gets a test.
+ */
+describe('false positives found by review', () => {
+    it('reads a four-digit episode number, rather than dropping the fourth digit', () => {
+        // Sonarr's default {episode:00} emits E1000 past 999. Read as episode
+        // 100, every long-running anime got a confident numbering finding.
+        expect(parseFileNumbering('/tv/One Piece/Season 21/One Piece - S21E1000 - Overwhelming Strength.mkv')).toMatchObject({
+            season: 21,
+            episode: 1000
+        });
+    });
+
+    it('does not read a series title as numbering', () => {
+        // 2x2 Shinobuden is a real series; 4x4 Adventures stands for the shape.
+        expect(parseFileNumbering('/tv/2x2 Shinobuden/Season 01/2x2 Shinobuden - Episode 1 - Ninja Nonsense.mkv')).toMatchObject({
+            season: 1,
+            episode: 1
+        });
+    });
+
+    it('does not read a resolution tag as numbering', () => {
+        expect(parseFileNumbering('/tv/Old Show/Season 01/Old Show - Episode 3 - The Pilot 640x480.avi')).toMatchObject({
+            season: 1,
+            episode: 3
+        });
+    });
+
+    it('takes the last numbering in the name, so a title containing one is not a decoy', () => {
+        expect(parseFileNumbering('/tv/The S1E1 Podcast/Season 02/The S1E1 Podcast - S02E03 - Title.mkv')).toMatchObject({
+            season: 2,
+            episode: 3
+        });
+    });
+
+    it('takes the first title field, not the longest, so release tags do not win', () => {
+        expect(extractFileTitle('/tv/S/Season 01/Show - S01E01 - Pilot - AMZN WEB-DL DDP5.1 H.264-NTb.mkv')).toBe('Pilot');
+    });
+
+    /** Sonarr and Radarr name files in English; a server set to another
+     *  metadata language disagrees on every title while both are correct. */
+    it('does not compare titles across scripts', () => {
+        const items: EpisodeRecord[] = [
+            ep({
+                id: 'ja',
+                name: '進撃の巨人 第一話',
+                season: 1,
+                episode: 1,
+                path: '/tv/AoT/Season 01/AoT - S01E01 - Shingeki no Kyojin.mkv'
+            })
+        ];
+        expect(findMismatches(items)).toEqual([]);
+    });
+
+    /** Radarr names a file with the year it held at import; TMDB moves festival
+     *  and limited dates across a year boundary afterwards. */
+    it('tolerates a one-year drift on a film', () => {
+        expect(
+            findMovieMismatches([
+                { id: 'd', name: 'Some Film', year: 2024, path: '/movies/Some Film (2023)/Some Film (2023) [Bluray-1080p].mkv' }
+            ])
+        ).toEqual([]);
+    });
+
+    it('still flags a film that is two years out', () => {
+        expect(
+            findMovieMismatches([
+                { id: 'w', name: 'The Thing', year: 2011, path: '/movies/The Thing (1982)/The Thing (1982).mkv' }
+            ])[0]?.reasons
+        ).toEqual(['year']);
+    });
+
+    it('takes the last parenthesised year', () => {
+        expect(parseMovieFile('/movies/Death Race 2000 (2008)/Death Race 2000 (2008).mkv')).toMatchObject({ year: 2008 });
+    });
+});
+
+describe('movieRemedy', () => {
+    /** The episode rule does not carry over. A film's year comes from the
+     *  provider match, not from a scan-time index, so re-identifying re-derives
+     *  it — and every matched film is pinned, so the episode rule would have
+     *  sent every single film finding to a pointless rename. */
+    it('sends a wrong year to a re-identify, even though the film is matched', () => {
+        expect(movieRemedy(['year'], true)).toBe('refresh_metadata');
+    });
+
+    it('refuses to name a fix for a matched title-only disagreement', () => {
+        expect(movieRemedy(['title'], true)).toBe('inspect');
+    });
+
+    it('fills in an unmatched film', () => {
+        expect(movieRemedy(['title'], false)).toBe('refresh_metadata');
     });
 });

--- a/test/fixMetadata.test.ts
+++ b/test/fixMetadata.test.ts
@@ -255,7 +255,13 @@ describe('fix_metadata', () => {
             return h.call({ query: 'Dragon Ball Kai', confirm: preview.structuredContent.confirm_token });
         };
 
-        it('pins the TVDB id before refreshing, so the agent cannot re-match the same way', async () => {
+        /**
+         * One call, not two. Checked against the server source:
+         * ApplySearchCriteria sets the provider ids and then awaits a full
+         * refresh itself before answering, so a second /Refresh is another full
+         * provider fetch of the same item for nothing.
+         */
+        it('pins the id and stops, because the identify call refreshes on its own', async () => {
             const h = harness();
             const { structuredContent } = await confirmed(h);
 
@@ -263,10 +269,7 @@ describe('fix_metadata', () => {
 
             const apply = h.wrote.find(w => w.path.startsWith('/Items/RemoteSearch/Apply/'));
             expect(apply?.body).toEqual({ ProviderIds: { Tvdb: String(TVDB) } });
-
-            const refresh = h.wrote.find(w => w.path.endsWith('/Refresh'));
-            expect(refresh).toBeDefined();
-            expect(h.wrote.indexOf(apply!)).toBeLessThan(h.wrote.indexOf(refresh!));
+            expect(h.wrote.some(w => w.path.endsWith('/Refresh'))).toBe(false);
         });
 
         /**
@@ -275,7 +278,8 @@ describe('fix_metadata', () => {
          * a completed repair. The casing comes from the vendored spec.
          */
         it('spells the refresh parameters the way the server actually reads them', async () => {
-            const h = harness();
+            // The plain refresh only runs when there is no id to pin.
+            const h = harness({ item: seriesItem({ ids: {} }) });
             await confirmed(h);
 
             const refresh = h.wrote.find(w => w.path.endsWith('/Refresh'));
@@ -293,11 +297,23 @@ describe('fix_metadata', () => {
             expect(h.wrote.some(w => w.path.endsWith('/Refresh'))).toBe(true);
         });
 
-        it('does not claim the refresh finished, because Jellyfin runs it in the background', async () => {
+        /** The queued path is the only one that cannot answer yet. */
+        it('says the count may improve only when the refresh was queued', async () => {
+            const queued = harness({ item: seriesItem({ ids: {} }) });
+            const { structuredContent } = await confirmed(queued);
+            expect(JSON.stringify(structuredContent.result)).toContain('queues');
+        });
+
+        /** The identify path finished the work before replying, so an unchanged
+         *  count is a final answer and saying "may be too early" would be a
+         *  hedge the server has already resolved. */
+        it('gives a final answer when the server finished before replying', async () => {
             const h = harness();
             const { structuredContent } = await confirmed(h);
+            const text = JSON.stringify(structuredContent.result);
 
-            expect(JSON.stringify(structuredContent.result)).toContain('background');
+            expect(text).toContain('final answer');
+            expect(text).not.toContain('too early');
         });
 
         it('is refused outright when the destructive tier is off', async () => {
@@ -366,6 +382,6 @@ describe('episodes pinned to their own provider ids', () => {
         expect(structuredContent.applied).toBe(true);
         const result = structuredContent.result as { verified: boolean; note: string };
         expect(result.verified).toBe(false);
-        expect(result.note).toContain('NOT VERIFIED');
+        expect(result.note).toContain('NOT FIXED');
     });
 });

--- a/test/fixMetadata.test.ts
+++ b/test/fixMetadata.test.ts
@@ -93,8 +93,12 @@ function harness(
             return new Response(null, { status: 204 });
         }
 
-        if (url.pathname === '/Items' && url.searchParams.get('IncludeItemTypes') === 'Movie') {
-            return jsonResponse({ Items: opts.films ?? [] });
+        // Both film reads: the whole-library one and the by-id one fix_metadata
+        // uses so a single repair does not pull the entire film library.
+        if (url.pathname === '/Items') {
+            const wanted = url.searchParams.get('ids');
+            const films = opts.films ?? [];
+            return jsonResponse({ Items: wanted === null ? films : films.filter(f => f.Id === wanted) });
         }
 
         if (url.pathname.startsWith('/Shows/')) {
@@ -338,8 +342,20 @@ describe('episodes pinned to their own provider ids', () => {
         expect(text).not.toContain('pinned');
     });
 
-    it('reports the repair unverified when the mismatch count did not move', async () => {
+    /** A write the preview predicts will do nothing no longer issues a token:
+     *  confirming a destructive no-op is how confirming becomes reflexive. */
+    it('does not offer to confirm a repair it expects to achieve nothing', async () => {
         const h = harness({ episodes: [pinned(1)] });
+        const { structuredContent } = await h.call({ query: 'Dragon Ball Kai' });
+
+        expect(structuredContent.noop).toBe(true);
+        expect(structuredContent.confirm_token).toBeUndefined();
+        expect(h.wrote).toHaveLength(0);
+    });
+
+    it('reports the repair unverified when the mismatch count did not move', async () => {
+        // Unpinned, so the repair is worth attempting and a token is issued.
+        const h = harness({ episodes: [broken(1)] });
         const preview = await h.call({ query: 'Dragon Ball Kai' });
         const { structuredContent } = await h.call({
             query: 'Dragon Ball Kai',

--- a/test/getMetadataIssues.test.ts
+++ b/test/getMetadataIssues.test.ts
@@ -96,11 +96,17 @@ describe('get_metadata_issues', () => {
         expect(result.items[0]?.fix).toContain('fix_metadata');
     });
 
-    it('sends a matched title mismatch to a rename instead', async () => {
+    /**
+     * A matched title mismatch used to be sent to a rename, on the strength of
+     * one series where the filenames were the outlier. It cannot know that: the
+     * same finding is produced by a Jellyfin holding correct titles in another
+     * language. It says so instead of naming a fix.
+     */
+    it('refuses to name a fix for a matched title mismatch', async () => {
         const result = await sweep(adapterWith({ Furious: [healthy(1), misnamed(2)] }));
 
-        expect(result.items[0]).toMatchObject({ remedy: 'rename_files', titleOnly: 1, pinned: 1 });
-        expect(result.items[0]?.fix).toContain('rename');
+        expect(result.items[0]).toMatchObject({ remedy: 'inspect', titleOnly: 1, pinned: 1 });
+        expect(result.items[0]?.fix).toContain('cannot tell which is right');
     });
 
     it('ranks numbering findings above title ones', async () => {
@@ -188,7 +194,10 @@ describe('films', () => {
         });
         const [row] = (await sweep(adapterWith({}, [], [wrong]))).items;
 
-        expect(row).toMatchObject({ kind: 'movie', numbering: 1, remedy: 'rename_files' });
+        // Not a rename. A film's year comes from the provider match rather than
+        // from a scan-time index, so re-identifying re-derives it — the episode
+        // rule does not carry over, and every matched film is pinned.
+        expect(row).toMatchObject({ kind: 'movie', numbering: 1, remedy: 'refresh_metadata' });
         expect(row?.examples?.[0]).toContain('2011');
     });
 
@@ -231,5 +240,34 @@ describe('films', () => {
 
         expect(result.total).toBe(1);
         expect(result.degraded).toEqual(['jellyfin']);
+    });
+});
+
+/**
+ * M3. "Could not look" and "looked and found nothing" arrive at the same count.
+ * A sweep whose token cannot see file paths — a non-administrator, which the
+ * sibling tool's own remedy text warns about — answered "0 items disagree",
+ * a clean bill of health from comparing nothing. `fix_metadata` already refuses
+ * that exact state as an error; the two must not contradict each other.
+ */
+describe('a series with no file paths is not a clean one', () => {
+    const noPaths = (n: number): EpisodeRecord => ({ id: `np${n}`, name: `Episode ${n}`, season: 1, episode: n });
+
+    it('reports it as not comparable rather than as scanned and clean', async () => {
+        const result = await sweep(adapterWith({ Hidden: [noPaths(1), noPaths(2)] }));
+
+        expect(result.notComparable).toEqual(['Hidden']);
+        expect(result.itemsScanned).toBe(0);
+        expect(result.total).toBe(0);
+    });
+
+    it('does not call the instance degraded, because the read succeeded', async () => {
+        const result = await sweep(adapterWith({ Hidden: [noPaths(1)] }));
+        expect(result.degraded).toEqual([]);
+    });
+
+    it('stays absent when every series had something to compare', async () => {
+        const result = await sweep(adapterWith({ Fine: [healthy(1)] }));
+        expect(result.notComparable).toBeUndefined();
     });
 });


### PR DESCRIPTION
A review of #204 and #206 found nine substantive defects. All fixed, each with
a regression test, because every one was found by reading the code rather than
by the suite.

## The remedy rule was the reasoning error

"Matched to a provider id, so the file is the outlier" was generalised from
three real series. It does not hold in either direction it was extended to.

**Films.** A film's year and title come from the provider match, not from a
scan-time index, so re-identifying re-derives both. Every matched film carries
provider ids, so the rule sent *every* film finding to a rename that cannot fix
it. Worse, `fix_metadata` told film users the repair was "expected to achieve
nothing" and to go rename a Sonarr series. The tests missed it because the film
fixture carried no provider ids.

**Title-only findings.** A title disagreement says the two sides differ, not
which is wrong. The identical finding is produced by a server holding correct
titles in another language. There is now a third remedy, `inspect`, which says
so rather than naming a fix. Only `numbering` still names one, because that is
the signal that was actually measured.

## The sweep gave a clean bill of health for a library it did not read

If the server withholds file paths, which happens for a non-administrator token
and which `fix_metadata`'s own remedy text warns about, `get_metadata_issues`
answered "0 of 219 items have metadata that disagrees with their files". That is
the reassuring lie the design forbids, and the two tools contradicted each other
about the same input: one refuses it as an error, the other called it clean.
Now reported as `notComparable`.

## Four parser false positives, all on the confident signal

| input | was read as | reality |
| --- | --- | --- |
| `One Piece - S21E1000` | episode 100 | Sonarr emits four digits past 999 |
| `2x2 Shinobuden - Episode 1` | season 2 episode 2 | a real series title |
| `The Pilot 640x480.avi` | season 640 episode 480 | a resolution tag |
| `The S1E1 Podcast - S02E03` | S1E1 | first match won; now the last |
| `- Pilot - AMZN WEB-DL DDP5.1 H.264-NTb` | title `AMZN WEB-DL DDP5 1 H 264` | longest field won; now the first |

Every one of these flagged a correct library with the reason the tool presents
as high confidence.

## The rest

- A one-year year drift is no longer a finding. Radarr names a file with the
  year it held at import and TMDB moves festival dates across a boundary
  afterwards; two years apart still counts.
- Titles are not compared across scripts.
- `fix_metadata` reads one film by id rather than pulling the whole film
  library, which it did four times per confirmed repair under a read timeout
  meant for a small response.
- `apply` acts on the plan the token was verified against rather than
  re-resolving the query, and the bound provider id is the one it actually
  sends.
- A write the preview predicts will achieve nothing no longer issues a token.
  Confirming a destructive no-op is how confirming becomes reflexive.
- `update_media` built its audit target from the bare service string exactly as
  the seven tools in #201 did. The issue's own list missed it, and so did I. The
  apply results of `delete_media`, `remove_blocklist_item` and `grab_release`
  were bare too.
- Prose and doc drift: a "partial list" note that described an absent list, a
  degraded summary that swallowed the unavailable note, `seriesScanned` vs
  `itemsScanned`, `remaining` vs `mismatchesAfter`, and an example line labelled
  as a path when it is a path and a title.

## Verification

2551 tests, lint and typecheck clean. Live re-sweep after the fixes: 219 items,
the same two real findings, no regressions. Furious moved from `rename_files` to
`inspect`, which is the honest verdict on the evidence the tool actually has.

The one thing I did not change: `registry.ts` still has two structurally unsafe
switch cases. The cast that would express the intent is rejected as unnecessary,
so closing it means a type-level service-id to config map in the schema. That is
a separate change and it is documented in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
