### PR TITLE
feat: report the root folders an *arr maps to nothing

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,8 @@ Thirty-six tools, but you never name them — you ask, and the model picks:
 ## Requirements
 
 - At least one supported service, LAN-reachable: Radarr 4.0+, Sonarr 4.0+,
-  Prowlarr 1.0+, Bazarr 1.4+, Jellyfin 10.8+, Seerr 1.0+, SABnzbd 3.0+,
-  Transmission 3.0+, qBittorrent 4.1+
+  Prowlarr 1.0+, Bazarr 1.4+, Jellyfin 10.8+, Plex Media Server 1.32+,
+  Seerr 1.0+, SABnzbd 3.0+, Transmission 3.0+, qBittorrent 4.1+
 - Docker, or Node 24+ to run from source
 - An MCP client speaking protocol revision `2026-07-28`
 
@@ -205,6 +205,7 @@ arr-mcp is glue; the hard parts belong to other people. Every service it speaks
 to is free software maintained largely by volunteers — [Radarr](https://radarr.video),
 [Sonarr](https://sonarr.tv), [Prowlarr](https://prowlarr.com),
 [Bazarr](https://www.bazarr.media), [Jellyfin](https://jellyfin.org),
+[Plex](https://www.plex.tv),
 [Seerr](https://github.com/seerr-team/seerr), [SABnzbd](https://sabnzbd.org),
 [Transmission](https://transmissionbt.com), [qBittorrent](https://www.qbittorrent.org) — as are the libraries it is built
 on: [MCP TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk),

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -167,6 +167,16 @@ is three extra calls per instance and it answers "what may I choose", not "is
 anything broken". An instance whose profile list cannot be read is named in
 `degraded` and left out of `options` — the rest of the answer stands.
 
+Each root folder also carries `unmappedFolders` when the instance reports any:
+the folder names under that root it associates with no item. It rides along on
+a call already being made, and it is the only trace the API gives of a mapping
+the service has lost — an item whose files it no longer knows about is never
+renamed, upgraded or searched for again. Read it as a fact rather than a
+verdict: a folder dropped in by hand and a delete that kept its files look
+exactly the same from here. Absent rather than empty when the root is fully
+mapped, so "nothing unmapped" stays distinguishable from "the service did not
+say".
+
 ### Did that command finish?
 
 `commands` is every **followable** task a service has queued or running, plus
@@ -1004,7 +1014,7 @@ no-op, and a request naming no field at all is refused rather than previewed.
 
 ## Prompts and resources
 
-Thirty-four tools do not tell you which one to reach for, and the questions
+Thirty-six tools do not tell you which one to reach for, and the questions
 people actually ask are rarely one call.
 
 **Five prompts**, which most clients surface as slash commands:

--- a/src/services/arrAdd.ts
+++ b/src/services/arrAdd.ts
@@ -67,7 +67,7 @@ export const SONARR_ADD: ArrAddShape = {
 };
 
 type RawProfile = { id?: number; name?: string };
-type RawRootFolder = { path?: string; freeSpace?: number };
+type RawRootFolder = { path?: string; freeSpace?: number; unmappedFolders?: { name?: string }[] };
 type RawLookup = { id?: number; title?: string; year?: number };
 
 export async function readQualityProfiles(http: ServiceHttp, service: string): Promise<QualityProfile[]> {
@@ -85,13 +85,24 @@ export async function readRootFolders(http: ServiceHttp, service: string): Promi
     const rows = await http.get<RawRootFolder[]>('/api/v3/rootfolder');
     return rows
         .filter((r): r is RawRootFolder & { path: string } => typeof r.path === 'string' && r.path !== '')
-        .map(r => ({
-            // Raw, because this is what gets posted back as a directory.
-            path: r.path,
-            // Fenced, because this is what reaches model context as prose.
-            display: fenceText(r.path, { service, field: 'path' }),
-            ...(typeof r.freeSpace === 'number' ? { freeSpaceBytes: r.freeSpace } : {})
-        }));
+        .map(r => {
+            // The service reports each unmapped folder three ways: `name`,
+            // `relativePath` and an absolute `path`. `name` is the one that is
+            // not already implied by the root's own path beside it.
+            const unmapped = (r.unmappedFolders ?? [])
+                .map(u => u.name)
+                .filter((n): n is string => typeof n === 'string' && n !== '')
+                .map(n => fenceText(n, { service, field: 'unmappedFolder' }));
+
+            return {
+                // Raw, because this is what gets posted back as a directory.
+                path: r.path,
+                // Fenced, because this is what reaches model context as prose.
+                display: fenceText(r.path, { service, field: 'path' }),
+                ...(typeof r.freeSpace === 'number' ? { freeSpaceBytes: r.freeSpace } : {}),
+                ...(unmapped.length === 0 ? {} : { unmappedFolders: unmapped })
+            };
+        });
 }
 
 export async function readTags(http: ServiceHttp, service: string): Promise<Tag[]> {

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -851,7 +851,22 @@ export type QualityProfile = { id: number; name: string; display: string };
  * both is what stops anyone having to un-fence a value, which `fenceText` is
  * deliberately not reversible for.
  */
-export type RootFolder = { path: string; display: string; freeSpaceBytes?: number };
+export type RootFolder = {
+    path: string;
+    display: string;
+    freeSpaceBytes?: number;
+    /**
+     * Folder names inside this root that the service maps to no item, fenced —
+     * these are read, never posted back, so unlike `path` there is no raw half.
+     *
+     * A fact rather than a verdict. It can be a mapping the service lost, a
+     * folder someone dropped in by hand, or a delete that kept the files, and
+     * nothing in the response separates those. Absent rather than empty when
+     * the root is fully mapped, so "nothing unmapped" and "the service did not
+     * say" stay distinguishable.
+     */
+    unmappedFolders?: string[];
+};
 
 /** What an external id resolves to, and whether the service already has it. */
 export type AddCandidate = {

--- a/src/tools/stackHealth.ts
+++ b/src/tools/stackHealth.ts
@@ -72,7 +72,14 @@ export type StackHealthResult = {
 export type InstanceOptions = {
     instance: string;
     qualityProfiles: { id: number; name: string }[];
-    rootFolders: { path: string; freeSpaceBytes?: number }[];
+    /**
+     * `unmappedFolders` names folders under this root that the instance
+     * associates with no item. Reported here because the root folder read
+     * already returns it and dropping it hid the only API-visible trace of a
+     * mapping the service has lost. It is a fact, not a fault: a hand-dropped
+     * folder and a delete that kept its files look identical from here.
+     */
+    rootFolders: { path: string; freeSpaceBytes?: number; unmappedFolders?: string[] }[];
     tags: string[];
 };
 
@@ -273,7 +280,8 @@ export async function buildStackHealth(
                                       qualityProfiles: profiles.map(p => ({ id: p.id, name: p.display })),
                                       rootFolders: folders.map(f => ({
                                           path: f.display,
-                                          ...(f.freeSpaceBytes === undefined ? {} : { freeSpaceBytes: f.freeSpaceBytes })
+                                          ...(f.freeSpaceBytes === undefined ? {} : { freeSpaceBytes: f.freeSpaceBytes }),
+                                          ...(f.unmappedFolders === undefined ? {} : { unmappedFolders: f.unmappedFolders })
                                       })),
                                       tags: tags.map(t => t.display)
                                   }

--- a/test/radarr.test.ts
+++ b/test/radarr.test.ts
@@ -119,4 +119,44 @@ describe('RadarrAdapter', () => {
         const a = adapter({});
         expect([hasDiskSpace(a), hasHealthChecks(a), hasScanState(a)]).toEqual([true, true, true]);
     });
+
+    /**
+     * A folder in the root that the service maps to no item. It is a fact
+     * rather than a verdict: it can be a lost mapping, something dropped in by
+     * hand, or a delete that kept the files. The service reports it on the
+     * root folder read we already make, and discarding it hid the only
+     * API-visible trace of the first case.
+     */
+    it('reports the root folders the service maps to nothing', async () => {
+        const folders = await adapter({
+            '/api/v3/rootfolder': [
+                {
+                    path: '/movies',
+                    freeSpace: 100,
+                    unmappedFolders: [
+                        {
+                            name: 'Back to Black (2024) [tmdbid-998846]',
+                            path: '/movies/Back to Black (2024) [tmdbid-998846]',
+                            relativePath: 'Back to Black (2024) [tmdbid-998846]'
+                        }
+                    ]
+                }
+            ]
+        }).listRootFolders();
+
+        // Fenced: a folder name is free text from the service and reaches model
+        // context as prose. Unlike `path` it is never posted back, so there is
+        // no raw half to keep beside it.
+        expect(folders[0]?.unmappedFolders).toEqual([
+            '<<untrusted:radarr.unmappedFolder>>Back to Black (2024) [tmdbid-998846]<</untrusted>>'
+        ]);
+    });
+
+    it('omits unmappedFolders rather than reporting an empty list when the root is fully mapped', async () => {
+        const folders = await adapter({
+            '/api/v3/rootfolder': [{ path: '/movies', freeSpace: 100, unmappedFolders: [] }]
+        }).listRootFolders();
+
+        expect(folders[0]).not.toHaveProperty('unmappedFolders');
+    });
 });

--- a/test/stackHealth.test.ts
+++ b/test/stackHealth.test.ts
@@ -485,6 +485,34 @@ describe('stack_health add options', () => {
         ]);
     });
 
+    /**
+     * Carried on the root folder that reported it, not as a list of its own:
+     * "three folders under /movies answer to nothing" is the finding, and a
+     * bare list of names would lose which root they sit in on a stack with
+     * more than one.
+     */
+    it('carries the folders a root maps to nothing', async () => {
+        const result = await buildStackHealth(
+            [
+                addable({
+                    folders: async () => [
+                        {
+                            path: '/movies',
+                            display: '/movies',
+                            freeSpaceBytes: 100,
+                            unmappedFolders: ['Back to Black (2024) [tmdbid-998846]']
+                        }
+                    ]
+                })
+            ],
+            { detail: 'full', limit: 50 }
+        );
+
+        expect(result.options?.[0]?.rootFolders).toEqual([
+            { path: '/movies', freeSpaceBytes: 100, unmappedFolders: ['Back to Black (2024) [tmdbid-998846]'] }
+        ]);
+    });
+
     it('leaves them out below full — a profile list is not a fault', async () => {
         expect((await buildStackHealth([addable()], std)).options).toBeUndefined();
         expect((await buildStackHealth([addable()], { detail: 'minimal', limit: 50 })).options).toBeUndefined();


### PR DESCRIPTION
Closes #213, and corrects that issue's premise.

## The detector in the issue cannot work

#213 proposed spotting a lost file mapping as "no files reported, bytes still on disk". I measured before building it and that predicate can never fire. `sizeOnDisk` is an exact sum of the file records the service holds, not a stat of the folder:

```
Rick and Morty:  statistics.sizeOnDisk=70722.9 MB  sum(episodefile.size)=70722.9 MB  delta=0.0 MB
Nuclear Now:     sizeOnDisk=6948.6 MB              movieFile.size=6948.6 MB          delta=0.0 MB
```

Six samples across both services, delta exactly zero every time. Lose the mapping and both halves go to zero together. A sweep over 196 films and 121 series flagged nothing, and all 81 films and 58 series reporting no file held exactly zero bytes. The "folder still holds media" half needs the filesystem, which we only reach over HTTP.

## What actually sees it

`/api/v3/rootfolder` returns `unmappedFolders`, on a call `listRootFolders` already makes, and `readRootFolders` was throwing it away. Three real ones on my Radarr:

```
root /storage/movies  unmappedFolders=3
    Back to Black (2024) [tmdbid-998846]
    Influencers (2025) [tmdbid-1476740]
    Night Always Comes (2025) [tmdbid-1254624]
```

Sonarr: zero.

## The change

`RootFolder` gains `unmappedFolders?: string[]`, fenced at the adapter since folder names are service-supplied free text that reach model context as prose. Surfaced on `stack_health`'s `options` root folders at `detail: "full"`, where the call is already paid for. No new tool, no new endpoint, no new request.

Absent rather than empty when a root is fully mapped, so "nothing unmapped" stays distinguishable from "the service did not say".

Reported as a fact, not a fault. An unmapped folder can be a mapping the service lost, something dropped in by hand, or a delete that kept its files, and nothing in the response separates those.

## Two doc gaps found on the way

- Plex was missing from the README's requirements and thanks lists, though it is in the headline service list. Requirements now says 1.32+.
- `docs/tools.md` still said thirty-four tools in the prompts section when there are thirty-six. Nothing asserts that number against `TOOL_NAMES`, which is why it drifted.

## Known gap

`/api/v3/rootfolder` has no fixture and no entry in `test/contract.test.ts`, so `unmappedFolders` is uncontracted. That is pre-existing (`path` and `freeSpace` have been read uncontracted since `listRootFolders` was written) and capturing it needs a path anonymiser, since the response carries the mount layout and real media titles. Worth doing alongside the Plex capture anonymiser rather than inventing a second one here.

## Verification

Three gates, all clean:

- `npm run lint`: no output
- `npm run typecheck`: no output
- `npm test`: 100 files, 2555 tests passed

Live: probed against my own Radarr and Sonarr, read-only. Nothing was written to either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
