### PR TITLE
test: contract /rootfolder, so an upstream rename cannot pass green

### DIFF
--- a/scripts/capture-fixtures.ts
+++ b/scripts/capture-fixtures.ts
@@ -304,7 +304,10 @@ const ENDPOINTS: Record<ServiceId, Endpoint[]> = {
                 return id === undefined ? undefined : `/api/v3/movie/${id}`;
             }
         },
-        { name: 'movie-lookup', path: '/api/v3/movie/lookup?term=matrix' }
+        { name: 'movie-lookup', path: '/api/v3/movie/lookup?term=matrix' },
+        // `unmappedFolders` rides along on this response and is what
+        // `stack_health` reports about folders the instance maps to no item.
+        { name: 'rootfolder', path: '/api/v3/rootfolder' }
     ],
     sonarr: [
         { name: 'system-status', path: '/api/v3/system/status' },
@@ -314,6 +317,8 @@ const ENDPOINTS: Record<ServiceId, Endpoint[]> = {
         { name: 'queue', path: '/api/v3/queue' },
         { name: 'blocklist', path: '/api/v3/blocklist?page=1&pageSize=10' },
         { name: 'calendar', path: '/api/v3/calendar' },
+        // See the Radarr entry: `unmappedFolders` rides along on this read.
+        { name: 'rootfolder', path: '/api/v3/rootfolder' },
         { name: 'series', path: '/api/v3/series' },
         {
             name: 'episode',

--- a/test/contract.test.ts
+++ b/test/contract.test.ts
@@ -168,6 +168,19 @@ const CONTRACTS: Record<string, ServiceContract> = {
             },
             { fixture: 'test/fixtures/radarr/movie-lookup.json', fields: ['title', 'tmdbId'] },
             {
+                // `unmappedFolders[].name` is the whole of what `stack_health`
+                // reports about a folder the instance maps to no item, and it
+                // is the only API-visible trace of a mapping the service has
+                // lost. `readRootFolders` has read `path` and `freeSpace` here
+                // uncontracted since it was written; contracting all three now
+                // means the nightly spec drift job catches an upstream rename
+                // rather than a user finding a field that silently went empty.
+                path: '/api/v3/rootfolder',
+                method: 'get',
+                fixture: 'test/fixtures/radarr/rootfolder.json',
+                fields: ['path', 'freeSpace', 'unmappedFolders', 'unmappedFolders.name']
+            },
+            {
                 path: '/api/v3/blocklist',
                 method: 'get',
                 fixture: 'test/fixtures/radarr/blocklist.json',
@@ -182,6 +195,19 @@ const CONTRACTS: Record<string, ServiceContract> = {
         dependencies: [
             { path: '/api/v3/system/status', method: 'get', fixture: 'test/fixtures/sonarr/system-status.json', fields: ['version'] },
             { path: '/api/v3/diskspace', method: 'get', fixture: 'test/fixtures/sonarr/diskspace.json', fields: ['path', 'label', 'freeSpace', 'totalSpace'] },
+            {
+                // No `unmappedFolders.name` here, unlike Radarr: the capture
+                // run found every folder in this instance's root mapped, so
+                // the recorded array is empty and there is no row to assert
+                // against. Same reasoning as the absent health dependencies
+                // above — left open rather than closed on an assumption. Add
+                // it the first time a real instance reports an unmapped
+                // folder.
+                path: '/api/v3/rootfolder',
+                method: 'get',
+                fixture: 'test/fixtures/sonarr/rootfolder.json',
+                fields: ['path', 'freeSpace', 'unmappedFolders']
+            },
             { path: '/api/v3/system/task', method: 'get', fixture: 'test/fixtures/sonarr/system-task.json', fields: ['taskName', 'lastExecution'] },
             {
                 fixture: 'test/fixtures/sonarr/calendar.json',

--- a/test/fixtures/radarr/rootfolder.json
+++ b/test/fixtures/radarr/rootfolder.json
@@ -1,0 +1,25 @@
+[
+  {
+    "path": "/storage/movies",
+    "accessible": true,
+    "freeSpace": 6060866371584,
+    "unmappedFolders": [
+      {
+        "name": "Back to Black (2024) [tmdbid-998846]",
+        "path": "/storage/movies/Back to Black (2024) [tmdbid-998846]",
+        "relativePath": "Back to Black (2024) [tmdbid-998846]"
+      },
+      {
+        "name": "Influencers (2025) [tmdbid-1476740]",
+        "path": "/storage/movies/Influencers (2025) [tmdbid-1476740]",
+        "relativePath": "Influencers (2025) [tmdbid-1476740]"
+      },
+      {
+        "name": "Night Always Comes (2025) [tmdbid-1254624]",
+        "path": "/storage/movies/Night Always Comes (2025) [tmdbid-1254624]",
+        "relativePath": "Night Always Comes (2025) [tmdbid-1254624]"
+      }
+    ],
+    "id": 2
+  }
+]

--- a/test/fixtures/sonarr/rootfolder.json
+++ b/test/fixtures/sonarr/rootfolder.json
@@ -1,0 +1,9 @@
+[
+  {
+    "path": "/storage/tv",
+    "accessible": true,
+    "freeSpace": 6060866371584,
+    "unmappedFolders": [],
+    "id": 2
+  }
+]


### PR DESCRIPTION
Closes the one gap left over from #213 that was worth closing.

1.24.0 shipped `unmappedFolders` through `stack_health`, reading a field nothing asserted. `readRootFolders` has also read `path` and `freeSpace` uncontracted since it was written, so `/api/v3/rootfolder` had no fixture and no contract entry at all. Upstream could rename any of the three and the suite would stay green while `stack_health` quietly reported nothing.

## What this adds

The endpoint in the capture list for both services, the two fixtures, and contract entries for what the adapter actually reads. Both services have vendored specs, so the entries get spec-checked as well as fixture-checked, which puts these fields under `openapi-drift.yml`.

Radarr's fixture carries three real unmapped folders, so `unmappedFolders.name` is assertable there:

```json
{
  "path": "/storage/movies",
  "freeSpace": 6060866371584,
  "unmappedFolders": [
    { "name": "Back to Black (2024) [tmdbid-998846]", ... }
  ]
}
```

Sonarr gets `path` and `freeSpace` only. Every folder in its root is mapped, so its recorded `unmappedFolders` is `[]` and there is no row to assert against. Left open rather than closed on an assumption, the same way the absent health dependencies already are, with a note to add it the first time a real instance reports one.

## Correcting myself

I said in #214, and in #213's body, that capturing this needed a path anonymiser first because the response carries the mount layout. That was wrong. The *arr fixtures already publish real paths verbatim:

```
movie[0].path    "/storage/movies/Blade ()"
movieFile.path   "/storage/movies/Nuclear (2022)/Nuclear.Now.2022.1080p.AMZN.WEB-DL.DDP5.1.H.264-SCOPE.mkv"
```

Mount layout, folder names, filenames and release group. The Plex path synthesis exists because those fixtures came from a volunteer tester's server, not because paths are sensitive in principle. So there was nothing to build, and this was a much smaller job than I described.

## What I deliberately did not do

The other two leftovers from #213 stay closed:

- **Joining an unmapped folder back to its item.** Speculative, and `stack_health` naming the folder is enough to act on.
- **The `rename_files` no-op.** `arrCommands.ts:158` sends `RenameMovie`/`RenameSeries` with item ids, so the service resolves its own file records and finds none when the mapping is gone. The reasoning holds but I have not observed it, and confirming it means firing a rename at real media. Not filing an unverified claim.

## Verification

- `npm run lint`: no output
- `npm run typecheck`: no output
- `npm test`: 100 files, 2559 tests passed, exit code 0

Captured against a live Radarr and Sonarr. `test/fixtures.test.ts` re-checks both new fixtures for leaks and passes; I read both in full before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
