### PR TITLE
feat: call Jellyfin's documented resume route, and raise the floor to 10.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Thirty-six tools, but you never name them — you ask, and the model picks:
 ## Requirements
 
 - At least one supported service, LAN-reachable: Radarr 4.0+, Sonarr 4.0+,
-  Prowlarr 1.0+, Bazarr 1.4+, Jellyfin 10.8+, Plex Media Server 1.32+,
+  Prowlarr 1.0+, Bazarr 1.4+, Jellyfin 10.9+, Plex Media Server 1.32+,
   Seerr 1.0+, SABnzbd 3.0+, Transmission 3.0+, qBittorrent 4.1+
 - Docker, or Node 24+ to run from source
 - An MCP client speaking protocol revision `2026-07-28`

--- a/scripts/capture-fixtures.ts
+++ b/scripts/capture-fixtures.ts
@@ -185,6 +185,39 @@ const neutraliseWatchState = (body: unknown): unknown => {
     };
 };
 
+/**
+ * Resume rows, neutralised without contradicting the endpoint.
+ *
+ * `neutraliseWatchState` zeroes `PlaybackPositionTicks` and drops
+ * `LastPlayedDate` — on a resumable set that would produce a fixture no
+ * `/UserItems/Resume` could ever return, and drop the two fields
+ * `getPlayback` reads for `percentComplete` and `lastPlayed`. A fixed
+ * position and date keep the shape honest while carrying no real watch
+ * history.
+ */
+const neutraliseResumeState = (body: unknown): unknown => {
+    const page = body as { Items?: Row[] };
+    if (!Array.isArray(page.Items)) return body;
+    return {
+        ...page,
+        Items: page.Items.map((item, i) => ({
+            ...item,
+            UserData:
+                item.UserData === undefined
+                    ? undefined
+                    : {
+                          ...(item.UserData as Row),
+                          Played: false,
+                          PlayCount: 1,
+                          IsFavorite: false,
+                          LastPlayedDate: `2026-01-0${i + 1}T20:00:00.0000000Z`,
+                          PlaybackPositionTicks: 18_000_000_000 * (i + 1),
+                          ...('PlayedPercentage' in (item.UserData as Row) ? { PlayedPercentage: 25 * (i + 1) } : {})
+                      }
+        }))
+    };
+};
+
 function anonymiseIndexer(row: Row, index: number): Row {
     const fields = Array.isArray(row.fields)
         ? (row.fields as Row[]).map(f => ({
@@ -407,6 +440,25 @@ const ENDPOINTS: Record<ServiceId, Endpoint[]> = {
                       '&Fields=ProviderIds,Genres&EnableUserData=true&EnableImages=false&Limit=20';
             },
             anonymise: neutraliseWatchState
+        },
+        {
+            name: 'resume',
+            // getPlayback's resumable half. Per-user like items-library, and
+            // from the same users[0] — if that user happens to have nothing in
+            // progress the fixture comes back empty and the contract entry for
+            // it goes red, which is the honest outcome: there is nothing to
+            // contract against.
+            //
+            // EnableImages=false is the same capture-only trim items-library
+            // uses. A live resume row carries four blurhashes, and a blurhash
+            // is long, alphanumeric and undelimited — the exact shape the
+            // fixture secret guard flags as a possible credential.
+            path: captured => {
+                const users = captured.get('users');
+                const id = Array.isArray(users) ? (users[0] as { Id?: string } | undefined)?.Id : undefined;
+                return id === undefined ? undefined : `/UserItems/Resume?userId=${id}&Limit=500&EnableImages=false`;
+            },
+            anonymise: neutraliseResumeState
         },
         {
             name: 'show-episodes',

--- a/src/services/jellyfin.ts
+++ b/src/services/jellyfin.ts
@@ -257,16 +257,20 @@ export class JellyfinAdapter
         const [sessions, resume] = await Promise.all([
             this.#http.get<RawSession[]>('/Sessions'),
             /**
-             * `/Users/{id}/Items/Resume` is the supported way to ask for the
-             * resumable set. `/Items?IsResumable=true` looks like the right query
-             * but is silently ignored by Jellyfin 10.11 — it returns the entire
-             * library, not just resumable items.
+             * `/UserItems/Resume` is the documented way to ask for the resumable
+             * set. `/Items?IsResumable=true` looks like the right query but is
+             * silently ignored — it returns the entire library, not just
+             * resumable items.
+             *
+             * The older `/Users/{id}/Items/Resume` still answers in Jellyfin 12,
+             * but only as `[Obsolete]`, and it is absent from the OpenAPI
+             * document — so nothing here would catch its removal.
              *
              * `Limit=500` ensures truncation is decided by `applyLimit` in the
              * contract layer, which reports it, rather than by an undocumented
              * server default page size, which does not.
              */
-            this.#http.get<RawItemsPage>(`/Users/${encodeURIComponent(user.id)}/Items/Resume?Limit=500`)
+            this.#http.get<RawItemsPage>(`/UserItems/Resume?userId=${encodeURIComponent(user.id)}&Limit=500`)
         ]);
 
         const nowPlaying: PlaybackEntry[] = sessions

--- a/src/services/versions.ts
+++ b/src/services/versions.ts
@@ -20,8 +20,11 @@ export const MINIMUM_VERSIONS: Record<ServiceId, string> = {
     prowlarr: '1.0.0',
     // `{ data: … }` envelope on /api/system/status.
     bazarr: '1.4.0',
-    // /ScheduledTasks with LastExecutionResult, and Fields=ProviderIds.
-    jellyfin: '10.8.0',
+    // 10.9.0 moved the per-user reads to their modern forms, and three calls
+    // here need them: `/Items/{itemId}`, `/UserPlayedItems/{itemId}` and
+    // `/UserItems/Resume`. 10.8 answers none of the three, so it never fully
+    // worked — this floor only stops it failing halfway through.
+    jellyfin: '10.9.0',
     // Seerr forked from Overseerr in February 2026; 1.0 is its first release.
     seerr: '1.0.0',
     // output=json on the query-parameter API.

--- a/test/contract.test.ts
+++ b/test/contract.test.ts
@@ -359,6 +359,29 @@ const CONTRACTS: Record<string, ServiceContract> = {
                 ]
             },
             {
+                // getPlayback's resumable half, which went uncontracted while it
+                // called `/Users/{userId}/Items/Resume`: that route is absent
+                // from the spec (obsolete since 10.9, undocumented in 12), so
+                // no entry here could have covered it. `/UserItems/Resume` is
+                // the documented form, and this entry now fails loudly if it
+                // goes the same way.
+                //
+                // `PlaybackPositionTicks` and `LastPlayedDate` are what become
+                // `percentComplete` and `lastPlayed`; a rename to either would
+                // leave every resume row looking freshly started.
+                path: '/UserItems/Resume',
+                method: 'get',
+                fixture: 'test/fixtures/jellyfin/resume.json',
+                fields: [
+                    'Items.Id',
+                    'Items.Name',
+                    'Items.Type',
+                    'Items.RunTimeTicks',
+                    'Items.UserData.PlaybackPositionTicks',
+                    'Items.UserData.LastPlayedDate'
+                ]
+            },
+            {
                 path: '/Shows/{seriesId}/Episodes',
                 method: 'get',
                 fixture: 'test/fixtures/jellyfin/show-episodes.json',

--- a/test/fixtures/jellyfin/resume.json
+++ b/test/fixtures/jellyfin/resume.json
@@ -1,0 +1,37 @@
+{
+  "Items": [
+    {
+      "Name": "The Amateur",
+      "ServerId": "03b5e7fd4c8a4de8b4164d4d21b72608",
+      "Id": "5eda2796fe11d1d5a770ce7f365e35de",
+      "HasSubtitles": true,
+      "Container": "mkv",
+      "PremiereDate": "2025-04-08T22:00:00.0000000Z",
+      "CriticRating": 61,
+      "OfficialRating": "NL-12",
+      "ChannelId": null,
+      "CommunityRating": 6.915,
+      "RunTimeTicks": 73612710000,
+      "AspectRatio": "",
+      "ProductionYear": 2025,
+      "IsFolder": false,
+      "Type": "Movie",
+      "UserData": {
+        "PlayedPercentage": 25,
+        "PlaybackPositionTicks": 18000000000,
+        "PlayCount": 1,
+        "IsFavorite": false,
+        "LastPlayedDate": "2026-01-01T20:00:00.0000000Z",
+        "Played": false,
+        "Key": "1087891",
+        "ItemId": "5eda2796fe11d1d5a770ce7f365e35de"
+      },
+      "VideoType": "VideoFile",
+      "ImageBlurHashes": {},
+      "LocationType": "FileSystem",
+      "MediaType": "Video"
+    }
+  ],
+  "TotalRecordCount": 1,
+  "StartIndex": 0
+}

--- a/test/identityTools.test.ts
+++ b/test/identityTools.test.ts
@@ -61,7 +61,7 @@ const RESUME = {
 const jellyfinRoutes = {
     '/Users': USERS,
     '/Sessions': SESSIONS,
-    [`/Users/${USER_ID}/Items/Resume?Limit=500`]: RESUME
+    [`/UserItems/Resume?userId=${USER_ID}&Limit=500`]: RESUME
 };
 
 const jellyfin = (over: Partial<MultiUserServiceConfig> = {}, routes: Record<string, unknown> = jellyfinRoutes) => {
@@ -114,7 +114,7 @@ describe('get_playback', () => {
 
     it('omits the percentage rather than dividing by zero when runtime is unknown', async () => {
         const noRuntime = { Items: [{ Id: 'x', Name: 'X', UserData: { PlaybackPositionTicks: 100 } }] };
-        const { adapter, resolver } = jellyfin({}, { ...jellyfinRoutes, [`/Users/${USER_ID}/Items/Resume?Limit=500`]: noRuntime });
+        const { adapter, resolver } = jellyfin({}, { ...jellyfinRoutes, [`/UserItems/Resume?userId=${USER_ID}&Limit=500`]: noRuntime });
         const result = await buildGetPlayback(adapter, resolver, { detail: 'full', limit: 50 });
 
         expect(result.items.find(i => i.kind === 'resume')?.percentComplete).toBeUndefined();
@@ -138,7 +138,7 @@ describe('get_playback', () => {
     });
 
     it('permits another user when allow_other_users is true', async () => {
-        const guestRoutes = { ...jellyfinRoutes, [`/Users/${GUEST_ID}/Items/Resume?Limit=500`]: { Items: [] } };
+        const guestRoutes = { ...jellyfinRoutes, [`/UserItems/Resume?userId=${GUEST_ID}&Limit=500`]: { Items: [] } };
         const { adapter, resolver } = jellyfin({ allow_other_users: true }, guestRoutes);
         const result = await buildGetPlayback(adapter, resolver, { detail: 'full', limit: 50, user: 'Guest' });
 
@@ -177,7 +177,7 @@ describe('get_playback', () => {
 
     it('reports truncation honestly', async () => {
         const many = { Items: repeat(RESUME.Items[0]!, 200) };
-        const { adapter, resolver } = jellyfin({}, { ...jellyfinRoutes, [`/Users/${USER_ID}/Items/Resume?Limit=500`]: many });
+        const { adapter, resolver } = jellyfin({}, { ...jellyfinRoutes, [`/UserItems/Resume?userId=${USER_ID}&Limit=500`]: many });
         const result = await buildGetPlayback(adapter, resolver, { detail: 'standard', limit: 50 });
 
         expect(result).toMatchObject({ total: 201, returned: 50, truncated: true });
@@ -185,7 +185,7 @@ describe('get_playback', () => {
 
     it('stays within its token budget at the absolute maximum', async () => {
         const many = { Items: repeat(RESUME.Items[0]!, 500) };
-        const { adapter, resolver } = jellyfin({}, { ...jellyfinRoutes, [`/Users/${USER_ID}/Items/Resume?Limit=500`]: many });
+        const { adapter, resolver } = jellyfin({}, { ...jellyfinRoutes, [`/UserItems/Resume?userId=${USER_ID}&Limit=500`]: many });
         const result = await buildGetPlayback(adapter, resolver, { detail: 'full', limit: 500 });
 
         expectWithinBudget(result, 40_000);

--- a/test/library-reads.test.ts
+++ b/test/library-reads.test.ts
@@ -396,7 +396,7 @@ describe('Jellyfin.listUserSeasons', () => {
     });
 });
 
-const RESUMABLE_ROUTE = '/Users/u1/Items/Resume?Limit=500';
+const RESUMABLE_ROUTE = '/UserItems/Resume?userId=u1&Limit=500';
 
 const RESUMABLE = {
     Items: [
@@ -426,9 +426,9 @@ describe('Jellyfin.getPlayback', () => {
     const someone = { id: 'u1', name: 'Someone' };
 
     it('reads the resumable set from the supported endpoint', async () => {
-        // /Users/{id}/Items/Resume is the supported way to ask for the resumable
-        // set. /Items?IsResumable=true looks like the right query but is silently
-        // ignored by Jellyfin 10.11 — it returns the entire library.
+        // /UserItems/Resume is the documented way to ask for the resumable set.
+        // /Items?IsResumable=true looks like the right query but is silently
+        // ignored — it returns the entire library.
         const entries = await adapter().getPlayback(someone);
         expect(entries).toHaveLength(2);
         expect(entries.every(e => e.kind === 'resume')).toBe(true);

--- a/test/versions.test.ts
+++ b/test/versions.test.ts
@@ -79,6 +79,20 @@ describe('assertVersionSupported', () => {
         expect(err.detail).toContain('3.0.0.0');
     });
 
+    it('rejects Jellyfin 10.8, whose API lacks three routes the adapter calls', () => {
+        // `/Items/{itemId}`, `/UserPlayedItems/{itemId}` and `/UserItems/Resume`
+        // all arrived in 10.9.0, alongside the deprecation of the per-user
+        // forms. Verified against the v10.8.0 tag: its UserLibraryController
+        // and PlaystateController carry only `Users/{userId}/...` routes.
+        //
+        // With the floor at 10.8.0 a 10.8 install passed the connection test
+        // and then 404ed on mark_watched and the watch-target read — a
+        // half-working install is worse than a named refusal.
+        const err = rejection(() => assertVersionSupported('jellyfin', '10.8.13'));
+        expect(err.kind).toBe('VersionUnsupported');
+        expect(err.remedy).toContain('10.9.0');
+    });
+
     it('accepts an unparseable version rather than blocking on it', () => {
         // A service that reports something we cannot parse is not evidence of
         // an old version, and refusing to talk to it would be worse than the


### PR DESCRIPTION
Jellyfin 12.0 shipped on 8 September. I checked what it breaks for us, and the answer is almost nothing: our auth is already the modern `Authorization: MediaBrowser Token="..."` scheme (the `EnableLegacyAuthorization` flag only gates `X-Emby-Token`, `X-MediaBrowser-Token`, `api_key` and the `Emby` scheme), we use no `/emby` or `/mediabrowser` prefixes, we call none of the removed endpoints, and the new `recursive` default cannot reach any of our queries since none pass a `parentId`.

One thing did turn up.

## The resume route

`getPlayback` called `/Users/{userId}/Items/Resume`. In 12.0 that route survives only as `[Obsolete("Kept for backwards compatibility")]`, and it is not in the OpenAPI document at all. That is why the contract test never covered it: you cannot contract a path the spec does not have. So the day upstream drops it, users find out before the suite does.

This moves to `/UserItems/Resume?userId=...` and adds a contract entry with a captured fixture. The entry fails loudly on a removed path (`no get /UserItems/Resume in specs/jellyfin.json`), and on a renamed field. I checked it bites by pointing it at a bogus field first.

## Why the floor moves to 10.9

`/UserItems/Resume` landed in 10.9.0. So did two routes this adapter already calls:

- `/Items/{itemId}` in `readWatchTarget`
- `/UserPlayedItems/{itemId}` in `setWatched`

Neither exists in 10.8.0 (checked against the v10.8.0 tag, where both controllers carry only `Users/{userId}/...` forms). So a 10.8 install already passed the connection test and then 404ed on `mark_watched` and the watch-target read. The floor was fiction. Raising it to 10.9.0 turns a silent half-failure into the `VersionUnsupported` error that `versions.ts` exists to produce, and breaks nothing that works today.

Sizing it as a minor with a note rather than a major for that reason, but say the word if you would rather it were a major.

## Verification

- Live probe against 10.11.11: both routes return identical resumable sets across all four users, so the swap is a no-op on the current stack
- Fixture captured live, with the same `EnableImages=false` trim `items-library` uses (a resume row carries four blurhashes, which the fixture secret guard reads as possible credentials)
- Full suite 2562 passed, typecheck clean, lint clean

Also incidentally: `specs/jellyfin.json` has been the 12.0.0 spec since 5 August, because upstream's `jellyfin-openapi-stable.json` was serving 12.0 during the RC run. Our generated types have described v12 for a month.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
