### PR TITLE
fix: say a download is still running, rather than passing on Radarr's 500

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -972,13 +972,17 @@ refuses and why. Rejected files are **excluded** from the import rather than
 forced through: this imports what the service is willing to take, and overriding
 its own matching is not something it will do on your behalf.
 
-Two outcomes that look alike and are not:
+Three outcomes that look alike and are not:
 
 - **Nothing to import** — the service sees no files for that download id. A
   no-op, with no confirmation asked for.
 - **Everything rejected** — there are files and it will take none of them. A
   refusal naming the reasons. Reporting that as "nothing to do" would read as
   "it was already imported", which is the opposite of what happened.
+- **Still downloading** — the download has not finished, so there is nothing to
+  import yet. Radarr and Sonarr answer this with an HTTP 500 from a null
+  dereference of their own rather than a clean refusal, so the message names the
+  state `get_queue` reports instead of passing that on as a service fault.
 
 The import re-reads the candidates when it runs rather than trusting the
 preview's list, so a download whose files have changed in between imports what

--- a/scripts/integration.ts
+++ b/scripts/integration.ts
@@ -646,24 +646,40 @@ if (typeof searchableHit?.service === 'string' && searchableHit.id !== undefined
  * The manual import, previewed against whatever the queue actually holds.
  * Skipped rather than invented when nothing is downloading: a made-up
  * download id captures a refusal, not the mapping.
+ *
+ * Which outcome is correct depends on the state of the row, so the row is
+ * chosen before the assertion is: only a *completed* download has anything to
+ * import, and Radarr and Sonarr answer a still-running one with an HTTP 500
+ * from their own null dereference. Taking `items[0]` and always expecting
+ * success painted the stack red for a whole release whenever the one thing in
+ * the queue happened to still be downloading.
  */
-const queueRow = (queueResult?.structuredContent as { items?: unknown[] } | undefined)?.items?.[0] as
-    | { service?: unknown; downloadId?: unknown }
-    | undefined;
+type QueueRow = { service?: unknown; downloadId?: unknown; status?: unknown };
+const queueRows = ((queueResult?.structuredContent as { items?: unknown[] } | undefined)?.items ?? []) as QueueRow[];
+const withId = queueRows.filter(r => typeof r.service === 'string' && typeof r.downloadId === 'string');
+const finished = (r: QueueRow): boolean => String(r.status).toLowerCase() === 'completed';
+const queueRow = withId.find(finished) ?? withId[0];
 
-if (typeof queueRow?.service === 'string' && typeof queueRow.downloadId === 'string') {
-    await run(
-        'trigger_scan',
-        {
-            service: queueRow.service.split('/')[0],
-            action: 'import',
-            download_id: queueRow.downloadId,
-            dry_run: true
-        },
-        'DRY RUN ONLY — the manual import path'
-    );
-} else {
+if (queueRow === undefined) {
     console.log('SKIP trigger_scan import — nothing in the queue carries a downloadId to preview against.');
+} else {
+    const importArgs = {
+        service: (queueRow.service as string).split('/')[0],
+        action: 'import',
+        download_id: queueRow.downloadId as string,
+        dry_run: true
+    };
+
+    if (finished(queueRow)) {
+        await run('trigger_scan', importArgs, 'DRY RUN ONLY — the manual import path');
+    } else {
+        await expectError(
+            'trigger_scan',
+            importArgs,
+            /has not finished downloading/,
+            'DRY RUN ONLY — nothing in the queue has finished, so the manual import path must say that rather than pass on the 500'
+        );
+    }
 }
 
 const gap = (subtitlesResult?.structuredContent as { items?: unknown[] } | undefined)?.items?.[0] as

--- a/src/services/arrManualImport.ts
+++ b/src/services/arrManualImport.ts
@@ -2,6 +2,7 @@ import { ServiceError } from '../core/errors.ts';
 import { fenceText } from '../core/fence.ts';
 import type { ServiceHttp } from '../core/http.ts';
 import { postArrCommand } from './arrCommands.ts';
+import { readArrQueue } from './arrQueue.ts';
 import type { CommandHandle, ImportCandidate } from './types.ts';
 
 /**
@@ -64,15 +65,62 @@ function toCandidate(service: string, resource: 'movie' | 'series', raw: RawCand
     };
 }
 
+/**
+ * Both services read `trackedDownload.ImportItem.OutputPath` with no null check
+ * (`ManualImportService.GetMediaFiles`), and `ImportItem` is set only once the
+ * download client reports the item complete — so a download that is still
+ * running answers HTTP 500 where a 4xx belongs. Confirmed against a live Radarr
+ * 6.3.0.10514; Sonarr's copy of the method is identical.
+ *
+ * An id the service never tracked is not this case — that answers 200 and an
+ * empty list — so the queue is read to confirm the state, and a 500 it cannot
+ * account for is rethrown untouched rather than blamed on an unfinished
+ * download.
+ */
+async function explainUnfinishedDownload(
+    http: ServiceHttp,
+    service: string,
+    resource: 'movie' | 'series',
+    downloadId: string,
+    err: unknown
+): Promise<unknown> {
+    if (!(err instanceof ServiceError) || err.kind !== 'UpstreamError') return err;
+
+    let row;
+    try {
+        row = (await readArrQueue(http, service, resource)).find(
+            q => q.downloadId?.toLowerCase() === downloadId.toLowerCase()
+        );
+    } catch {
+        // The queue is only here to explain. Failing to read it leaves the
+        // original error, which is still the truthful one.
+        return err;
+    }
+
+    if (row === undefined || row.status.toLowerCase() === 'completed') return err;
+
+    const state = row.importState === undefined ? row.status : `${row.status}/${row.importState}`;
+    return new ServiceError('UpstreamError', service, `download ${downloadId} has not finished downloading`, {
+        remedy: `get_queue reports it as ${state}. There is nothing to import until the download client says the item is complete — ${service} answers HTTP 500 rather than a clean refusal until then. Wait for it to finish, then try again.`,
+        cause: err
+    });
+}
+
 async function readCandidates(
     http: ServiceHttp,
     service: string,
     resource: 'movie' | 'series',
     downloadId: string
 ): Promise<{ raw: RawCandidate[]; candidates: ImportCandidate[] }> {
-    const raw = await http.get<RawCandidate[]>(
-        `/api/v3/manualimport?downloadId=${encodeURIComponent(downloadId)}&filterExistingFiles=true`
-    );
+    let raw: RawCandidate[];
+    try {
+        raw = await http.get<RawCandidate[]>(
+            `/api/v3/manualimport?downloadId=${encodeURIComponent(downloadId)}&filterExistingFiles=true`
+        );
+    } catch (err) {
+        throw await explainUnfinishedDownload(http, service, resource, downloadId, err);
+    }
+
     return {
         raw,
         candidates: raw.map(r => toCandidate(service, resource, r)).filter((c): c is ImportCandidate => c !== undefined)

--- a/test/manualImport.test.ts
+++ b/test/manualImport.test.ts
@@ -35,7 +35,7 @@ const CANDIDATES = [
     }
 ];
 
-function stack(candidates: unknown = CANDIDATES) {
+function stack(candidates: unknown = CANDIDATES, queue: unknown[] = []) {
     const sent: { path: string; search: string; method: string; body: Record<string, unknown> | undefined }[] = [];
 
     const impl = (async (input: string | URL | Request, init?: RequestInit) => {
@@ -48,13 +48,34 @@ function stack(candidates: unknown = CANDIDATES) {
             body: typeof init?.body === 'string' ? (JSON.parse(init.body) as Record<string, unknown>) : undefined
         });
 
-        if (url.pathname === '/api/v3/manualimport') return jsonResponse(candidates);
+        if (url.pathname === '/api/v3/manualimport') {
+            // A number stands for the status the service answers with, which is
+            // how the 500 cases below are written.
+            return typeof candidates === 'number'
+                ? jsonResponse({ message: 'Object reference not set to an instance of an object.' }, candidates)
+                : jsonResponse(candidates);
+        }
+        if (url.pathname === '/api/v3/queue') return jsonResponse({ records: queue, totalRecords: queue.length });
         if (url.pathname === '/api/v3/command') return jsonResponse({ id: 91, name: 'ManualImport', status: 'queued' });
         return jsonResponse({ message: 'not found' }, 404);
     }) as unknown as typeof fetch;
 
     return { impl, sent };
 }
+
+/**
+ * Radarr and Sonarr answer HTTP 500 for a download that has not finished — see
+ * the note on `explainUnfinishedDownload`. These rows are what `/queue` says
+ * about such a download, taken from a live Radarr 6.3.0.10514.
+ */
+const RUNNING_ROW = {
+    id: 1,
+    title: 'Heat.1995.mkv',
+    downloadId: 'nzo_abc',
+    status: 'queued',
+    trackedDownloadState: 'downloading',
+    movieId: 15
+};
 
 describe('manual import candidates', () => {
     it('reports what the service matched and what it will not take', async () => {
@@ -147,5 +168,67 @@ describe('running a manual import', () => {
         await expect(new SonarrAdapter(keyed(8989), s.impl).runManualImport('nzo_x')).rejects.toThrow(
             /no episode matched/
         );
+    });
+});
+
+/**
+ * The live integration run caught this: previewing an import for a download
+ * that is still running answers HTTP 500, because both services dereference a
+ * null `ImportItem`. `UpstreamError: HTTP 500 at /api/v3/manualimport` tells a
+ * model nothing it can act on; "it has not finished downloading" does.
+ */
+describe('a download that has not finished', () => {
+    it('says so, rather than reporting a bare upstream error', async () => {
+        const s = stack(500, [RUNNING_ROW]);
+        await expect(new RadarrAdapter(keyed(7878), s.impl).listImportCandidates('nzo_abc')).rejects.toThrow(
+            /has not finished downloading/
+        );
+    });
+
+    it('names the state get_queue reports, so the model can say what to wait for', async () => {
+        const s = stack(500, [RUNNING_ROW]);
+        await expect(new RadarrAdapter(keyed(7878), s.impl).runManualImport('nzo_abc')).rejects.toThrow(
+            /queued\/downloading/
+        );
+        expect(s.sent.some(x => x.method === 'POST')).toBe(false);
+    });
+
+    it('explains Sonarr the same way — its copy of the method has the same hole', async () => {
+        const s = stack(500, [{ ...RUNNING_ROW, movieId: undefined, seriesId: 7 }]);
+        await expect(new SonarrAdapter(keyed(8989), s.impl).listImportCandidates('nzo_abc')).rejects.toThrow(
+            /has not finished downloading/
+        );
+    });
+
+    it('matches the queue row whatever case the download id was given in', async () => {
+        const s = stack(500, [{ ...RUNNING_ROW, downloadId: 'ABC123' }]);
+        await expect(new RadarrAdapter(keyed(7878), s.impl).listImportCandidates('abc123')).rejects.toThrow(
+            /has not finished downloading/
+        );
+    });
+
+    /**
+     * The guard that keeps this from becoming a catch-all: a 500 on a download
+     * the client has finished is a real fault, and calling it "still
+     * downloading" would send someone looking in the wrong place.
+     */
+    it('leaves a 500 on a completed download as the upstream error it is', async () => {
+        const s = stack(500, [{ ...RUNNING_ROW, status: 'completed', trackedDownloadState: 'importBlocked' }]);
+        await expect(new RadarrAdapter(keyed(7878), s.impl).listImportCandidates('nzo_abc')).rejects.toThrow(
+            /HTTP 500/
+        );
+    });
+
+    it('leaves a 500 the queue says nothing about alone', async () => {
+        const s = stack(500, []);
+        await expect(new RadarrAdapter(keyed(7878), s.impl).listImportCandidates('nzo_abc')).rejects.toThrow(
+            /HTTP 500/
+        );
+    });
+
+    /** An unknown id is a 200 and an empty list upstream, not a 500. */
+    it('still refuses an unknown download id on its own terms', async () => {
+        const s = stack([], [RUNNING_ROW]);
+        await expect(new RadarrAdapter(keyed(7878), s.impl).runManualImport('nzo_abc')).rejects.toThrow(/get_queue/);
     });
 });


### PR DESCRIPTION
The live integration run has had one standing failure:

```
FAIL trigger_scan {"service":"radarr","action":"import","download_id":"D80…","dry_run":true}
  — radarr upstream error: HTTP 500 at /api/v3/manualimport
```

It is not stale test data, and it is not a malformed request. It is Radarr
crashing, and us passing the crash straight through.

## What the 500 body says

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at NzbDrone.Core.MediaFiles.MovieImport.Manual.ManualImportService.GetMediaFiles(...)
      in ./NzbDrone.Core/MediaFiles/MovieImport/Manual/ManualImportService.cs:line 115
```

Line 115 in the live version, `v6.3.0.10514`, is:

```csharp
path = trackedDownload.ImportItem.OutputPath.FullPath;
```

`ImportItem` is only ever assigned by `CompletedDownloadService`, which returns
early when `DownloadItem.Status != Completed`. The queue row it was called with
was `status: "queued"` / `trackedDownloadState: "downloading"`, so `ImportItem`
was null. Sonarr's copy of the method is identical, line for line, so it has
the same hole.

## Why this is not our request being wrong

`downloadId` and `filterExistingFiles` are both documented query parameters in
`specs/radarr.json`, and dropping `filterExistingFiles` changes nothing.

The probe that settles it: a download id the service has never tracked returns
`200 []`, taking the `trackedDownload == null` branch above. Only a *tracked
but unfinished* download 500s. A malformed request would fail both ways.

## The change

`readCandidates` now catches an `UpstreamError` from the preview, reads the
queue, and names the state the download is actually in:

> radarr upstream error: download D80… has not finished downloading — get_queue
> reports it as queued/downloading. There is nothing to import until the
> download client says the item is complete — radarr answers HTTP 500 rather
> than a clean refusal until then. Wait for it to finish, then try again.

Guarded so it cannot become a catch-all. A 500 on a row the queue calls
`completed`, or one the queue says nothing about, is rethrown untouched;
blaming a genuine fault on an unfinished download would send someone looking in
the wrong place. A queue read that itself fails leaves the original error. The
extra call only happens on the error path.

`scripts/integration.ts` took queue row 0 and always expected success, so this
case went red purely on the timing of what happened to be queued. It now
prefers a completed row and falls back to `expectError` when the only queued
download is still running.

`docs/tools.md` gains a third bullet in the "outcomes that look alike and are
not" list.

## Verification

- `npm test` — 2569 passed, 100 files, 0 failed
- `npm run typecheck`, `npm run lint` — clean
- `npm run integration` against the live stack — **59/59**, up from 58/59

Seven new unit cases cover both services, the case-insensitive queue match, and
each of the three guards that keep a real 500 reported as a real 500.

The integration exit code is still 1, for the unchanged reason that
`get_metadata_issues` and `fix_metadata` have no case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
