### PR TITLE
fix: send Sonarr its own name for the import-list exclusion flag

### DIFF
--- a/src/services/arrQueue.ts
+++ b/src/services/arrQueue.ts
@@ -105,6 +105,16 @@ export async function removeArrQueueItem(
     );
 }
 
+/**
+ * Radarr spells the import-list exclusion `addImportExclusion`; Sonarr spells
+ * the same flag `addImportListExclusion`, and so does Whisparr, which forked
+ * it. Both names are in the vendored specs. The difference matters because
+ * ASP.NET drops a query parameter it cannot bind rather than refusing the
+ * request, so Radarr's name sent to Sonarr deleted the series with the
+ * exclusion defaulted to false and still answered 200.
+ */
+const EXCLUSION_PARAM = { movie: 'addImportExclusion', series: 'addImportListExclusion' } as const;
+
 /** Radarr's `/movie/{id}`, Sonarr's `/series/{id}` — same flags, different noun. */
 export async function deleteArrMedia(
     http: ServiceHttp,
@@ -121,7 +131,8 @@ export async function deleteArrMedia(
     }
 
     await http.delete(
-        `/api/v3/${resource}/${numeric}?deleteFiles=${String(opts.deleteFiles)}&addImportExclusion=${String(opts.addImportExclusion)}`
+        `/api/v3/${resource}/${numeric}?deleteFiles=${String(opts.deleteFiles)}` +
+            `&${EXCLUSION_PARAM[resource]}=${String(opts.addImportExclusion)}`
     );
 }
 

--- a/test/destructiveWrites.test.ts
+++ b/test/destructiveWrites.test.ts
@@ -118,6 +118,20 @@ describe('deleting media', () => {
         expect(sent.find(s => s.method === 'DELETE')?.path).toBe('/api/v3/series/7');
     });
 
+    // The two services spell the exclusion flag differently, and ASP.NET drops
+    // a query parameter it cannot bind rather than refusing the request — so
+    // Radarr's name sent to Sonarr deletes the series with the exclusion
+    // silently defaulted to false, and the tool still reports success. The
+    // user then watches their import list put it straight back.
+    it("uses Sonarr's own name for the exclusion flag, which is not Radarr's", async () => {
+        const { impl, sent } = recordingFetch({});
+        await new SonarrAdapter(keyed(8989), impl).deleteMedia('7', { deleteFiles: true, addImportExclusion: true });
+
+        const del = sent.find(s => s.method === 'DELETE');
+        expect(del?.search).toContain('addImportListExclusion=true');
+        expect(del?.search).not.toContain('addImportExclusion=');
+    });
+
     // The empty-body case: routing a delete through the JSON parse would turn
     // every successful deletion into "response was not valid JSON".
     it('succeeds on the empty 200 the arrs actually return', async () => {


### PR DESCRIPTION
Radarr's `DELETE /api/v3/movie/{id}` takes `addImportExclusion`. Sonarr's `DELETE /api/v3/series/{id}` takes `addImportListExclusion`, and so does Whisparr's, which forked it. Both spellings are sitting in the vendored specs. `deleteArrMedia` hardcoded Radarr's for both nouns.

This is not a 400. ASP.NET drops a query parameter it cannot bind rather than refusing the request, so on Sonarr the series was deleted with the exclusion defaulted to false and the call answered 200. `delete_media` reported success, the audit row recorded `addImportExclusion: true`, and the next import list sync put the series straight back. The failure is only visible a sync later, which is why nothing caught it.

The param name now follows the resource, next to the reason it has to.

Found while reviewing #224, which routes Whisparr through the same helper and would have inherited it on a service where import lists are the normal way to add things.

## Verification

- `npm run lint`: no output
- `npm run typecheck`: no output
- `npm test`: 101 files, 2575 tests passed
- New test asserts Sonarr sends `addImportListExclusion=true` and does not send `addImportExclusion=`. Confirmed red before the fix (`expected '?deleteFiles=true&addImportExclusion=…' to contain 'addImportListExclusion=true'`), green after.

Not verified against a live Sonarr. The claim rests on `specs/sonarr.json` and `specs/radarr.json`, which disagree on the name, and on ASP.NET's binding behaviour for unknown query parameters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
